### PR TITLE
Remove old Python 3.8 references

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.10', '3.12']
+        python-version: ['3.10', '3.12']
     steps:
       - uses: actions/checkout@v2
       - name: lint with black

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,6 +1,6 @@
 # **TaranisNG backend setup**
 1. Install **Postgresql** database and create database e.g. taranisdb
-2. Install **Python 3.7** or later
+2. Install **Python 3.10** or later
 3. In taranis-ng-common, taranis-ng-collectors and taranis-ng-core install and activate python virtual environment:
     `virtualenv -p python3.7 venv`
     `source venv/bin/activate`

--- a/src/shared/setup.cfg
+++ b/src/shared/setup.cfg
@@ -11,17 +11,15 @@ url = https://github.com/SK-CERT/Taranis-NG
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.12
     Topic :: Security
 
 [options]
 packages = find:
 include_package_data = True
 zip_safe = False
-python_requires = >=3.7
+python_requires = >=3.10
 install_requires =
     marshmallow
     marshmallow-enum


### PR DESCRIPTION
Git doesn't run the 3.8 linting (tests are faster)