### PR TITLE
Fix: Docker build fail. Warning: The license_file parameter is deprecated…

### DIFF
--- a/src/presenters/requirements.txt
+++ b/src/presenters/requirements.txt
@@ -12,6 +12,6 @@ pdfkit==0.6.1
 PyJWT==1.7.1
 python-dotenv==0.10.5
 pytz==2019.3
-PyYAML==5.4
+PyYAML==6.0.1
 six==1.14.0
 Werkzeug==0.16.0


### PR DESCRIPTION
Docker build start failing after some date with warning: The license_file parameter is deprecated, use license_files instead. Before this date it was working ok. Some new Python policy.