### PR TITLE
fix gui shortcuts in assess

### DIFF
--- a/src/gui/src/assets/keyboard_mixin.js
+++ b/src/gui/src/assets/keyboard_mixin.js
@@ -68,7 +68,7 @@ const keyboardMixin = targetId => ({
                 which = ".multiselect button";
                 temp = document.querySelector(".multiselect");
             } else {
-                which = ".newdial button";
+                which = ".v-card button";
                 temp = this.card_items[this.pos];
             }
 

--- a/src/gui/src/components/assess/ToolbarGroupAssess.vue
+++ b/src/gui/src/components/assess/ToolbarGroupAssess.vue
@@ -7,7 +7,7 @@
         <v-icon v-bind="UI.TOOLBAR.ICON.SELECTOR_SEPARATOR">{{ UI.ICON.SEPARATOR }}</v-icon>
         <div v-for="btn in actions" :key="btn.action" :class="UI.CLASS.multiselect_buttons">
             <v-btn v-bind="UI.TOOLBAR.BUTTON.SELECTOR"
-                   v-if="btn.can" :disabled="btn.disabled" @click.stop="action(btn.action)" :data-btn="btn.like" :title="btn.title">
+                   v-if="btn.can" :disabled="btn.disabled" @click.stop="action(btn.action)" :data-btn="btn.data_btn" :title="btn.title">
                 <v-icon v-bind="UI.TOOLBAR.ICON.SELECTOR">{{ UI.ICON[btn.ui_icon] }}</v-icon>
             </v-btn>
         </div>


### PR DESCRIPTION
fixes SK-CERT/Taranis-NG#55

As explained in https://github.com/SK-CERT/Taranis-NG/issues/55#issuecomment-998955319
toolbar lost it's newdial class. I opted to use the class of the news item itself as I was unable find any other suitable existing class assignment and to add a new class to the toolbar. Works fine for me.

And for the multi-select toolbar, the data-btn property was not set because of a human error when rewriting the toolbar