### PR TITLE
Collectors update (Limit for article links, logs, fixes)

### DIFF
--- a/src/collectors/collectors/base_collector.py
+++ b/src/collectors/collectors/base_collector.py
@@ -49,12 +49,11 @@ class BaseCollector:
 
     @staticmethod
     def print_exception(source, error):
-        log_info('OSINTSource ID: ' + source.id)
-        log_info('OSINTSource name: ' + source.name)
+        log_warning('OSINTSource name: ' + source.name)
         if str(error).startswith('b'):
-            log_info('ERROR: ' + str(error)[2:-1])
+            log_warning('ERROR: ' + str(error)[2:-1])
         else:
-            log_info('ERROR: ' + str(error))
+            log_warning('ERROR: ' + str(error))
 
     @staticmethod
     def timezone_info():
@@ -306,3 +305,13 @@ class BaseCollector:
 
     def initialize(self):
         self.refresh()
+
+    @staticmethod
+    def read_int_parameter(name, default_value, source):
+        try:
+            val = int(source.parameter_values[name])
+            if val <= 0:
+                val = default_value
+        except Exception:
+            val = default_value
+        return val


### PR DESCRIPTION
- Better logs: article link progress for current page
- Added optional "Limit for article links" setting (WEB, RSS, ATOM). You can process only first N articles. Usefull on sources with big article count (when you don't want kill collector)
- Display "Page limit reached" only if "Pagination limit" was set
- Fixed crash when article items are parsed ok but link is not found (java scripts, not fully dynamicaly loaded page)
- Removed one duplicity log about parsing article link
- Removed from RSS/ATOM date check condition (now it works in the same way as in WEB collector, now it's possible collect initial source state)
- Fixed ATOM author element that can exist/miss in header/entry