### PR TITLE
src/publishers/requirements.txt upgrade paramiko

### DIFF
--- a/src/publishers/requirements.txt
+++ b/src/publishers/requirements.txt
@@ -12,7 +12,7 @@ marshmallow-enum==1.5.1
 oauth2client==4.1.3
 Jinja2==2.11.3
 MarkupSafe==1.1.0
-paramiko==2.8.0
+paramiko==2.10.1
 python-dateutil==2.8.1
 python-dotenv==0.10.3
 python-gnupg==0.4.6


### PR DESCRIPTION
paramiko < 2.10.1 is susceptible to CVE-2022-24302
https://github.com/paramiko/paramiko/commit/4c491e299c9b800358b16fa4886d8d94f45abe2e

versions should be compatible