### PR TITLE
Correct date formats

### DIFF
--- a/src/collectors/collectors/web_collector.py
+++ b/src/collectors/collectors/web_collector.py
@@ -687,6 +687,7 @@ class WebCollector(BaseCollector):
         if not published_str:
             published_str = 'today'
         published = dateparser.parse(published_str, settings={'DATE_ORDER': 'DMY'})
+        published_str = published.strftime("%Y-%m-%d %H:%M")  # remove microseconds/seconds from the screen, looks ugly
 
         link = current_url
 
@@ -698,7 +699,7 @@ class WebCollector(BaseCollector):
                         hashlib.sha256(for_hash.encode()).hexdigest(),
                         title, article_description,
                         self.web_url, link,
-                        published,
+                        published_str,
                         author,
                         datetime.datetime.now(),
                         article_full_text,

--- a/src/shared/shared/schema/osint_source.py
+++ b/src/shared/shared/schema/osint_source.py
@@ -47,8 +47,8 @@ class OSINTSourceUpdateStatusSchema(Schema):
     class Meta:
         unknown = EXCLUDE
 
-    last_collected = fields.DateTime("%d.%m.%Y - %H:%M:%s")
-    last_attempted = fields.DateTime("%d.%m.%Y - %H:%M:%s")
+    last_collected = fields.DateTime("%d.%m.%Y - %H:%M:%S")
+    last_attempted = fields.DateTime("%d.%m.%Y - %H:%M:%S")
     last_error_message = fields.Str()
     last_data = fields.Raw()
 

--- a/src/shared/shared/schema/remote.py
+++ b/src/shared/shared/schema/remote.py
@@ -16,7 +16,7 @@ class RemoteAccessSchema(Schema):
 
 
 class RemoteAccessPresentationSchema(RemoteAccessSchema, PresentationSchema):
-    last_synced = fields.DateTime("%d.%m.%Y - %H:%M:%s")
+    last_synced = fields.DateTime("%d.%m.%Y - %H:%M:%S")
 
 
 class RemoteNodeSchema(Schema):
@@ -33,5 +33,5 @@ class RemoteNodeSchema(Schema):
 
 
 class RemoteNodePresentationSchema(RemoteNodeSchema, PresentationSchema):
-    last_synced = fields.DateTime("%d.%m.%Y - %H:%M:%s")
+    last_synced = fields.DateTime("%d.%m.%Y - %H:%M:%S")
     event_id = fields.Str()


### PR DESCRIPTION
- corrected wrong formatting: %H:%M:%s -> %H:%M:%S (%s doesn't return seconds)
- for WEB collector show nice published date for news items (no need microseconds, looks ugly)