### PR TITLE
Fix non working ACL for Product Types

### DIFF
--- a/src/core/api/user.py
+++ b/src/core/api/user.py
@@ -32,7 +32,7 @@ class UserProductTypes(Resource):
 
     @auth_required('PUBLISH_ACCESS')
     def get(self):
-        return product_type.ProductType.get_all_json(None, auth_manager.get_user_from_jwt(), False)
+        return product_type.ProductType.get_all_json(None, auth_manager.get_user_from_jwt(), True)
 
 
 class UserPublisherPresets(Resource):


### PR DESCRIPTION
When you set ACL for Product Types in selection combo you get all types. This is wrong behavior. Now you can see only your an "public" types.