### PR TITLE
Upgrade GitHub action: checkout@v2 -> v4 on lint

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: ['3.10', '3.12']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: lint with black
         uses: rickstaa/action-black@v1
         with:


### PR DESCRIPTION
Fix warnings on GitHub **lint with black** action:
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: `https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/`