### PR TITLE
Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,10 +17,10 @@ updates:
     directory: "/src/collectors"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/src/core"
-    schedule:
-      interval: "weekly"
+#  - package-ecosystem: "pip"
+#    directory: "/src/core"
+#    schedule:
+#      interval: "weekly"
   - package-ecosystem: "pip" 
     directory: "/src/presenters"
     schedule:


### PR DESCRIPTION
Use GitHub Dependabot - added Docker, pip (core excluded for now) and npm