### PR TITLE
Fix MISP template

### DIFF
--- a/src/presenters/templates/misp.json
+++ b/src/presenters/templates/misp.json
@@ -1,20 +1,21 @@
-{
-{% for report_item in data.report_items %}
-    "threat_level_id": {% if report_item.attrs.event_threat_level == 'High' %}"1"{% elif report_item.attrs.event_threat_level == 'Medium' %}"2"{% elif report_item.attrs.event_threat_level == 'Low' %}"3"{% elif report_item.attrs.event_threat_level == 'Undefined' %}"4"{% else %}null{% endif %},
+{ {% for report_item in data.report_items %}
+  "Event": {
+    "analysis": {% if report_item.attrs.event_analysis == 'Initial' %}"0"{% elif report_item.attrs.event_analysis == 'Ongoing' %}"1"{% elif report_item.attrs.event_analysis == 'Complete' %}"2"{% else %}null{% endif %},
+    "distribution": {% if report_item.attrs.event_distribution == 'Your Organisation only' %}"0"{% elif report_item.attrs.event_distribution == 'This Community Only' %}"1"{% elif report_item.attrs.event_distribution == 'Conected Communities' %}"2"{% elif report_item.attrs.event_distribution == 'All Communities' %}"3"{% elif report_item.attrs.event_distribution == 'Sharing Group' %}"4"{% else %}null{% endif %},
     "info": {% if report_item.attrs.event_info %}"{{ report_item.attrs.event_info }}"{% else %}null{% endif %},
     "published": false,
-    "distribution": {% if report_item.attrs.event_distribution == 'Your Organisation only' %}"0"{% elif report_item.attrs.event_distribution == 'This Community Only' %}"1"{% elif report_item.attrs.event_distribution == 'Conected Communities' %}"2"{% elif report_item.attrs.event_distribution == 'All Communities' %}"3"{% elif report_item.attrs.event_distribution == 'Sharing Group' %}"4"{% else %}null{% endif %},
-    "analysis": {% if report_item.attrs.event_analysis == 'Initial' %}"0"{% elif report_item.attrs.event_analysis == 'Ongoing' %}"1"{% elif report_item.attrs.event_analysis == 'Complete' %}"2"{% else %}null{% endif %},
+    "threat_level_id": {% if report_item.attrs.event_threat_level == 'High' %}"1"{% elif report_item.attrs.event_threat_level == 'Medium' %}"2"{% elif report_item.attrs.event_threat_level == 'Low' %}"3"{% elif report_item.attrs.event_threat_level == 'Undefined' %}"4"{% else %}null{% endif %},
+    "uuid": "{{ report_item.uuid }}",
     "Attribute": [
-        {
-        "type": {% if report_item.attrs.attribute_type %}"{{ report_item.attrs.attribute_type }}"{% else %}null{% endif %},
+      {    
         "category": {% if report_item.attrs.attribute_category %}"{{ report_item.attrs.attribute_category }}"{% else %}null{% endif %},
-        "to_ids": {% if report_item.attrs.attribute_additional_information == 'For Intrusion Detection System' %}true{% else %}false{% endif %},
+        "comment": {% if report_item.attrs.attribute_contextual_comment %}"{{ report_item.attrs.attribute_contextual_comment }}"{% else %}null{% endif %},
         "disable_correlation": {% if report_item.attrs.attribute_additional_information == 'Disable Correlation' %}true{% else %}false{% endif %},
         "distribution": {% if report_item.attrs.attribute_distribution == 'Your Organisation Only' %}"0"{% elif report_item.attrs.attribute_distribution == 'This Community Only' %}"1"{% elif report_item.attrs.attribute_distribution == 'Connected Communities' %}"2"{% elif report_item.attrs.attribute_distribution == 'All Communities' %}"3"{% elif report_item.attrs.attribute_distribution == 'Sharing Group' %}"4"{% elif report_item.attrs.attribute_distribution == 'Inherit Event' %}"5"{% else %}null{% endif %},
-        "comment": {% if report_item.attrs.attribute_contextual_comment %}"{{ report_item.attrs.attribute_contextual_comment }}"{% else %}null{% endif %},
+        "to_ids": {% if report_item.attrs.attribute_additional_information == 'For Intrusion Detection System' %}true{% else %}false{% endif %},
+        "type": {% if report_item.attrs.attribute_type %}"{{ report_item.attrs.attribute_type }}"{% else %}null{% endif %},
         "value": {% if report_item.attrs.attribute_value %}"{{ report_item.attrs.attribute_value }}"{% else %}null{% endif %}
-        }
+      }
     ]
-{% endfor %}
+  }{{ ", " if not loop.last else "" }}{% endfor %}
 }


### PR DESCRIPTION
This way it is closer to the specification.
Added "Event" at the beginning. Added UUID to event. 

BUT
- There is still not an UUID for Attribute, that is mandatory according to specs.
- Generates MISP only for the first report item. I think each report must to be generated to separate file. But this way it is at least valid JSON (although with duplicate key), that is possible to open without issues.
