### PR TITLE
Use text format in Content for manually entered news items

### DIFF
--- a/src/gui/src/i18n/cs/messages.js
+++ b/src/gui/src/i18n/cs/messages.js
@@ -107,6 +107,7 @@ const messages_cs = {
         review: "Souhrn",
         source: "Zdroj",
         link: "Odkaz",
+        content: "Obsah",
         successful: "Novinka byla vytvořena",
     },
 

--- a/src/gui/src/i18n/en/messages.js
+++ b/src/gui/src/i18n/en/messages.js
@@ -107,6 +107,7 @@ const messages_en = {
         review: "Review",
         source: "Source",
         link: "Link",
+        content: "Content",
         successful: "News item was successfully created"
     },
 

--- a/src/gui/src/i18n/sk/messages.js
+++ b/src/gui/src/i18n/sk/messages.js
@@ -37,28 +37,68 @@ const messages_sk = {
 
     user_menu: {
         settings: "Nastavenia profilu",
-        logout: "Odhlásiť sa"
+        logout: "Odhlásiť sa",
+        dark_theme: "Tmavý motiv",
     },
 
     main_menu: {
-        assess: "Zistiť",
+        enter: "Vložiť",
+        assess: "Vyhodnotiť",
         analyze: "Analyzovať",
         publish: "Publikovať",
         config: "Konfigurácia",
-        dashboard: "Dashboard"
+        dashboard: "Dashboard",
+        my_assets: "Aktíva"
     },
 
     nav_menu: {
-        newsitems: "Nové zistenia",
+        enter: "Vytvoriť novinku",
+        newsitems: "Novinky",
         products: "Produkty",
         publications: "Publikácie",
         recent: "Najnovšie",
         popular: "Populárne",
         favourites: "Obľúbené",
         configuration: "Konfigurácia",
-        collectors_nodes: "Server zberačov údajov",
+        collectors_nodes: "Inštancie zberačov",
+        presenters_nodes: "Inštancie prezenterov",
+        publishers_nodes: "Inštancie publikateľov",
+        bots_nodes: "Inštancie robotov",
         osint_sources: "OSINT zdroje",
+        osint_source_groups: "OSINT skupiny",
+        publisher_presets: "Publikačné kanály",
+        bot_presets: "Roboti",
         collectors: "Zberače údajov",
+        report_items: "Analýzy",
+        attributes: "Atribúty",
+        report_types: "Typy analýz",
+        product_types: "Typy produktov",
+        roles: "Role",
+        acls: "ACL",
+        users: "Užívatelia",
+        organizations: "Organizácie",
+        word_lists: "Slovníky",
+        asset_groups: "Skupiny aktív",
+        notification_templates: "Šablóny oznámení",
+        remote_access: "Vzdialený prístup",
+        remote_nodes: "Vzdialené inštancie",
+        local: "Lokálne"
+    },
+
+    notification: {
+        close: "Zavrieť"
+    },
+
+    enter: {
+        create: "Vytvoriť",
+        validation_error: "Prosím vyplňte všetky povinné polia",
+        error: "Novinku sa nepodarilo vytvoriť",
+        title: "Názov",
+        review: "Súhrn",
+        source: "Zdroj",
+        link: "Odkaz",
+        content: "Obsah",
+        successful: "Novinka bola úspešne vytvorená",
     },
 
     collectors_node: {
@@ -81,7 +121,7 @@ const messages_sk = {
         add: "Pridať",
         cancel: "Zrušiť",
         validation_error: "Prosím vyplňte všetky povinné polia",
-        error: "Nepodarilo sa vytvoriť zadaný zdroj.",
+        error: "Nepodarilo sa vytvoriť zadaný zdroj",
         name: "Meno",
         description: "Popis",
         last_attempt: "Posledný pokus",

--- a/src/gui/src/views/users/EnterView.vue
+++ b/src/gui/src/views/users/EnterView.vue
@@ -14,41 +14,36 @@
             <v-form @submit.prevent="add" id="form" ref="form" style="width: 100%; padding: 8px">
                 <v-card>
                     <v-card-text>
-                        <v-text-field
-                                :label="$t('enter.title')"
-                                name="title"
-                                type="text"
-                                v-model="news_item.title"
-                                v-validate="'required'"
-                                data-vv-name="title"
-                                :error-messages="errors.collect('title')"
+                        <v-text-field :label="$t('enter.title')"
+                                      name="title"
+                                      type="text"
+                                      v-model="news_item.title"
+                                      v-validate="'required'"
+                                      data-vv-name="title"
+                                      :error-messages="errors.collect('title')"
                         ></v-text-field>
 
-                        <v-textarea
-                                :label="$t('enter.review')"
-                                name="review"
-                                v-model="news_item.review"
+                        <v-textarea :label="$t('enter.review')"
+                                    name="review"
+                                    v-model="news_item.review"
                         ></v-textarea>
 
-                        <v-text-field
-                                :label="$t('enter.source')"
-                                name="source"
-                                type="text"
-                                v-model="news_item.source"
+                        <v-text-field :label="$t('enter.source')"
+                                      name="source"
+                                      type="text"
+                                      v-model="news_item.source"
                         ></v-text-field>
 
-                        <v-text-field
-                                :label="$t('enter.link')"
-                                name="link"
-                                type="text"
-                                v-model="news_item.link"
+                        <v-text-field :label="$t('enter.link')"
+                                      name="link"
+                                      type="text"
+                                      v-model="news_item.link"
                         ></v-text-field>
 
-                        <vue-editor
-                                ref="assessEnter"
-                                v-model="editorData"
-                                :editorOptions="editorOptionVue2"
-                        ></vue-editor>
+                        <v-textarea :label="$t('enter.content')"
+                                    name="content"
+                                    v-model="news_item.content"
+                        ></v-textarea>
 
                     </v-card-text>
                 </v-card>
@@ -67,37 +62,17 @@
 
 <script>
     import ViewLayout from "../../components/layouts/ViewLayout";
-    import { VueEditor } from 'vue2-editor';
     import {addNewsItem} from "@/api/assess";
-
-    const toolbarOptions = [
-        ['bold', 'italic', 'underline', 'strike', { 'script': 'sub' }, { 'script': 'super' },
-            'blockquote', 'code-block', 'clean'],
-        [{ align: "" }, { align: "center" }, { align: "right" }, { align: "justify" }],
-        [{ 'list': 'ordered' }, { 'list': 'bullet' }, { 'indent': '-1' }, { 'indent': '+1' }],
-        [{ 'size': ['small', false, 'large', 'huge'] }, { 'header': [1, 2, 3, 4, 5, 6, false] },
-            { 'color': [] }, { 'background': [] }],
-        ['link', 'image'],
-    ];
 
     export default {
         name: "Enter",
         components: {
             ViewLayout,
-            VueEditor,
         },
         data: () => ({
 
             show_error: false,
             show_validation_error: false,
-
-            editorOptionVue2: {
-                theme: 'snow',
-                modules: {
-                    toolbar: toolbarOptions
-                }
-            },
-            editorData: "",
             news_item: {
                 id: "",
                 title: "",
@@ -120,8 +95,6 @@
                 this.$validator.validateAll().then(() => {
 
                     if (!this.$validator.errors.any()) {
-
-                        this.news_item.content = this.editorData;
 
                         let i = window.location.pathname.indexOf("/source/");
                         let len = window.location.pathname.length;
@@ -152,8 +125,6 @@
                             this.news_item.attributes = []
 
                             this.$validator.reset();
-
-                            this.editorData = '<p></p>';
 
                             this.$root.$emit('notification',
                                 {


### PR DESCRIPTION
Create manually news item content with text format. Use same format for content as other collected news items from various source types. Before html now pure text. 
Problem was that content viewer show also html tags from text, These html tags were also indexed.
Update Slovak language