### PR TITLE
"Clear" user data (Core migration fix)

### DIFF
--- a/src/core/auth/base_authenticator.py
+++ b/src/core/auth/base_authenticator.py
@@ -89,10 +89,12 @@ class BaseAuthenticator:
             access_token = create_access_token(
                 identity=user.username,
                 additional_claims={
-                    "id": user.id,
-                    "name": user.name,
-                    "organization_name": user.get_current_organization_name(),
-                    "permissions": user.get_permissions(),
+                    "user_claims": {
+                        "id": user.id,
+                        "name": user.name,
+                        "organization_name": user.get_current_organization_name(),
+                        "permissions": user.get_permissions(),
+                    }
                 },
             )
 

--- a/src/core/managers/auth_manager.py
+++ b/src/core/managers/auth_manager.py
@@ -308,10 +308,13 @@ def get_perm_from_jwt_token(user):
 
     """
     try:
-        # does it include permissions?
         jwt_data = get_jwt()
-        if not jwt_data or "permissions" not in jwt_data:
-            log_manager.store_user_auth_error_activity(user, "Missing permissions in JWT")
+        if not jwt_data or "user_claims" not in jwt_data:
+            log_manager.store_user_auth_error_activity(user, "Missing user data in JWT")
+            return None
+        jwt_data = jwt_data["user_claims"]
+        if "permissions" not in jwt_data:
+            log_manager.store_user_auth_error_activity(user, "Missing user permissions in JWT")
             return None
 
         all_users_perms = set(jwt_data["permissions"])
@@ -363,7 +366,7 @@ def auth_required(required_permissions, *acl_args):
                 log_manager.store_user_auth_error_activity(user, f"Access denied by ACL for user: {user.username}")
                 return error
 
-            # allow  check here
+            # allow
             log_manager.store_user_activity(user, str(required_permissions_set), str(request.get_json(force=True, silent=True)))
             return fn(*args, **kwargs)
 

--- a/src/gui/src/store/auth/taranis_authenticator.js
+++ b/src/gui/src/store/auth/taranis_authenticator.js
@@ -55,7 +55,7 @@ const getters = {
 
     getUserData(state) {
         const data = JSON.parse(atob(state.jwt.split('.')[1]));
-        return data
+        return data.user_claims
     },
 
     getSubjectName(state) {


### PR DESCRIPTION
"Clear" user data. In last big update we broke this. It's due get_jwt_claims() functionality was removed from latest version of flask_jwt and by migration process was all user data mixed with jwt service data.