### PR TITLE
Remove marshmallow-enum

### DIFF
--- a/src/bots/requirements.txt
+++ b/src/bots/requirements.txt
@@ -4,7 +4,6 @@ Flask-RESTful==0.3.10
 gevent==24.10.3
 gunicorn==23.0.0
 marshmallow==3.23.0
-marshmallow-enum==1.5.1
 oauthlib==3.2.2
 PySocks==1.7.1
 python-dotenv==1.0.1

--- a/src/collectors/requirements.txt
+++ b/src/collectors/requirements.txt
@@ -8,7 +8,6 @@ Flask-RESTful==0.3.10
 gevent==24.10.3
 gunicorn==23.0.0
 marshmallow==3.23.0
-marshmallow-enum==1.5.1
 PySocks==1.7.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1

--- a/src/core/requirements.txt
+++ b/src/core/requirements.txt
@@ -16,8 +16,7 @@ Jinja2==2.11.3
 ldap3==2.9.1
 Mako==1.1.0
 MarkupSafe==1.1.1
-marshmallow==3.18.0
-marshmallow-enum==1.5.1
+marshmallow==3.23.0
 psycogreen==1.0.2
 psycopg2-binary==2.9.6
 PyJWT==1.7.1

--- a/src/presenters/requirements.txt
+++ b/src/presenters/requirements.txt
@@ -5,6 +5,5 @@ gevent==24.10.3
 gunicorn==23.0.0
 Jinja2==3.1.4
 marshmallow==3.23.0
-marshmallow-enum==1.5.1
 python-dotenv==1.0.1
 weasyprint==62.3

--- a/src/publishers/requirements.txt
+++ b/src/publishers/requirements.txt
@@ -5,7 +5,6 @@ Flask-RESTful==0.3.10
 gevent==24.10.3
 gunicorn==23.0.0
 marshmallow==3.23.0
-marshmallow-enum==1.5.1
 oauth2client==4.1.3
 paramiko==3.5.0
 python-dotenv==1.0.1

--- a/src/shared/setup.cfg
+++ b/src/shared/setup.cfg
@@ -22,4 +22,3 @@ zip_safe = False
 python_requires = >=3.10
 install_requires =
     marshmallow
-    marshmallow-enum

--- a/src/shared/shared/schema/acl_entry.py
+++ b/src/shared/shared/schema/acl_entry.py
@@ -1,6 +1,7 @@
+"""Module for ACL entry schema."""
+
 from marshmallow import Schema, fields, EXCLUDE
 from enum import Enum, auto
-from marshmallow_enum import EnumField
 
 from shared.schema.presentation import PresentationSchema
 from shared.schema.role import RoleSchema
@@ -8,6 +9,19 @@ from shared.schema.user import UserSchemaBase
 
 
 class ItemType(Enum):
+    """An enumeration class that represents different types of items.
+
+    Attributes:
+        COLLECTOR (auto): Represents a collector item type.
+        OSINT_SOURCE (auto): Represents an OSINT source item type.
+        OSINT_SOURCE_GROUP (auto): Represents a group of OSINT sources.
+        WORD_LIST (auto): Represents a word list item type.
+        REPORT_ITEM (auto): Represents a report item type.
+        REPORT_ITEM_TYPE (auto): Represents a type of report item.
+        PRODUCT_TYPE (auto): Represents a product type item.
+        DELEGATION (auto): Represents a delegation item type.
+    """
+
     COLLECTOR = auto()
     OSINT_SOURCE = auto()
     OSINT_SOURCE_GROUP = auto()
@@ -19,25 +33,62 @@ class ItemType(Enum):
 
 
 class ACLEntryStatusSchema(Schema):
+    """Defines the schema for an ACL (Access Control List) entry status.
+
+    Attributes:
+        see (fields.Bool): Indicates if the entry has permission to see the resource.
+        access (fields.Bool): Indicates if the entry has permission to access the resource.
+        modify (fields.Bool): Indicates if the entry has permission to modify the resource.
+    """
+
     see = fields.Bool()
     access = fields.Bool()
     modify = fields.Bool()
 
 
 class ACLEntrySchema(ACLEntryStatusSchema):
