### PR TITLE
Added option to trigger vertical view in the news analysis page

### DIFF
--- a/src/gui/src/components/analyze/NewsItemSelector.vue
+++ b/src/gui/src/components/analyze/NewsItemSelector.vue
@@ -61,9 +61,9 @@
             </v-col>
         </v-row>
 
-        <NewsItemSingleDetail ref="newsItemSingleDetail"/>
-        <NewsItemDetail ref="newsItemDetail"/>
-        <NewsItemAggregateDetail ref="newsItemAggregateDetail"/>
+        <NewsItemSingleDetail ref="newsItemSingleDetail" :attach="attach" />
+        <NewsItemDetail ref="newsItemDetail" :attach="attach" />
+        <NewsItemAggregateDetail ref="newsItemAggregateDetail" :attach="attach" />
     </v-row>
 </template>
 
@@ -95,7 +95,8 @@
             analyze_selector: Boolean,
             report_item_id: Number,
             edit: Boolean,
-            modify: Boolean
+            modify: Boolean,
+            attach: undefined
         },
         data: () => ({
             dialog: false,

--- a/src/gui/src/components/assess/NewsItemAggregateDetail.vue
+++ b/src/gui/src/components/assess/NewsItemAggregateDetail.vue
@@ -1,6 +1,6 @@
 <template>
     <v-row v-bind="UI.DIALOG.ROW.WINDOW">
-        <v-dialog v-bind="UI.DIALOG.FULLSCREEN" v-model="visible" @keydown.esc="close">
+        <v-dialog v-bind="UI.DIALOG.FULLSCREEN" v-model="visible" @keydown.esc="close" :attach="attach">
             <v-card>
 
                 <v-toolbar v-bind="UI.DIALOG.TOOLBAR" data-dialog="aggregate-detail">
@@ -111,6 +111,7 @@
         name: "NewsItemAggregateDetail",
         props: {
             analyze_selector: Boolean,
+            attach: undefined
         },
         components: {VueEditor},
         mixins: [AuthMixin],

--- a/src/gui/src/components/assess/NewsItemDetail.vue
+++ b/src/gui/src/components/assess/NewsItemDetail.vue
@@ -1,6 +1,6 @@
 <template>
     <v-row v-bind="UI.DIALOG.ROW.WINDOW">
-        <v-dialog v-bind="UI.DIALOG.FULLSCREEN" v-model="visible" @keydown.esc="close">
+        <v-dialog v-bind="UI.DIALOG.FULLSCREEN" v-model="visible" @keydown.esc="close" :attach="attach">
             <v-card>
                 <v-toolbar v-bind="UI.DIALOG.TOOLBAR" data-dialog="item-detail">
                     <v-btn icon dark @click="close()" data-btn="close">
@@ -117,6 +117,7 @@
         mixins: [AuthMixin],
         props: {
             analyze_selector: Boolean,
+            attach: undefined
         },
         data: () => ({
             visible: false,

--- a/src/gui/src/components/assess/NewsItemSingleDetail.vue
+++ b/src/gui/src/components/assess/NewsItemSingleDetail.vue
@@ -1,6 +1,6 @@
 <template>
     <v-row v-bind="UI.DIALOG.ROW.WINDOW">
-        <v-dialog v-bind="UI.DIALOG.FULLSCREEN" v-model="visible" @keydown.esc="close">
+        <v-dialog v-bind="UI.DIALOG.FULLSCREEN" v-model="visible" @keydown.esc="close" :attach="attach">
             <v-card>
 
                 <v-toolbar v-bind="UI.DIALOG.TOOLBAR" data-dialog="single-detail">
@@ -179,7 +179,8 @@ export default {
     components: {NewsItemAttribute, VueEditor},
     mixins: [AuthMixin],
     props: {
-        analyze_selector: Boolean
+        analyze_selector: Boolean,
+        attach: undefined
     },
     computed: {
         canAccess() {

--- a/src/gui/src/main.js
+++ b/src/gui/src/main.js
@@ -87,5 +87,9 @@ export const vm = new Vue({
     store,
     router,
     render: h => h(App),
+    beforeCreate() {
+        const val = localStorage.getItem('TNGVericalView') == 'true';
+        this.$store.commit('setVerticalView', val);
+    }
 
 }).$mount('#app');

--- a/src/gui/src/store/store.js
+++ b/src/gui/src/store/store.js
@@ -19,7 +19,8 @@ const state = {
         name: '',
         organization_name: '',
         permissions: []
-    }
+    },
+    vertical_view: false,
 };
 
 const actions = {
@@ -30,14 +31,23 @@ const actions = {
 
     logout(context) {
         context.commit('clearJwtToken')
-    }
+    },
+
+    setVerticalView(context, data) {
+        context.commit('setVerticalView', data)
+    },
 };
 
 const mutations = {
 
     setUser(state, userData) {
         state.user = userData
-    }
+    },
+
+    setVerticalView(state, data) {
+        state.vertical_view = data
+        localStorage.setItem('TNGVericalView', data)
+    },
 };
 
 const getters = {
@@ -56,7 +66,11 @@ const getters = {
 
     getPermissions(state) {
         return state.user.permissions;
-    }
+    },
+
+    getVerticalView() {
+        return state.vertical_view
+    },
 };
 
 export const store = new Vuex.Store({


### PR DESCRIPTION
Users can now enjoy a much more convenient view of the selected News articles when creating a new Report item in TNG.

![image](https://user-images.githubusercontent.com/1970811/176853442-5f6f6b89-ffdf-4f8e-86ce-d573b07f5023.png)
