### PR TITLE
Fix error: Property or method "editorData" is not defined

### DIFF
--- a/src/gui/src/components/assess/NewsItemAggregateDetail.vue
+++ b/src/gui/src/components/assess/NewsItemAggregateDetail.vue
@@ -133,6 +133,7 @@
         },
         data: () => ({
             content: null,
+            editorData: '<p></p>',
             editorOptionVue2: {
                 theme: 'snow',
                 placeholder: "insert text here ...",

--- a/src/gui/src/components/assess/NewsItemSingleDetail.vue
+++ b/src/gui/src/components/assess/NewsItemSingleDetail.vue
@@ -178,6 +178,7 @@
         },
         data: () => ({
             content: null,
+            editorData: '<p></p>',
             editorOptionVue2: {
                 theme: 'snow',
                 placeholder: "insert text here ...",

--- a/src/gui/src/components/config/assets/NewNotificationTemplate.vue
+++ b/src/gui/src/components/config/assets/NewNotificationTemplate.vue
@@ -111,6 +111,7 @@
         data: () => ({
             visible: false,
             edit: false,
+            editorData: '<p></p>',
             editorOptionVue2: {
                 theme: 'snow',
                 modules: {


### PR DESCRIPTION
Fix error: Property or method "editorData" is not defined on the instance but referenced during render. Make sure that this property is reactive, either in the data option, or for class-based components, by initializing the property.