+    """A schema class that inherits from ACLEntryStatusSchema.
+
+    Attributes:
+        Meta (class): A nested class that contains metadata for the schema.
+            unknown (str): Specifies the behavior for unknown fields. Set to EXCLUDE.
+        id (fields.Integer): An integer field representing the ID of the ACL entry.
+        name (fields.Str): A string field representing the name of the ACL entry.
+        description (fields.Str): A string field representing the description of the ACL entry.
+        item_type (fields.Enum): An enum field representing the type of the item.
+        item_id (fields.Str): A string field representing the ID of the item.
+        everyone (fields.Bool): A boolean field indicating if the ACL entry applies to everyone.
+    """
+
     class Meta:
+        """Meta class for configuring schema behavior.
+
+        Attributes:
+            unknown (marshmallow.fields.Field): Specifies the behavior for unknown fields in the input data.
+                Set to `EXCLUDE` to ignore unknown fields.
+        """
+
         unknown = EXCLUDE
 
     id = fields.Integer()
     name = fields.Str()
     description = fields.Str()
 
-    item_type = EnumField(ItemType)
+    item_type = fields.Enum(ItemType)
     item_id = fields.Str()
 
     everyone = fields.Bool()
 
 
 class ACLEntryPresentationSchema(ACLEntrySchema, PresentationSchema):
+    """A schema that combines the ACLEntrySchema and PresentationSchema.
+
+    It includes nested fields for roles and users.
+
+    Attributes:
+        roles (list): A list of roles associated with the ACL entry, represented by RoleSchema.
+        users (list): A list of users associated with the ACL entry, represented by UserSchemaBase.
+    """
+
     roles = fields.Nested(RoleSchema, many=True)
     users = fields.Nested(UserSchemaBase, many=True)

--- a/src/shared/shared/schema/attribute.py
+++ b/src/shared/shared/schema/attribute.py
@@ -4,7 +4,6 @@ This module contains classes and schemas related to attributes, including enums,
 """
 
 from marshmallow import Schema, fields, post_load, EXCLUDE
-from marshmallow_enum import EnumField
 from enum import Enum, auto
 
 from shared.schema.presentation import PresentationSchema
@@ -43,8 +42,7 @@ class AttributeValidator(Enum):
 
 
 class AttributeEnumSchema(Schema):
-    """
-    Schema class for attribute enums.
+    """Schema class for attribute enums.
 
     This schema defines the structure for attribute enums.
     It includes fields for id, index, value, and description.
@@ -70,8 +68,7 @@ class AttributeEnum:
     """Class representing an attribute enum."""
 
     def __init__(self, id, index, value, description):
-        """
-        Initialize an Attribute object.
+        """Initialize an Attribute object.
 
         Args:
             index (int): The index of the attribute.
@@ -95,9 +92,9 @@ class AttributeBaseSchema(Schema):
     id = fields.Int()
     name = fields.Str()
     description = fields.Str(allow_none=True)
-    type = EnumField(AttributeType)
+    type = fields.Enum(AttributeType)
     default_value = fields.Str(allow_none=True)
-    validator = EnumField(AttributeValidator, allow_none=True)
+    validator = fields.Enum(AttributeValidator, allow_none=True)
     validator_parameter = fields.Str(allow_none=True)
 
     @post_load
@@ -122,8 +119,7 @@ class Attribute:
     """Class representing an attribute."""
 
     def __init__(self, id, name, description, type, default_value, validator, validator_parameter, attribute_enums):
-        """
-        Initialize an Attribute object.
+        """Initialize an Attribute object.
 
         Args:
             id (int): The ID of the attribute.
@@ -134,9 +130,6 @@ class Attribute:
             validator: The validator function for the attribute.
             validator_parameter: The parameter for the validator function.
             attribute_enums: Attribute enum values.
-
-        Returns:
-            None
         """
         self.id = id
         self.name = name

