### PR TITLE
doc harware requirements: add cpu cores

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This is just a taste of its features:
 - use wordlists for filtering and highlighting
 - publish the self-service asset management portal to your constituency and allow them to set various notification profiles for those times when a vulnerability hits their product.
 
-Hardware requirements: make sure to have at least 2 GB of RAM and 5 GB of disk
+Hardware requirements: make sure to have at least 2 GB of RAM, 2 CPU cores and 5 GB of disk
 storage available for running, 20 GB of disk storage if you want to build the
 project from scratch.
 


### PR DESCRIPTION
recommend at least two cpu cores for running TaranisNG
reason: the database container can then easier handle the requests and
other containers do not that easily block database operations
