### PR TITLE
Update linting.yaml with Python 3.12

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.10']
+        python-version: ['3.8', '3.10', '3.12']
     steps:
       - uses: actions/checkout@v2
       - name: lint with black


### PR DESCRIPTION
Add Python 3.12 because it is used in up-to-date containers.