### PR TITLE
Fix: Display the description in the OSINT source groups grid

### DIFF
--- a/src/gui/src/components/config/osint_sources/CardGroup.vue
+++ b/src/gui/src/components/config/osint_sources/CardGroup.vue
@@ -71,7 +71,7 @@
                 if (this.card.default) {
                     return this.$t('osint_source_group.default_group_description')
                 } else {
-                    return this.card.desc
+                    return this.card.description
                 }
             },
             cardStatus() {


### PR DESCRIPTION
Fixed display of the description in the OSINT source groups grid (it was empty)