### PR TITLE
Fix sorting report atrributes to respect user order

### DIFF
--- a/src/core/model/report_item.py
+++ b/src/core/model/report_item.py
@@ -28,7 +28,7 @@ from marshmallow import fields, post_load
 
 from managers.db_manager import db
 from model.news_item import NewsItemAggregate
-from model.report_item_type import AttributeGroup, AttributeGroupItem
+from model.report_item_type import AttributeGroupItem
 from model.report_item_type import ReportItemType
 from model.acl_entry import ACLEntry
 from shared.schema.acl_entry import ItemType


### PR DESCRIPTION
Fix sorting report attributes to respect user order.  This is caused …by change: Opitimalization: tables relationship (join) #334