### PR TITLE
Upgrade GitHub actions warnings

### DIFF
--- a/.github/workflows/docker_build_bots.yaml
+++ b/.github/workflows/docker_build_bots.yaml
@@ -1,4 +1,4 @@
-name: Bots Docker image
+name: Docker image - Bots
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "GHCR_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
       - name: Build and push bots
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           file: docker/Dockerfile.bots
           push: true

--- a/.github/workflows/docker_build_collectors.yaml
+++ b/.github/workflows/docker_build_collectors.yaml
@@ -1,4 +1,4 @@
-name: Collectors Docker image
+name: Docker image - Collectors
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "GHCR_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
       - name: Build and push collectors
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           file: docker/Dockerfile.collectors
           push: true

--- a/.github/workflows/docker_build_core.yaml
+++ b/.github/workflows/docker_build_core.yaml
@@ -1,4 +1,4 @@
-name: Core Docker image
+name: Docker image - Core
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "GHCR_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
       - name: Build and push core
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           file: docker/Dockerfile.core
           push: true

--- a/.github/workflows/docker_build_gui.yaml
+++ b/.github/workflows/docker_build_gui.yaml
@@ -1,4 +1,4 @@
-name: GUI Docker image
+name: Docker image - GUI
 
 on:
   push:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -27,7 +27,7 @@ jobs:
         run: |
           echo "GHCR_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
       - name: Build and push gui
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           file: docker/Dockerfile.gui
           push: true

--- a/.github/workflows/docker_build_presenters.yaml
+++ b/.github/workflows/docker_build_presenters.yaml
@@ -1,4 +1,4 @@
-name: Presenters Docker image
+name: Docker image - Presenters
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "GHCR_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
       - name: Build and push presenters
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           file: docker/Dockerfile.presenters
           push: true

--- a/.github/workflows/docker_build_publishers.yaml
+++ b/.github/workflows/docker_build_publishers.yaml
@@ -1,4 +1,4 @@
-name: Publishers Docker image
+name: Docker image - Publishers
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "GHCR_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
       - name: Build and push publishers
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           file: docker/Dockerfile.publishers
           push: true

--- a/.github/workflows/docker_build_shared.yaml
+++ b/.github/workflows/docker_build_shared.yaml
@@ -16,8 +16,8 @@ jobs:
     name: build wheel
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: build
@@ -26,7 +26,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel build
           python -m build
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |


### PR DESCRIPTION
docker/login-action@v2 -> v3
docker/build-push-action@v3 -> v6
actions/checkout@v3 ->v4
actions/setup-python@v4 -> v5
softprops/action-gh-release@v1 -> v2

Warning: The following actions use a deprecated Node.js version and will be forced to run on node20: docker/login-action@v2, docker/build-push-action@v3.