### PR TITLE
Fix: display report item details on product (previously empty)

### DIFF
--- a/src/gui/src/assets/keyboard_mixin.js
+++ b/src/gui/src/assets/keyboard_mixin.js
@@ -458,7 +458,7 @@ const keyboardMixin = targetId => ({
                             this.keyboard_state = 'DEFAULT';
                             break;
                     }
-                    if (this.keyboard_state = 'DEFAULT') {
+                    if (this.keyboard_state === 'DEFAULT') {
                         this.$root.$emit('notification',
                             {
                                 type: 'success',

--- a/src/gui/src/components/analyze/RemoteReportItemSelector.vue
+++ b/src/gui/src/components/analyze/RemoteReportItemSelector.vue
@@ -229,11 +229,17 @@
                         })
                     }
 
-                    if (this.$store.getters.getCurrentReportItemGroup === null && this.links.length > 0) {
-                        this.selected_group_id = this.links[0].id
-                        this.$store.dispatch("changeCurrentReportItemGroup", this.links[0].id);
+                    // check if .links exist otherwise it will crash with undefined error
+                    if (this.links.length > 0) {
+                        if (this.$store.getters.getCurrentReportItemGroup === null) {
+                            this.selected_group_id = this.links[0].id
+                            this.$store.dispatch("changeCurrentReportItemGroup", this.selected_group_id);
+                        } else {
+                            this.selected_group_id = this.$store.getters.getCurrentReportItemGroup
+                            this.links[0].id = this.selected_group_id
+                        }
                     } else {
-                        this.selected_group_id = this.links[0].id = this.$store.getters.getCurrentReportItemGroup
+                        this.selected_group_id = this.$store.getters.getCurrentReportItemGroup
                     }
                 });
 

--- a/src/gui/src/components/publish/ReportItemSelector.vue
+++ b/src/gui/src/components/publish/ReportItemSelector.vue
@@ -32,7 +32,7 @@
 
         <v-spacer style="height:8px"></v-spacer>
 
-        <NewReportItem ref="reportItemDialog"/>
+        <NewReportItem ref="reportItemDialog" :read_only="true"/>
 
         <component publish_selector class="item-selector" v-bind:is="cardLayout()" v-for="value in values" :card="value"
                    :key="value.id"

--- a/src/gui/src/i18n/en/messages.js
+++ b/src/gui/src/i18n/en/messages.js
@@ -686,6 +686,7 @@ const messages_en = {
     report_item: {
         add_new: "New report item",
         edit: "Edit report item",
+        read: "Report item preview",
         save: "Save",
         cancel: "Cancel",
         validation_error: "Please fill in all required fields",


### PR DESCRIPTION
Fix: display report item details on product (previously empty, @dodancs)
Bug: crash on null .link
Bug: crash on fast report item open (not yet loaded data types) 
Now need to properly format read_only attributes (radio, checkbox etc because now are displayed as text field)