### PR TITLE
Fixed: first key is acting as shorcut in empty editor

### DIFF
--- a/src/gui/src/assets/keyboard_mixin.js
+++ b/src/gui/src/assets/keyboard_mixin.js
@@ -150,13 +150,14 @@ const keyboardMixin = targetId => ({
                     break;
                 }
             }
-            // window.console.debug("keyAlias:", keyAlias, "activeElement:", document.activeElement);
+            // window.console.debug("keyAlias:", keyAlias, ", type:", document.activeElement.type, ", class:", document.activeElement.className, ", activeElement:", document.activeElement);
             if ((document.activeElement == search_field ||
-                 document.activeElement.className == "ql-editor" ||
+                 document.activeElement.className.includes("ql-editor") ||
                  document.activeElement.type == "text" ||
                  document.activeElement.type == "textarea") && (keyAlias !== 'close_item' || press.keyCode !== 27)) {
                 // when search field, editor, text or textarea is active, ignore all keypresses except Escape
                 // example problem: Assess, create report from item and you type N in description field -> all is canceled and it creates new report again
+                // maybe we should check some specific shortcuts on "v-card" class? It's easier, less conditions
                 return;
             }
 

--- a/src/gui/src/components/assess/NewsItemSingleDetail.vue
+++ b/src/gui/src/components/assess/NewsItemSingleDetail.vue
@@ -48,7 +48,7 @@
                         <v-tab href="#tab-2">
                             <span>{{ $t('assess.attributes') }}</span>
                         </v-tab>
-                        <v-tab href="#tab-3">
+                        <v-tab href="#tab-3" @click="onTabClick(3)">
                             <span>{{ $t('assess.comments') }}</span>
                         </v-tab>
 
@@ -305,6 +305,15 @@
             handleDeletion() {
                 this.showDeletePopup = false;
                 this.cardItemToolbar('delete')
+            },
+            onTabClick(tabNumber) {
+                if (tabNumber === 3) {   // Set the editor's focus so the user can start typing immediately
+                    this.$nextTick(() => {
+                        setTimeout(() => {
+                            this.$refs.assessDetailComments.quill.focus();
+                        }, 100);
+                    });
+                }
             }
         }
     }


### PR DESCRIPTION
Fixed: first key is acting as shorcut in empty editor component (e.g Assess Detail Comments)
Added: set focus directly to to Assess Detail Comments after switching to Comments tab