### PR TITLE
fix MISP template

### DIFF
--- a/src/presenters/templates/misp.json
+++ b/src/presenters/templates/misp.json
@@ -1,19 +1,19 @@
 {
 {% for report_item in data.report_items %}
-    "threat_level_id": {% if report_item.attrs.event_threat_level == 'High' %}"1"{% endif %}{% if report_item.attrs.event_threat_level == 'Medium' %}"2"{% endif %}{% if report_item.attrs.event_threat_level == 'Low' %}"3"{% endif %}{% if report_item.attrs.event_threat_level == 'Undefined' %}"4"{% endif %},
-    "info": {% if report_item.attrs.event_info %}"{{ report_item.attrs.event_info }}"{% endif %},
+    "threat_level_id": {% if report_item.attrs.event_threat_level == 'High' %}"1"{% elif report_item.attrs.event_threat_level == 'Medium' %}"2"{% elif report_item.attrs.event_threat_level == 'Low' %}"3"{% elif report_item.attrs.event_threat_level == 'Undefined' %}"4"{% else %}null{% endif %},
+    "info": {% if report_item.attrs.event_info %}"{{ report_item.attrs.event_info }}"{% else %}null{% endif %},
     "published": false,
-    "distribution": {% if report_item.attrs.event_distribution == 'Your Organisation only' %}"0"{% endif %}{% if report_item.attrs.event_distribution == 'This Community Only' %}"1"{% endif %}{% if report_item.attrs.event_distribution == 'Conected Communities' %}"2"{% endif %}{% if report_item.attrs.event_distribution == 'All Communities' %}"3"{% endif %}{% if report_item.attrs.event_distribution == 'Sharing Group' %}"4"{% endif %},
-    "analysis": {% if report_item.attrs.event_analysis == 'Initial' %}"0"{% endif %}{% if report_item.attrs.event_analysis == 'Ongoing' %}"1"{% endif %}{% if report_item.attrs.event_analysis == 'Complete' %}"2"{% endif %},
+    "distribution": {% if report_item.attrs.event_distribution == 'Your Organisation only' %}"0"{% elif report_item.attrs.event_distribution == 'This Community Only' %}"1"{% elif report_item.attrs.event_distribution == 'Conected Communities' %}"2"{% elif report_item.attrs.event_distribution == 'All Communities' %}"3"{% elif report_item.attrs.event_distribution == 'Sharing Group' %}"4"{% else %}null{% endif %},
+    "analysis": {% if report_item.attrs.event_analysis == 'Initial' %}"0"{% elif report_item.attrs.event_analysis == 'Ongoing' %}"1"{% elif report_item.attrs.event_analysis == 'Complete' %}"2"{% else %}null{% endif %},
     "Attribute": [
         {
-        "type": {% if report_item.attrs.attribute_type %}"{{ report_item.attrs.attribute_type }}"{% endif %},
-        "category": {% if report_item.attrs.attribute_category %}"{{ report_item.attrs.attribute_category }}"{% endif %},
+        "type": {% if report_item.attrs.attribute_type %}"{{ report_item.attrs.attribute_type }}"{% else %}null{% endif %},
+        "category": {% if report_item.attrs.attribute_category %}"{{ report_item.attrs.attribute_category }}"{% else %}null{% endif %},
         "to_ids": {% if report_item.attrs.attribute_additional_information == 'For Intrusion Detection System' %}true{% else %}false{% endif %},
         "disable_correlation": {% if report_item.attrs.attribute_additional_information == 'Disable Correlation' %}true{% else %}false{% endif %},
-        "distribution": {% if report_item.attrs.attribute_distribution == 'Your Organisation Only' %}"0"{% endif %}{% if report_item.attrs.attribute_distribution == 'This Community Only' %}"1"{% endif %}{% if report_item.attrs.attribute_distribution == 'Connected Communities' %}"2"{% endif %}{% if report_item.attrs.attribute_distribution == 'All Communities' %}"3"{% endif %}{% if report_item.attrs.attribute_distribution == 'Sharing Group' %}"4"{% endif %}{% if report_item.attrs.attribute_distribution == 'Inherit Event' %}"5"{% endif %},
-        "comment": {% if report_item.attrs.attribute_contextual_comment %}"{{ report_item.attrs.attribute_contextual_comment }}"{% endif %},
-        "value": {% if report_item.attrs.attribute_value %}"{{ report_item.attrs.attribute_value }}"{% endif %}
+        "distribution": {% if report_item.attrs.attribute_distribution == 'Your Organisation Only' %}"0"{% elif report_item.attrs.attribute_distribution == 'This Community Only' %}"1"{% elif report_item.attrs.attribute_distribution == 'Connected Communities' %}"2"{% elif report_item.attrs.attribute_distribution == 'All Communities' %}"3"{% elif report_item.attrs.attribute_distribution == 'Sharing Group' %}"4"{% elif report_item.attrs.attribute_distribution == 'Inherit Event' %}"5"{% else %}null{% endif %},
+        "comment": {% if report_item.attrs.attribute_contextual_comment %}"{{ report_item.attrs.attribute_contextual_comment }}"{% else %}null{% endif %},
+        "value": {% if report_item.attrs.attribute_value %}"{{ report_item.attrs.attribute_value }}"{% else %}null{% endif %}
         }
     ]
 {% endfor %}


### PR DESCRIPTION
This fixes the generation of template. When some values are missing, the generated JSON file is not valid. This patch might not result in a valid MISP file (it probably is not valid, I haven't checked), but it ensures that the generated file is a valid JSON.