### PR TITLE
gitignore: add more rules and make others more generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,27 +1,28 @@
-**/venv/
-**/.idea/
+# built and cached files
+venv/
+__pycache__/
+*.pyc
+node_modules/
+dist/
+build/
 
-src/gui/node_modules/
-src/gui/dist/
-src/core/__pycache__/
-src/core/migrations/versions/__pycache__/
-
+# temporary files of editors
 .DS_Store
-.*.swp
+.*.sw?
 .~
+*.*~
+*.bak
 
-node_modules
-/dist
-
+# sensitive data not to be commited
 .env.local
 .env.*.local
+*.pem
+*.key
+*.log
 
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-
-.idea
-.vscode
+# settings of editors
+.idea/
+.vscode/
 *.suo
 *.ntvs*
 *.njsproj


### PR DESCRIPTION
adding more temporary files of editors
change some existing rules to make them more generic, matching all
directory levels
group the entries by type, document that