### PR TITLE
In Products, display "Report type" instead of string "Title" in row detail

### DIFF
--- a/src/gui/src/components/publish/CardProduct.vue
+++ b/src/gui/src/components/publish/CardProduct.vue
@@ -11,7 +11,7 @@
                                     <v-icon center>{{card.tag}}</v-icon>
                                 </v-col>
                                 <v-col>
-                                    <div class="grey--text">{{$t('card_item.title')}}</div>
+                                    <div class="grey--text">{{card.product_type_name}}</div>
                                     <span>{{card.title}}</span>
                                 </v-col>
                                 <v-col>

--- a/src/gui/src/components/publish/ContentDataPublish.vue
+++ b/src/gui/src/components/publish/ContentDataPublish.vue
@@ -51,7 +51,16 @@
                 }
                 this.$store.dispatch("getAllProducts", {filter: this.filter, offset:offset, limit:limit})
                     .then(() => {
+                        const product_types = Object.values(this.$store.getters.getProductTypes.items);
                         this.collections = this.collections.concat(this.$store.getters.getProducts.items);
+                        for (let i = 0; i < this.collections.length; i++) {
+                            let product_type = product_types.filter(x => x.id == this.collections[i].product_type_id);
+                            if (product_type.length) {
+                                this.collections[i].product_type_name = product_type[0].title;
+                            } else {
+                                this.collections[i].product_type_name = this.$t('card_item.title');
+                            }
+                        }
                         setTimeout(() => {
                             this.data_loaded = true
                         }, 1000);


### PR DESCRIPTION
In Products, display "Report type" instead of string "Title" in row detail. Normally Title is repeating on each line and doesn't have any "useful" meaning.

![image](https://user-images.githubusercontent.com/10151485/224690402-a96787bb-88cb-40bf-868c-f30588edad77.png)

Maybe some settings for that or it's ok? Having on each row some useful information is better than repeating "Title" string.