### PR TITLE
Assess news items: remove duplicate source link

### DIFF
--- a/src/gui/src/components/assess/NewsItemDetail.vue
+++ b/src/gui/src/components/assess/NewsItemDetail.vue
@@ -88,9 +88,6 @@
                                             <span>{{news_item.news_item_data.link}}</span>
                                         </a>
                                     </v-row>
-                                    <v-row>
-                                        <span>{{news_item.news_item_data.source}}</span>
-                                    </v-row>
                                 </v-container>
 
 


### PR DESCRIPTION
the source link is already displayed at the top, so remove the link which is displayed below the news item

Before:
![Screenshot_2021-11-01_09-41-03](https://user-images.githubusercontent.com/199050/139645301-707941ba-77a0-4c54-93e8-4c9f4c62b71c.png)

(I'm still struggling with docker to get my local changes effective in the docker containers in order to validate that this actually works - any help is appreciated)