### PR TITLE
Fixed: Invalid JWT: Not enough segments on Logout

### DIFF
--- a/src/gui/src/App.vue
+++ b/src/gui/src/App.vue
@@ -38,7 +38,9 @@ export default {
                 .then(sse => {
                     this.sseConnection = sse
                     sse.onError(() => {
-                        this.reconnectSSE()
+                        if (this.$store.getters.getJWT != '') {
+                            this.reconnectSSE()
+                        }
                     });
                     sse.subscribe('news-items-updated', (data) => {
                         this.$root.$emit('news-items-updated', data)


### PR DESCRIPTION
The reconnectSSE function attempts to reconnect on error. Avoid attempting to reconnect to SSE with cleared credentials.