### PR TITLE
Automatically initialize "collectors" node on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,12 @@ After installation, you have to connect the core application with collectors,
 presenters, and publishers. There is no limit to how many of these you have.
 The default docker installation deploys one instance of each for you automatically.
 
-Adding a collector node: Log in as an `admin`, then navigate to Configuration
--> Collectors nodes. Click `Add new`. Enter any name and description. For URL,
+Adding a collector node: TL;DR: no action needed. Longer version: This is done automatically on startup if no collectors are defined, unless you define `SKIP_DEFAULT_COLLECTOR=true` environment variable. To verify: Log in as an `admin`, then navigate to Configuration -> Collectors nodes. You should see `Default Docker Collector` in the list.
+
+Adding a presenter node: Log in as an `admin`, then navigate to Configuration
+-> Presenters nodes. Click `Add new`. Enter any name and description. For URL,
 enter `http://collectors/` and for key, enter `supersecret` (or whatever
 password you chose during the installation). Click `Save`.
-
-Adding a presenter node: repeat the process at Configuration -> Presenters
-nodes. Fill in the fields. For URL, enter `http://presenters/`. Don't forget to
-set the password.
 
 Adding a publisher node: repeat the process at Configuration -> Publishers
 nodes. Fill in the fields. For URL, enter `http://publishers/`. Don't forget to

--- a/docker/README.md
+++ b/docker/README.md
@@ -138,6 +138,7 @@ Any configuration options are available at [https://hub.docker.com/_/postgres](h
 | `JWT_SECRET_KEY`            | JWT token secret key. | `J6flTliJ076zWg` |
 | `OPENID_LOGOUT_URL`         | Keycloak logout URL. | `https://example.com/auth/realms/master/protocol/openid-connect/logout` |
 | `WORKERS_PER_CORE`          | Number of gunicorn worker threads to spawn per CPU core. | `4` |
+| `SKIP_DEFAULT_COLLECTOR`    | Set to `true` to prevent initialization of a default docker collector at first run | `` |
 
 Taranis NG can use [connection pooling](https://docs.sqlalchemy.org/en/14/core/pooling.html) to maintain multiple active connections to the database server. Connection pooling is required when your deployment serves hundreds of customers from one instance. To enable connection pooling, set the `DB_POOL_SIZE`, `DB_POOL_RECYCLE`, and `DB_POOL_TIMEOUT` environment variables.
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -66,6 +66,8 @@ services:
 
       TZ: "${TZ}"
       DEBUG: "true"
+      # to allow automatic initialisation of collectors/presenters/publishers
+      COLLECTOR_PRESENTER_PUBLISHER_API_KEY: "${COLLECTOR_PRESENTER_PUBLISHER_API_KEY}"
     labels:
       traefik.enable: "true"
       traefik.http.services.taranis-api.loadbalancer.server.port: "80"

--- a/docker/prestart_core.sh
+++ b/docker/prestart_core.sh
@@ -4,4 +4,12 @@ echo "Running inside /app/prestart.sh..."
 
 echo "Running migrations..."
 /app/db_migration.py db upgrade head
+
+if [ `./manage.py collector --list | wc -l` = 0 -a x"$SKIP_DEFAULT_COLLECTOR" != "xtrue" ]; then
+    (
+    echo "Adding default collector"
+    ./manage.py collector --create --name "Default Docker Collector" --description "A local collector node configured as a part of Taranis NG default installation." --api-url "http://collectors/" --api-key "$COLLECTOR_PRESENTER_PUBLISHER_API_KEY"
+    ) &
+fi
+
 echo "Done."

--- a/src/core/manage.py
+++ b/src/core/manage.py
@@ -238,10 +238,22 @@ class CollectorManagement(Command):
                 'api_url': opt_api_url,
                 'api_key': opt_api_key,
                 'collectors': [],
-                'status': 0
+                'status': '0'
             }
 
-            collectors_info, status_code = CollectorsApi(opt_api_url, opt_api_key).get_collectors_info("")
+            print('Trying to contact a new collector node...')
+            retries, max_retries = 0, 30
+            while retries < max_retries:
+                try:
+                    collectors_info, status_code = CollectorsApi(opt_api_url, opt_api_key).get_collectors_info("")
+                    break;
+                except:
+                    collectors_info = 'Collector unavailable'
+                    status_code = 0
+                    time.sleep(1)
+                retries += 1
+                print('Retrying [{}/{}]...'.format(retries, max_retries))
+
 
             if status_code != 200:
                 print('Cannot create a new collector node!')


### PR DESCRIPTION
This eliminates one step of the installation process: connecting the docker `core` to the docker `collectors` node.

The new node is added by running `manage.py` from within the `core` container.  The new collector will be automatically configured if there are no collectors present. The feature can be disabled by setting the environment variable `SKIP_DEFAULT_COLLECTOR=true`.