### PR TITLE
Fix saving comments in News Items (was not working)

### DIFF
--- a/src/gui/src/components/assess/NewsItemAggregateDetail.vue
+++ b/src/gui/src/components/assess/NewsItemAggregateDetail.vue
@@ -65,6 +65,7 @@
                     <v-tab-item value="tab-2" class="pa-5">
                         <vue-editor
                                 ref="assessAggregateDetailComments"
+                                v-model="editorData"
                                 :editorOptions="editorOptionVue2"
                         />
                     </v-tab-item>
@@ -157,7 +158,7 @@
                 this.news_item = news_item;
                 this.title = news_item.title;
                 this.description = news_item.description;
-                this.editorData = this.news_item.comments
+                this.editorData = news_item.comments
 
                 this.$root.$emit('first-dialog', 'push');
             },

--- a/src/gui/src/components/assess/NewsItemSingleDetail.vue
+++ b/src/gui/src/components/assess/NewsItemSingleDetail.vue
@@ -134,6 +134,7 @@
                     <v-tab-item value="tab-3" class="pa-5">
                         <vue-editor
                             ref="assessDetailComments"
+                            v-model="editorData"
                             :editorOptions="editorOptionVue2"
                         />
                     </v-tab-item>
@@ -232,14 +233,14 @@ export default {
                     this.news_item.news_items[0] = response.data;
                     this.title = news_item.title;
                     this.description = news_item.description;
-                    this.editorData = this.news_item.comments
+                    this.editorData = news_item.comments
                 });
             } else {
                 this.visible = true
                 this.news_item = news_item;
                 this.title = news_item.title;
                 this.description = news_item.description;
-                this.editorData = this.news_item.comments
+                this.editorData = news_item.comments
             }
 
             this.$root.$emit('first-dialog', 'push');


### PR DESCRIPTION
Saving comments in News Items was not working. Fixed for saving in Single NewsItem and Aggregate NewsItems