### PR TITLE
OpenAPI docs

### DIFF
--- a/resources/openapi.yaml
+++ b/resources/openapi.yaml
@@ -1,0 +1,101 @@
+openapi: 3.0.3
+info:
+  title: TaranisNG
+  description: |-
+    The TaranisNG Core server offers API Endpoints for TaranisNG GUI, Publishers, Presenters, Collectors and Bots.
+    TaranisNG Publishers offers...
+    This document is based on the OpenAPI 3.0 specification.
+  license:
+    name: GPL-3.0
+  version: 1.0.11
+externalDocs:
+  description: Taranis-NG GitHub
+  url: https://github.com/ait-cs-IaaS/Taranis-NG/
+servers:
+  - url: https://dev.taranis.cyberrange.rocks/api
+tags:
+  - name: Core
+    description: Core is core
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+paths:
+  /api/isalive:
+    get:
+      tags:
+        - Core
+      summary: Returns Core status
+      description: Returns Core status
+      operationId: IsAlive
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isalive:
+                    type: boolean
+        '400':
+          description: Invalid status value
+  /user/login:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ''
+      operationId: loginUser
+      parameters:
+        - name: username
+          in: query
+          description: The user name for login
+          required: false
+          schema:
+            type: string
+        - name: password
+          in: query
+          description: The password for login in clear text
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          headers:
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: Invalid username/password supplied
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          example: theUser
+        password:
+          type: string
+          example: '12345'
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header


### PR DESCRIPTION
Write swagger documentation for currently existing API Endpoints https://swagger.io/specification/

The goal is not to use auto-generation, but rather to (after creating the initial yaml) to follow a "design first" approach. 

Discussing changes in the openapi.yaml and afterwards implementing it on the various endpoints.

