### PR TITLE
Adds LDAP authentication

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
         max-file: "10"
 
   core:
-    depends_on: 
+    depends_on:
       - "redis"
       - "database"
     restart: unless-stopped
@@ -46,7 +46,7 @@ services:
         HTTPS_PROXY: "${HTTPS_PROXY}"
         http_proxy: "${HTTP_PROXY}"
         https_proxy: "${HTTPS_PROXY}"
-    environment: 
+    environment:
       REDIS_URL: "redis://redis"
       DB_URL: "database"
       DB_DATABASE: "taranis-ng"
@@ -55,6 +55,9 @@ services:
       DB_POOL_SIZE: 100
       DB_POOL_RECYCLE: 300
       DB_POOL_TIMEOUT: 30
+      TARANIS_NG_AUTHENTICATOR: "${TARANIS_NG_AUTHENTICATOR}"
+      LDAP_SERVER: "${LDAP_SERVER}"
+      LDAP_BASE_DN: "${LDAP_BASE_DN}"
 
       JWT_SECRET_KEY: "${JWT_SECRET_KEY}"
       OPENID_LOGOUT_URL: ""
@@ -116,7 +119,7 @@ services:
       options:
         max-size: "200k"
         max-file: "10"
-    
+
   collectors:
     depends_on:
       core:
@@ -144,7 +147,7 @@ services:
       options:
         max-size: "200k"
         max-file: "10"
-    
+
   presenters:
     depends_on:
       core:
@@ -173,7 +176,7 @@ services:
       options:
         max-size: "200k"
         max-file: "10"
-    
+
   publishers:
     depends_on:
       core:
@@ -212,7 +215,7 @@ services:
         HTTPS_PROXY: "${HTTPS_PROXY}"
         http_proxy: "${HTTP_PROXY}"
         https_proxy: "${HTTPS_PROXY}"
-#    ports: 
+#    ports:
 #      - "8080:80"
     environment:
       NGINX_WORKERS: "4"
@@ -253,7 +256,7 @@ services:
     image: "traefik:latest"
     environment:
       TZ: "${TZ}"
-    ports: 
+    ports:
       - "${TARANIS_NG_HTTP_PORT}:80"
       - "${TARANIS_NG_HTTPS_PORT}:443"
       - "${TRAEFIK_MANAGEMENT_PORT}:9090"

--- a/src/core/auth/README.md
+++ b/src/core/auth/README.md
@@ -1,0 +1,1 @@
+Place certificate for LDAP authentication in this folder and name it ldap_ca.pem 

--- a/src/core/auth/ldap_authenticator.py
+++ b/src/core/auth/ldap_authenticator.py
@@ -1,0 +1,34 @@
+from managers import log_manager
+from auth.base_authenticator import BaseAuthenticator
+from flask import request
+from ldap3 import Server, Connection, ALL, Tls
+import ssl
+import time
+import random
+import os
+
+class LDAPAuthenticator(BaseAuthenticator):
+
+    LDAP_SERVER = os.getenv('LDAP_SERVER')
+    LDAP_BASE_DN = os.getenv('LDAP_BASE_DN')
+    LDAP_CA_CERT_PATH = 'auth/ldap_ca.pem'
+    if not os.path.isfile(LDAP_CA_CERT_PATH):
+        LDAP_CA_CERT_PATH = None
+        log_manager.store_auth_error_activity("No LDAP CA certificate found. LDAP authentication might not work.")
+
+    def get_required_credentials(self):
+        return ["username", "password"]
+
+    def authenticate(self, credentials):
+        tls = Tls(ca_certs_file=self.LDAP_CA_CERT_PATH, validate=ssl.CERT_REQUIRED, version=ssl.PROTOCOL_TLSv1_2)
+        server = Server(self.LDAP_SERVER, use_ssl=True, tls=tls, get_info=ALL)
+        conn = Connection(server, user=f'uid={credentials["username"]},{self.LDAP_BASE_DN}', password=credentials["password"], read_only=True)
+
+        if not conn.bind():
+            data = request.get_json()
+            data["password"] = log_manager.sensitive_value(data["password"])
+            log_manager.store_auth_error_activity("Authentication failed for user: " + credentials["username"], request_data=data)
+            time.sleep(random.uniform(1, 3))
+            return BaseAuthenticator.generate_error()
+
+        return BaseAuthenticator.generate_jwt(credentials["username"])

--- a/src/core/managers/auth_manager.py
+++ b/src/core/managers/auth_manager.py
@@ -11,6 +11,7 @@ from managers import log_manager, time_manager
 from auth.keycloak_authenticator import KeycloakAuthenticator
 from auth.openid_authenticator import OpenIDAuthenticator
 from auth.password_authenticator import PasswordAuthenticator
+from auth.ldap_authenticator import LDAPAuthenticator
 from model.collectors_node import CollectorsNode
 from model.news_item import NewsItem
 from model.osint_source import OSINTSourceGroup
@@ -37,13 +38,15 @@ def initialize(app):
 
     JWTManager(app)
 
-    which = os.getenv('TARANIS_NG_AUTHENTICATOR')
+    which = os.getenv('TARANIS_NG_AUTHENTICATOR').casefold()
     if which == 'openid':
         current_authenticator = OpenIDAuthenticator()
     elif which == 'keycloak':
         current_authenticator = KeycloakAuthenticator()
     elif which == 'password':
         current_authenticator = PasswordAuthenticator()
+    elif which == 'ldap':
+        current_authenticator = LDAPAuthenticator()
     else:
         current_authenticator = PasswordAuthenticator()
 

--- a/src/core/requirements.txt
+++ b/src/core/requirements.txt
@@ -14,12 +14,13 @@ greenlet==1.1.1
 gunicorn==20.0.4
 idna==2.9
 Jinja2==2.11.3
+ldap3==2.9.1
 Mako==1.1.0
 MarkupSafe==1.1.0
 marshmallow==3.18.0
 marshmallow-enum==1.5.1
 psycogreen==1.0.2
-psycopg2-binary==2.8.4
+psycopg2-binary==2.9.6
 PyJWT==1.7.1
 python-dateutil==2.8.1
 python-dotenv==0.10.3


### PR DESCRIPTION
Adds LDAP authentication. When bind is successful, user gets authenticated. Necessary settings is set in .env. I had to increase version of psycopg2-binary, otherwise the container would not launch, but I did not investigate it closely.