### PR TITLE
Fix: OSINT sources open first OSINT group screen

### DIFF
--- a/src/gui/src/components/config/osint_sources/CardGroup.vue
+++ b/src/gui/src/components/config/osint_sources/CardGroup.vue
@@ -84,7 +84,7 @@
         },
         methods: {
             itemClicked(data) {
-                this.$root.$emit('show-edit', data)
+                this.$root.$emit('show-edit-src-grp', data)
             },
             deleteClicked(data) {
                 this.$root.$emit('delete-item', data)

--- a/src/gui/src/components/config/osint_sources/NewOSINTSourceGroup.vue
+++ b/src/gui/src/components/config/osint_sources/NewOSINTSourceGroup.vue
@@ -221,7 +221,7 @@ export default {
                 this.osint_sources = this.$store.getters.getOSINTSources.items
             });
 
-        this.$root.$on('show-edit', (data) => {
+        this.$root.$on('show-edit-src-grp', (data) => {
             this.visible = true;
             this.edit = true;
             this.show_error = false;
@@ -235,7 +235,7 @@ export default {
         });
     },
     beforeDestroy() {
-        this.$root.$off('show-edit')
+        this.$root.$off('show-edit-src-grp')
     }
 }
 </script>


### PR DESCRIPTION
when you open OSINT sources multiple times you get first Osint groups screen which you must first close to continue work