### PR TITLE
Specify SQLAlchemy version in requirements.txt for core + .gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ src/.env
 *.pem
 *.key
 *.log
+*.crt
 local/
 
 # settings of editors

--- a/src/core/requirements.txt
+++ b/src/core/requirements.txt
@@ -1,4 +1,4 @@
-alembic==1.3.2
+alembic==1.10.2
 certifi==2019.11.28
 Flask==1.1.4
 Flask-Cors==3.0.10
@@ -31,6 +31,7 @@ schedule==0.6.0
 six==1.13.0
 sseclient-py==1.7
 soupsieve==1.9.5
+SQLAlchemy==1.4.47
 urllib3==1.26.7
 Werkzeug==0.16.0
 pycryptodomex==3.17


### PR DESCRIPTION
When trying to build a docker container of core I got into issues related to this sqlalchemy/sqlalchemy/issues/6226. SQLAlchemy version was not specified in requirements.txt, therefore alembic (probably - https://alembic.sqlalchemy.org/en/latest/front.html#dependencies) selected the current version 2.0.7. This created an error in db_migration.py, line 7.  It works as it is supposed to with the latest version of SQLAlchemy 1.4.