### PR TITLE
Fix: Access denied by ACL in News items (deleting Osint sources)

### DIFF
--- a/src/core/model/news_item.py
+++ b/src/core/model/news_item.py
@@ -220,8 +220,8 @@ class NewsItem(db.Model):
                 NewsItem.id == news_item_id)
 
             query = query.join(NewsItemData, NewsItem.news_item_data_id == NewsItemData.id)
-            query = query.join(OSINTSource, NewsItemData.osint_source_id == OSINTSource.id)
-
+            # LEFT JOIN because when deleting Osint sources -> SET NULL to News items -> ACL right fails
+            query = query.outerjoin(OSINTSource, NewsItemData.osint_source_id == OSINTSource.id)
             query = query.outerjoin(ACLEntry, or_(and_(NewsItemData.osint_source_id == ACLEntry.item_id,
                                                        ACLEntry.item_type == ItemType.OSINT_SOURCE),
                                                   and_(OSINTSource.collector_id == ACLEntry.item_id,


### PR DESCRIPTION
When deleting Osint sources is NULL set to in News items (osint_source_id). This cause that function NewsItem.allowed_with_acl() fail and show message `Access denied by ACL`