### PR TITLE
ignore slackclient

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
     directory: "/src/collectors"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "slackclient"
 #  - package-ecosystem: "pip"
 #    directory: "/src/core"
 #    schedule:


### PR DESCRIPTION
slackclient Python package to be ignored by dependabot