--- a/src/shared/shared/schema/parameter.py
+++ b/src/shared/shared/schema/parameter.py
@@ -1,9 +1,19 @@
+"""This module defines classes and schemas for handling parameters and their serialization/deserialization."""
+
 from enum import Enum, auto
 from marshmallow import Schema, fields, post_load
-from marshmallow_enum import EnumField
 
 
 class ParameterType(Enum):
+    """Enum class representing different types of parameters.
+
+    Attributes:
+        STRING (auto): Represents a string parameter type.
+        NUMBER (auto): Represents a numeric parameter type.
+        BOOLEAN (auto): Represents a boolean parameter type.
+        LIST (auto): Represents a list parameter type.
+    """
+
     STRING = auto()
     NUMBER = auto()
     BOOLEAN = auto()
@@ -11,19 +21,56 @@ class ParameterType(Enum):
 
 
 class ParameterSchema(Schema):
+    """ParameterSchema is a Marshmallow schema for serializing and deserializing Parameter objects.
+
+    Attributes:
+        id (fields.Int): The unique identifier of the parameter.
+        key (fields.Str): The key associated with the parameter.
+        name (fields.Str): The name of the parameter.
+        description (fields.Str): A brief description of the parameter.
+        type (fields.Enum): The type of the parameter, which is an enumeration of ParameterType.
+    Methods:
+        make_parameter(data, **kwargs):
+            Creates a Parameter instance from the deserialized data.
+    """
+
     id = fields.Int()
     key = fields.Str()
     name = fields.Str()
     description = fields.Str()
-    type = EnumField(ParameterType)
+    type = fields.Enum(ParameterType)
 
     @post_load
     def make_parameter(self, data, **kwargs):
+        """Create a Parameter instance from the provided data.
+
+        Args:
+            data (dict): A dictionary containing the data to initialize the Parameter instance.
+            **kwargs: Additional keyword arguments.
+        Returns:
+            Parameter: An instance of the Parameter class initialized with the provided data.
+        """
         return Parameter(**data)
 
 
 class Parameter:
+    """A class used to represent a Parameter.
+
+    Methods:
+        __init__(self, id, key, name, description, type):
+            Initializes a new Parameter instance.
+    """
+
     def __init__(self, id, key, name, description, type):
+        """Initialize a new Parameter instance.
+
+        Args:
+            id (int): The unique identifier for the parameter.
+            key (str): The key associated with the parameter.
+            name (str): The name of the parameter.
+            description (str): A brief description of the parameter.
+            type (str): The type of the parameter.
+        """
         self.id = id
         self.key = key
         self.name = name
@@ -32,13 +79,43 @@ class Parameter:
 
 
 class ParameterExportSchema(Schema):
+    """Schema for exporting parameters.
+
+    Attributes:
+        key (str): The key of the parameter.
+    Methods:
+        make(data, **kwargs):
+            Creates a ParameterExport instance from the loaded data.
+    """
+
     key = fields.Str()
 
     @post_load
     def make(self, data, **kwargs):
+        """Create a ParameterExport instance from the provided data.
+
+        Args:
+            data (dict): A dictionary containing the data to initialize the ParameterExport instance.
+            **kwargs: Additional keyword arguments.
+        Returns:
+            ParameterExport: An instance of ParameterExport initialized with the provided data.
+        """
         return ParameterExport(**data)
 
 
 class ParameterExport:
+    """A class used to represent a Parameter Export.
+
+    Args:
+        key (str): The key associated with the parameter export.
+    Methods:
+        __init__(self, key): Initializes the ParameterExport with the given key.
+    """
+
     def __init__(self, key):
+        """Initialize a Parameter instance with a given key.
+
+        Args:
+            key (str): The key associated with the parameter.
+        """
         self.key = key


### PR DESCRIPTION
Remove unnecessary and deprecated library marshmallow-enum. Enum is part of marshmellow since version 3.18.0