### PR TITLE
fix: dialog is centered based on scrollbars range and not on screen size

### DIFF
--- a/src/gui/src/components/analyze/NewReportItem.vue
+++ b/src/gui/src/components/analyze/NewReportItem.vue
@@ -226,14 +226,14 @@
 </template>
 
 <style>
-.taranis-ng-vertical-view {
-    position: relative;
-}
+    .taranis-ng-vertical-view {
+        position: relative;
+    }
 
-.v-dialog__content,
-.v-dialog--fullscreen {
-    position: absolute;
-}
+    .v-dialog__content,
+    .v-dialog--fullscreen {
+        position: fixed;
+    }
 </style>
 
 <script>


### PR DESCRIPTION
fix: on screen with big records count is dialog centered based on scrollbars range and not on screen size. It is showing outside viewable range and user get "disabled" screen.
Example: Open Assess and press User/Settings -> screen get disabled and nothing shown, but scroll down to see this dialog....