### PR TITLE
Update requirements.txt in core

### DIFF
--- a/src/core/requirements.txt
+++ b/src/core/requirements.txt
@@ -8,7 +8,7 @@ flask-oidc==1.4.0
 Flask-RESTful==0.3.10
 Flask-Script==2.0.6
 Flask-SQLAlchemy==2.5.1
-gevent==21.8.0
+gevent==21.12.0
 greenlet==1.1.1
 gunicorn==20.0.4
 idna==2.9


### PR DESCRIPTION
Slightly newer version of gevent for core. It will not build anymore because of the old gevent version and produces this issue:
```
8.150 Collecting gevent==21.8.0 (from -r /app/requirements.txt (line 11))
8.167   Downloading gevent-21.8.0.tar.gz (6.2 MB)
8.294      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.2/6.2 MB 49.5 MB/s eta 0:00:00
9.123   Installing build dependencies: started
13.45   Installing build dependencies: finished with status 'done'
13.45   Getting requirements to build wheel: started
15.50   Getting requirements to build wheel: finished with status 'error'
15.51   error: subprocess-exited-with-error
15.51   
15.51   × Getting requirements to build wheel did not run successfully.
15.51   │ exit code: 1
15.51   ╰─> [45 lines of output]
15.51       Compiling src/gevent/resolver/cares.pyx because it changed.
15.51       [1/1] Cythonizing src/gevent/resolver/cares.pyx
15.51       performance hint: src/gevent/libev/corecext.pyx:1325:0: Exception check on '_syserr_cb' will always require the GIL to be acquired.
15.51       Possible solutions:
15.51           1. Declare '_syserr_cb' as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
15.51           2. Use an 'int' return type on '_syserr_cb' to allow an error code to be returned.
15.51       
15.51       Error compiling Cython file:
15.51       ------------------------------------------------------------
15.51       ...
15.51       cdef tuple integer_types
15.51       
15.51       if sys.version_info[0] >= 3:
15.51           integer_types = int,
15.51       else:
15.51           integer_types = (int, long)
15.51                                 ^
15.51       ------------------------------------------------------------
15.51       
15.51       src/gevent/libev/corecext.pyx:60:26: undeclared name not builtin: long
15.51       Compiling src/gevent/libev/corecext.pyx because it changed.
15.51       [1/1] Cythonizing src/gevent/libev/corecext.pyx
15.51       Traceback (most recent call last):
15.51         File "/usr/local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
15.51           main()
15.51         File "/usr/local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
15.51           json_out['return_val'] = hook(**hook_input['kwargs'])
15.51         File "/usr/local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
15.51           return hook(config_settings)
15.51         File "/tmp/pip-build-env-woljd0is/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 334, in get_requires_for_build_wheel
15.51           return self._get_build_requires(config_settings, requirements=[])
15.51         File "/tmp/pip-build-env-woljd0is/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 304, in _get_build_requires
15.51           self.run_setup()
15.51         File "/tmp/pip-build-env-woljd0is/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 522, in run_setup
15.51           super().run_setup(setup_script=setup_script)
15.51         File "/tmp/pip-build-env-woljd0is/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 320, in run_setup
15.51           exec(code, locals())
15.51         File "<string>", line 50, in <module>
15.51         File "/tmp/pip-install-otmpn7cb/gevent_557eecbe888a46e4959ec3fa81f1d4f9/_setuputils.py", line 237, in cythonize1
15.51           new_ext = cythonize(
15.51         File "/tmp/pip-build-env-woljd0is/overlay/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1109, in cythonize
15.51           cythonize_one(*args)
15.51         File "/tmp/pip-build-env-woljd0is/overlay/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1256, in cythonize_one
15.51           raise CompileError(None, pyx_file)
15.51       Cython.Compiler.Errors.CompileError: src/gevent/libev/corecext.pyx
15.51       [end of output]
15.51   
15.51   note: This error originates from a subprocess, and is likely not a problem with pip.
15.51 error: subprocess-exited-with-error
15.51 
15.51 × Getting requirements to build wheel did not run successfully.
15.51 │ exit code: 1
15.51 ╰─> See above for output.
15.51 
15.51 note: This error originates from a subprocess, and is likely not a problem with pip.
15.61 
15.61 [notice] A new release of pip is available: 24.1.2 -> 24.3.1
15.61 [notice] To update, run: pip install --upgrade pip
------
failed to solve: process "/bin/sh -c apk add --no-cache --virtual .build-deps     gcc     g++     build-base    libc-dev    zlib-dev     linux-headers     make     glib-dev     musl-dev     python3-dev     libffi-dev     postgresql-dev &&     pip install --no-cache-dir -r /app/requirements.txt &&     apk --purge del .build-deps" did not complete successfully: exit code: 1
```
