### PR TITLE
Fix DB: PGTZ, Fix Bots: TARANIS_NG_CORE_URL

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       POSTGRES_USER: "taranis-ng"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
       TZ: "${TZ}"
+      PGTZ: "${TZ}"
     command: ["postgres", "-c", "shared_buffers=${DB_SHARED_BUFFERS}", "-c", "max_connections=${DB_MAX_CONNECTIONS}"]
     volumes:
       - "database_data:/var/lib/postgresql/data"
@@ -105,7 +106,7 @@ services:
         https_proxy: "${HTTPS_PROXY}"
     environment:
       API_KEY: "${COLLECTOR_PRESENTER_PUBLISHER_API_KEY}"
-      TARANIS_NG_CORE_URL: "http://core/api/v1"
+      TARANIS_NG_CORE_URL: "http://core"
       TARANIS_NG_CORE_SSE: "http://core/sse"
       WORKERS_PER_CORE: "1"
       TZ: "${TZ}"


### PR DESCRIPTION
Fix in docker-compose.yml:
**Bots:** TARANIS_NG_CORE_URL variable - bad URL
**DB:** PGTZ variable - problem with timezone error messages in DB after running Bots. I hope there will be no problem for other things :-)
