### PR TITLE
Fix: disable shorcuts on text/textarea fields (prevents typing text)

### DIFF
--- a/src/gui/src/assets/keyboard_mixin.js
+++ b/src/gui/src/assets/keyboard_mixin.js
@@ -151,8 +151,12 @@ const keyboardMixin = targetId => ({
                 }
             }
             // window.console.debug("keyAlias:", keyAlias, "activeElement:", document.activeElement);
-            if ((document.activeElement == search_field || document.activeElement.className == "ql-editor")  && (keyAlias !== 'close_item' || press.keyCode !== 27)) {
-                // when search field or editor is active, ignore all keypresses except Escape
+            if ((document.activeElement == search_field ||
+                 document.activeElement.className == "ql-editor" ||
+                 document.activeElement.type == "text" ||
+                 document.activeElement.type == "textarea") && (keyAlias !== 'close_item' || press.keyCode !== 27)) {
+                // when search field, editor, text or textarea is active, ignore all keypresses except Escape
+                // example problem: Assess, create report from item and you type N in description field -> all is canceled and it creates new report again
                 return;
             }
 


### PR DESCRIPTION
Example: Assess, create report from item and you type N in description field -> all is canceled and it creates new report again