### PR TITLE
Fix: Manually creating news item can produce error

### DIFF
--- a/src/gui/src/views/users/EnterView.vue
+++ b/src/gui/src/views/users/EnterView.vue
@@ -97,7 +97,7 @@
                     toolbar: toolbarOptions
                 }
             },
-
+            editorData: "",
             news_item: {
                 id: "",
                 title: "",


### PR DESCRIPTION
Creating news item manually with empty "Content" field can cause: **_500: Internal Server Error_** and some generic user message. User doesn't know what is wrong. Normally is possible store empty Content but user must do some interaction first (write and delete text)