### PR TITLE
update containers to alpine 3.21

### DIFF
--- a/docker/Dockerfile.bots
+++ b/docker/Dockerfile.bots
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine3.19 AS build_shared
+FROM python:3.13-alpine3.21 AS build_shared
 
 WORKDIR /build_shared/
 
@@ -8,7 +8,7 @@ RUN python -m build
 
 
 
-FROM python:3.13-alpine3.19 AS production
+FROM python:3.13-alpine3.21 AS production
 
 WORKDIR /app/
 

--- a/docker/Dockerfile.collectors
+++ b/docker/Dockerfile.collectors
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine3.19 AS build_shared
+FROM python:3.13-alpine3.21 AS build_shared
 
 WORKDIR /build_shared/
 
@@ -8,7 +8,7 @@ RUN python -m build
 
 
 
-FROM python:3.13-alpine3.19 AS production
+FROM python:3.12-alpine3.21 AS production
 
 WORKDIR /app/
 

--- a/docker/Dockerfile.core
+++ b/docker/Dockerfile.core
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine3.20 AS build_shared
+FROM python:3.13-alpine3.21 AS build_shared
 
 WORKDIR /build_shared/
 
@@ -17,7 +17,7 @@ COPY ./src/core/sse/forward.c .
 RUN gcc -o forward forward.c
 
 
-FROM python:3.13-alpine3.20 AS production
+FROM python:3.13-alpine3.21 AS production
 
 WORKDIR /app/
 

--- a/docker/Dockerfile.presenters
+++ b/docker/Dockerfile.presenters
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine3.19 AS build_shared
+FROM python:3.13-alpine3.21 AS build_shared
 
 WORKDIR /build_shared/
 
@@ -8,7 +8,7 @@ RUN python -m build
 
 
 
-FROM python:3.13-alpine3.19 AS production
+FROM python:3.13-alpine3.21 AS production
 
 WORKDIR /app/
 

--- a/docker/Dockerfile.publishers
+++ b/docker/Dockerfile.publishers
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine3.19 AS build_shared
+FROM python:3.13-alpine3.21 AS build_shared
 
 WORKDIR /build_shared/
 
@@ -8,7 +8,7 @@ RUN python -m build
 
 
 
-FROM python:3.13-alpine3.19 AS production
+FROM python:3.12-alpine3.21 AS production
 
 WORKDIR /app/
 


### PR DESCRIPTION
collectors and publishers use Python 3.12 for now because of Tweepy dependency on imghdr