### PR TITLE
Assess: Do not reload news items when in selection mode

### DIFF
--- a/src/gui/src/components/assess/ContentDataAssess.vue
+++ b/src/gui/src/components/assess/ContentDataAssess.vue
@@ -193,7 +193,10 @@
             },
 
             news_items_updated() {
-                this.updateData(false, true);
+                // only update items when not in selection mode
+                if (! this.multiSelectActive) {
+                    this.updateData(false, true);
+                }
             },
 
             aggregateOpen(folder) {


### PR DESCRIPTION
Automatic reloading of news items, when selection mode is active, means
that all selections are lost (=data loss). Disabling automatic reload is
not a perfect solution, items could still be added on the top without
removing existing selections, but this prevents data loss and enhances
the usability significantly.