### PR TITLE
Fix migration and bump Python version

### DIFF
--- a/docker/Dockerfile.collectors
+++ b/docker/Dockerfile.collectors
@@ -8,7 +8,7 @@ RUN python -m build
 
 
 
-FROM python:3.12-alpine3.21 AS production
+FROM python:3.13-alpine3.21 AS production
 
 WORKDIR /app/
 

--- a/docker/Dockerfile.publishers
+++ b/docker/Dockerfile.publishers
@@ -8,7 +8,7 @@ RUN python -m build
 
 
 
-FROM python:3.12-alpine3.21 AS production
+FROM python:3.13-alpine3.21 AS production
 
 WORKDIR /app/
 

--- a/src/core/migrations/versions/4cd4c4758a81_remove_atom_collector.py
+++ b/src/core/migrations/versions/4cd4c4758a81_remove_atom_collector.py
@@ -98,9 +98,9 @@ def upgrade():
             stmt = collector_table.delete().where(collector_table.c.id == atom_collector_id)
             conn.execute(stmt)
 
-        # delete Atom Collector Parameters
-        stmt = parameter_value_table.delete().where(parameter_value_table.c.parameter_id.in_(atom_collector_parameter_ids))
-        conn.execute(stmt)
+            # delete Atom Collector Parameter Values
+            stmt = parameter_value_table.delete().where(parameter_value_table.c.parameter_id.in_(atom_collector_parameter_ids))
+            conn.execute(stmt)
 
 
 def downgrade():


### PR DESCRIPTION
This just fixes the migration which removes Atom collector and also thanks to new tweepy version released, bumps Python version for collectors and publishers.