### PR TITLE
shortcuts: ignore keypresses in search field except Escape

### DIFF
--- a/src/gui/src/assets/keyboard_mixin.js
+++ b/src/gui/src/assets/keyboard_mixin.js
@@ -136,6 +136,10 @@ const keyboardMixin = targetId => ({
                     break;
                 }
             }
+            if (document.activeElement == search_field && (keyAlias !== 'close_item' || press.keyCode !== 27)) {
+                // when search field is active, ignore all keypresses except Escape
+                return;
+            }
 
             if ( !this.isSomeFocused() ) {
                 if (!this.focus) {


### PR DESCRIPTION
Only Escape is a valid keypress when the search is active
all other presses must be ignored
