### PR TITLE
Added a remove button to products to remove report items

### DIFF
--- a/src/core/model/asset.py
+++ b/src/core/model/asset.py
@@ -139,7 +139,6 @@ class Asset(db.Model):
         if len(cpes) > 0:
             query_string = "SELECT DISTINCT asset_id FROM asset_cpe WHERE value LIKE ANY(:cpes) OR {}"
             params = {"cpes": cpes}
-
             inner_query = ""
             for i in range(len(cpes)):
                 if i > 0:
@@ -148,9 +147,10 @@ class Asset(db.Model):
                 inner_query += ":" + param + " LIKE value"
                 params[param] = cpes[i]
 
-            result = db.engine.execute(text(query_string.format(inner_query)), params)
+            result = db.session.execute(text(query_string.format(inner_query)), params)
+            asset_ids = [row[0] for row in result]
 
-            return [db.session.get(cls, row._mapping[0]) for row in result]
+            return [db.session.get(cls, pk) for pk in asset_ids]
         else:
             return []
 

--- a/src/core/model/product.py
+++ b/src/core/model/product.py
@@ -201,7 +201,7 @@ class Product(db.Model):
             for report_item in product.report_items:
                 report_item.see = True
                 report_item.access = True
-                report_item.modify = False
+                report_item.modify = True
 
         products_schema = ProductPresentationSchema(many=True)
         return {"total_count": count, "items": products_schema.dump(products)}

--- a/src/core/model/report_item.py
+++ b/src/core/model/report_item.py
@@ -488,7 +488,6 @@ class ReportItem(db.Model):
         if len(cpes) > 0:
             query_string = "SELECT DISTINCT report_item_id FROM report_item_cpe WHERE value LIKE ANY(:cpes) OR {}"
             params = {"cpes": cpes}
-
             inner_query = ""
             for i in range(len(cpes)):
                 if i > 0:
@@ -497,9 +496,10 @@ class ReportItem(db.Model):
                 inner_query += ":" + param + " LIKE value"
                 params[param] = cpes[i]
 
-            result = db.engine.execute(text(query_string.format(inner_query)), params)
+            result = db.session.execute(text(query_string.format(inner_query)), params)
+            report_item_ids = [row[0] for row in result]
 
-            return [row._mapping[0] for row in result]
+            return report_item_ids
         else:
             return []
 

--- a/src/gui/src/components/analyze/CardAnalyze.vue
+++ b/src/gui/src/components/analyze/CardAnalyze.vue
@@ -34,7 +34,7 @@
                                                v-bind="UI.CARD.TOOLBAR.COMPACT" :style="UI.STYLE.card_toolbar">
                                             <v-col v-bind="UI.CARD.COL.TOOLS">
                                                 <v-btn v-if="canDelete" icon class="red"
-                                                       @click.stop="toggleDeletePopup('delete')"
+                                                       @click.stop="showMsgBox('delete')"
                                                        :title="$t('analyze.tooltip.delete_item')">
                                                     <v-icon color="white">mdi-trash-can-outline</v-icon>
                                                 </v-btn>
@@ -45,11 +45,12 @@
                                                 </v-btn>
                                             </v-col>
                                         </v-row>
-                                        <v-row v-if="publish_selector"
+                                        <v-row v-if="!multiSelectActive && publish_selector"
                                                v-bind="UI.CARD.TOOLBAR.COMPACT" :style="UI.STYLE.card_toolbar">
                                             <v-col v-bind="UI.CARD.COL.TOOLS">
                                                 <v-btn v-if="canModify" icon
-                                                       @click.stop="toggleDeletePopup('remove')">
+                                                       @click.stop="showMsgBox('remove')"
+                                                       :title="$t('analyze.tooltip.remove_item')">
                                                     <v-icon color="accent">mdi-minus-circle-outline</v-icon>
                                                 </v-btn>
                                             </v-col>
@@ -63,9 +64,9 @@
             </v-col>
         </v-row>
         <v-row>
-            <MessageBox class="justify-center" v-if="showDeletePopup"
-                        @buttonYes="handleDeletion" @buttonCancel="revertPopupAction"
-                        :title="$t('common.messagebox.delete')" :message="card.title">
+            <MessageBox class="justify-center" v-if="msgbox_visible"
+                        @buttonYes="handleMsgBox" @buttonCancel="cancelMsgBox"
+                        :title="$t(msgBoxTitle)" :message="card.title">
             </MessageBox>
         </v-row>
     </v-container>
@@ -89,8 +90,8 @@
             toolbar: false,
             selected: false,
             status: "in_progress",
-            showDeletePopup: false,
-            popupAction: "",
+            msgbox_visible: false,
+            msgbox_action: "",
         }),
         computed: {
 
@@ -117,11 +118,21 @@
                     return ""
                 }
             },
+
             itemStatus() {
                 if (this.card.completed) {
                     return "completed"
                 } else {
                     return "in_progress"
+                }
+            },
+
+            msgBoxTitle() {
+                switch (this.msgbox_action) {
+                    case "remove":
+                        return "common.messagebox.remove";
+                    default:
+                        return "common.messagebox.delete";
                 }
             }
         },
@@ -144,9 +155,11 @@
                     }
                 }
             },
+
             deleteClicked(data) {
                 this.$root.$emit('delete-report-item', data)
             },
+
             cardItemToolbar(action) {
                 switch (action) {
                     case "delete":
@@ -172,19 +185,19 @@
                 this.selected = false
             },
 
-            toggleDeletePopup(action) {
-                this.popupAction = action;
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox(action) {
+                this.msgbox_action = action;
+                this.msgbox_visible = true;
             },
 
-            revertPopupAction() {
-                this.popupAction = ""
-                this.showDeletePopup = !this.showDeletePopup;
+            cancelMsgBox() {
+                this.msgbox_action = ""
+                this.msgbox_visible = false;
             },
 
-            handleDeletion() {
-                this.showDeletePopup = false;
-                this.cardItemToolbar(this.popupAction);
+            handleMsgBox() {
+                this.msgbox_visible = false;
+                this.cardItemToolbar(this.msgbox_action);
             }
         },
         mounted() {

--- a/src/gui/src/components/analyze/NewsItemSelector.vue
+++ b/src/gui/src/components/analyze/NewsItemSelector.vue
@@ -54,7 +54,7 @@
                                :card="value"
                                :showToolbar="true"
                                data_set="assess_report_item"
-                               @remove-item-from-selector="toggleDeletePopup(value)"
+                               @remove-item-from-selector="showMsgBox(value)"
                                @show-single-aggregate-detail="showSingleAggregateDetail(value)"
                                @show-aggregate-detail="showAggregateDetail(value)"
                                @show-item-detail="showItemDetail(value)" />
@@ -66,9 +66,9 @@
             <NewsItemAggregateDetail ref="newsItemAggregateDetail" :attach="attach" />
         </v-row>
         <v-row>
-            <MessageBox class="justify-center" v-if="showDeletePopup"
-                        @buttonYes="removeFromSelector(to_delete)" @buttonCancel="showDeletePopup = false"
-                        :title="$t('common.messagebox.delete')" :message="to_delete.title">
+            <MessageBox class="justify-center" v-if="msgbox_visible"
+                        @buttonYes="removeFromSelector(to_delete)" @buttonCancel="msgbox_visible = false"
+                        :title="$t('common.messagebox.remove')" :message="to_delete.title">
             </MessageBox>
         </v-row>
     </v-container>
@@ -113,7 +113,7 @@
             groups: [],
             links: [],
             selected_group_id: "",
-            showDeletePopup: false,
+            msgbox_visible: false,
             to_delete: Object,
         }),
         mixins: [AuthMixin],
@@ -196,7 +196,7 @@
             },
 
             removeFromSelector(aggregate) {
-                this.showDeletePopup = false;
+                this.msgbox_visible = false;
                 let data = {}
                 data.delete = true
                 data.aggregate_id = aggregate.id
@@ -246,10 +246,9 @@
                 }
             },
 
-            toggleDeletePopup(aggregate) {
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox(aggregate) {
+                this.msgbox_visible = true;
                 this.to_delete = aggregate;
-
             },
         },
 

--- a/src/gui/src/components/assess/CardAssess.vue
+++ b/src/gui/src/components/assess/CardAssess.vue
@@ -124,7 +124,7 @@
                                                             mdi-thumb-down
                                                         </v-icon>
                                                     </v-btn>
-                                                    <v-btn v-if="canDelete" icon @click.stop="toggleDeletePopup()"
+                                                    <v-btn v-if="canDelete" icon @click.stop="showMsgBox()"
                                                            :title="$t('assess.tooltip.delete_item')"
                                                            data-btn="delete">
                                                         <v-icon color="accent">{{ UI.ICON.DELETE }}</v-icon>
@@ -134,7 +134,8 @@
                                             <v-row v-if="analyze_selector && analyze_can_modify"
                                                    v-bind="UI.CARD.TOOLBAR.COMPACT" :style="UI.STYLE.card_toolbar">
                                                 <v-col v-bind="UI.CARD.COL.TOOLS">
-                                                    <v-btn icon @click.stop="cardItemToolbar('remove')">
+                                                    <v-btn icon @click.stop="cardItemToolbar('remove')"
+                                                           :title="$t('assess.tooltip.remove_item')">
                                                         <v-icon color="accent">mdi-minus-circle-outline</v-icon>
                                                     </v-btn>
                                                 </v-col>
@@ -149,8 +150,8 @@
             </v-col>
         </v-row>
         <v-row>
-            <MessageBox class="justify-center" v-if="showDeletePopup"
-                        @buttonYes="handleDeletion" @buttonCancel="showDeletePopup = false"
+            <MessageBox class="justify-center" v-if="msgbox_visible"
+                        @buttonYes="handleMsgBox" @buttonCancel="msgbox_visible = false"
                         :title="$t('common.messagebox.delete')" :message="card.title">
             </MessageBox>
         </v-row>
@@ -191,7 +192,7 @@
             toolbar: false,
             opened: false,
             selected: false,
-            showDeletePopup: false,
+            msgbox_visible: false,
         }),
         computed: {
             canAccess() {
@@ -427,11 +428,13 @@
                     this.$el.querySelector(".card .layout").classList.remove('focus');
                 }
             },
-            toggleDeletePopup() {
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox() {
+                console.trace('showMsgBox');
+                this.msgbox_visible = true;
             },
-            handleDeletion() {
-                this.showDeletePopup = false;
+            handleMsgBox() {
+                console.trace('handleMsgBox', this.msgbox_action);
+                this.msgbox_visible = false;
                 this.cardItemToolbar('delete')
             }
         },

--- a/src/gui/src/components/assess/CardAssessItem.vue
+++ b/src/gui/src/components/assess/CardAssessItem.vue
@@ -97,7 +97,7 @@
                                                     <v-icon :color="buttonStatus(news_item.me_dislike)">mdi-thumb-down</v-icon>
                                                 </v-btn>
 
-                                                <v-btn v-if="canDelete" icon @click.stop="toggleDeletePopup" data-btn="delete" :title="$t('assess.tooltip.delete_item')">
+                                                <v-btn v-if="canDelete" icon @click.stop="showMsgBox" data-btn="delete" :title="$t('assess.tooltip.delete_item')">
                                                     <v-icon color="accent">mdi-delete</v-icon>
                                                 </v-btn>
 
@@ -112,8 +112,8 @@
             </v-col>
         </v-row>
         <v-row>
-            <MessageBox class="justify-center" v-if="showDeletePopup"
-                        @buttonYes="handleDeletion" @buttonCancel="showDeletePopup = false"
+            <MessageBox class="justify-center" v-if="msgbox_visible"
+                        @buttonYes="handleMsgBox" @buttonCancel="msgbox_visible = false"
                         :title="$t('common.messagebox.delete')" :message="news_item.news_item_data.title">
             </MessageBox>
         </v-row>
@@ -142,7 +142,7 @@
         data: () => ({
             toolbar: false,
             selected: false,
-            showDeletePopup: false,
+            msgbox_visible: false,
         }),
         computed: {
             canAccess() {
@@ -321,11 +321,11 @@
                     this.$el.querySelector(".card .layout").classList.remove('focus');
                 }
             },
-            toggleDeletePopup() {
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox() {
+                this.msgbox_visible = true;
             },
-            handleDeletion() {
-                this.showDeletePopup = false;
+            handleMsgBox() {
+                this.msgbox_visible = false;
                 this.cardItemToolbar('delete')
             }
         },

--- a/src/gui/src/components/assess/NewsItemAggregateDetail.vue
+++ b/src/gui/src/components/assess/NewsItemAggregateDetail.vue
@@ -15,7 +15,7 @@
                             <v-btn v-if="canModify" small icon @click.stop="cardItemToolbar('ungroup')" :title="$t('assess.tooltip.ungroup_item')">
                                 <v-icon small color="accent">mdi-ungroup</v-icon>
                             </v-btn>
-                            <v-btn v-if="canDelete" small icon @click.stop="toggleDeletePopup" :title="$t('assess.tooltip.delete_item')">
+                            <v-btn v-if="canDelete" small icon @click.stop="showMsgBox" :title="$t('assess.tooltip.delete_item')">
                                 <v-icon small color="accent">mdi-delete</v-icon>
                             </v-btn>
                             <v-btn v-if="canCreateReport" small icon @click.stop="cardItemToolbar('new')" :title="$t('assess.tooltip.analyze_item')">
@@ -74,8 +74,8 @@
             </v-dialog>
         </v-row>
         <v-row>
-            <MessageBox class="justify-center" v-if="showDeletePopup"
-                        @buttonYes="handleDeletion" @buttonCancel="showDeletePopup = false"
+            <MessageBox class="justify-center" v-if="msgbox_visible"
+                        @buttonYes="handleMsgBox" @buttonCancel="msgbox_visible = false"
                         :title="$t('common.messagebox.delete')" :message="news_item.title">
             </MessageBox>
         </v-row>
@@ -146,7 +146,7 @@
             title: "",
             description: "",
             toolbar: false,
-            showDeletePopup: false,
+            msgbox_visible: false,
         }),
         methods: {
             open(news_item) {
@@ -259,11 +259,11 @@
                     return "accent"
                 }
             },
-            toggleDeletePopup() {
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox() {
+                this.msgbox_visible = true;
             },
-            handleDeletion() {
-                this.showDeletePopup = false;
+            handleMsgBox() {
+                this.msgbox_visible = false;
                 this.cardItemToolbar('delete')
             }
         }

--- a/src/gui/src/components/assess/NewsItemDetail.vue
+++ b/src/gui/src/components/assess/NewsItemDetail.vue
@@ -14,7 +14,7 @@
                             <v-btn v-if="canModify" small icon @click.stop="cardItemToolbar('ungroup')" :title="$t('assess.tooltip.ungroup_item')">
                                 <v-icon small color="accent">mdi-ungroup</v-icon>
                             </v-btn>
-                            <v-btn v-if="canDelete" small icon @click.stop="toggleDeletePopup" :title="$t('assess.tooltip.delete_item')">
+                            <v-btn v-if="canDelete" small icon @click.stop="showMsgBox" :title="$t('assess.tooltip.delete_item')">
                                 <v-icon small color="accent">mdi-delete</v-icon>
                             </v-btn>
                             <a v-if="canAccess" :href="news_item.news_item_data.link" target="_blank" rel="noreferrer" :title="$t('assess.tooltip.open_source')">
@@ -102,8 +102,8 @@
             </v-dialog>
         </v-row>
         <v-row>
-            <MessageBox class="justify-center" v-if="showDeletePopup"
-                        @buttonYes="handleDeletion" @buttonCancel="showDeletePopup = false"
+            <MessageBox class="justify-center" v-if="msgbox_visible"
+                        @buttonYes="handleMsgBox" @buttonCancel="msgbox_visible = false"
                         :title="$t('common.messagebox.delete')" :message="news_item.news_item_data.title">
             </MessageBox>
         </v-row>
@@ -132,7 +132,7 @@
             visible: false,
             news_item: { news_item_data: {} },
             toolbar: false,
-            showDeletePopup: false,
+            msgbox_visible: false,
         }),
         computed: {
             canAccess() {
@@ -250,11 +250,11 @@
                     return "accent"
                 }
             },
-            toggleDeletePopup() {
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox() {
+                this.msgbox_visible = true;
             },
-            handleDeletion() {
-                this.showDeletePopup = false;
+            handleMsgBox() {
+                this.msgbox_visible = false;
                 this.cardItemToolbar('delete')
             }
         }

--- a/src/gui/src/components/assess/NewsItemSingleDetail.vue
+++ b/src/gui/src/components/assess/NewsItemSingleDetail.vue
@@ -12,7 +12,7 @@
                         <v-spacer></v-spacer>
 
                         <div v-if="!multiSelectActive && !analyze_selector">
-                            <v-btn v-if="canDelete" small icon @click.stop="toggleDeletePopup()" :title="$t('assess.tooltip.delete_item')">
+                            <v-btn v-if="canDelete" small icon @click.stop="showMsgBox()" :title="$t('assess.tooltip.delete_item')">
                                 <v-icon small color="accent">mdi-delete</v-icon>
                             </v-btn>
                             <a v-if="canAccess" :href="news_item.news_items[0].news_item_data.link" rel="noreferrer" target="_blank" :title="$t('assess.tooltip.open_source')">
@@ -119,8 +119,8 @@
                 </v-card>
             </v-dialog>
         </v-row>
-        <MessageBox class="justify-center" v-if="showDeletePopup"
-                    @buttonYes="handleDeletion" @buttonCancel="showDeletePopup = false"
+        <MessageBox class="justify-center" v-if="msgbox_visible"
+                    @buttonYes="handleMsgBox" @buttonCancel="msgbox_visible = false"
                     :title="$t('common.messagebox.delete')" :message="news_item.title">
         </MessageBox>
     </v-container>
@@ -191,7 +191,7 @@
             modify: false,
             news_item: { news_items: [{ news_item_data: {} }] },
             toolbar: false,
-            showDeletePopup: false,
+            msgbox_visible: false,
         }),
         methods: {
             open(news_item) {
@@ -299,11 +299,11 @@
                     return "accent"
                 }
             },
-            toggleDeletePopup() {
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox() {
+                this.msgbox_visible = true;
             },
-            handleDeletion() {
-                this.showDeletePopup = false;
+            handleMsgBox() {
+                this.msgbox_visible = false;
                 this.cardItemToolbar('delete')
             },
             onTabClick(tabNumber) {

--- a/src/gui/src/components/assets/CardAsset.vue
+++ b/src/gui/src/components/assets/CardAsset.vue
@@ -23,7 +23,7 @@
                                 <v-col :style="UI.STYLE.card_hover_toolbar">
                                     <v-row v-if="deleteAllowed() && hover" v-bind="UI.CARD.TOOLBAR.COMPACT" :style="UI.STYLE.card_toolbar">
                                         <v-col v-bind="UI.CARD.COL.TOOLS">
-                                            <v-btn icon class="red" @click.stop="toggleDeletePopup">
+                                            <v-btn icon class="red" @click.stop="showMsgBox">
                                                 <v-icon color="white">{{ UI.ICON.DELETE }}</v-icon>
                                             </v-btn>
                                         </v-col>
@@ -46,8 +46,8 @@
             </v-col>
         </v-row>
         <v-row>
-            <MessageBox class="justify-center" v-if="showDeletePopup"
-                        @buttonYes="handleDeletion" @buttonCancel="showDeletePopup = false"
+            <MessageBox class="justify-center" v-if="msgbox_visible"
+                        @buttonYes="handleMsgBox" @buttonCancel="msgbox_visible = false"
                         :title="$t('common.messagebox.delete')" :message="card.title">
             </MessageBox>
         </v-row>
@@ -70,7 +70,7 @@
             toolbar: false,
             selected: false,
             status: "in_progress",
-            showDeletePopup: false,
+            msgbox_visible: false,
         }),
         mixins: [AuthMixin],
         computed: {
@@ -107,11 +107,11 @@
                         break;
                 }
             },
-            toggleDeletePopup() {
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox() {
+                this.msgbox_visible = true;
             },
-            handleDeletion() {
-                this.showDeletePopup = false;
+            handleMsgBox() {
+                this.msgbox_visible = false;
                 this.cardItemToolbar('delete')
             }
         }

--- a/src/gui/src/components/common/card/CardCompact.vue
+++ b/src/gui/src/components/common/card/CardCompact.vue
@@ -23,7 +23,7 @@
                                 <v-col :style="UI.STYLE.card_hover_toolbar">
                                     <v-row v-if="hover" v-bind="UI.CARD.TOOLBAR.COMPACT" :style="UI.STYLE.card_toolbar">
                                         <v-col v-bind="UI.CARD.COL.TOOLS">
-                                            <v-btn v-if="checkPermission(deletePermission)" icon class="red" @click.stop="toggleDeletePopup">
+                                            <v-btn v-if="checkPermission(deletePermission)" icon class="red" @click.stop="showMsgBox">
                                                 <v-icon color="white">{{ UI.ICON.DELETE }}</v-icon>
                                             </v-btn>
                                         </v-col>
@@ -36,8 +36,8 @@
             </v-col>
         </v-row>
         <v-row>
-            <MessageBox class="justify-center" v-if="showDeletePopup"
-                        @buttonYes="handleDeletion" @buttonCancel="showDeletePopup = false"
+            <MessageBox class="justify-center" v-if="msgbox_visible"
+                        @buttonYes="handleMsgBox" @buttonCancel="msgbox_visible = false"
                         :title="$t('common.messagebox.delete')" :message="card.title">
             </MessageBox>
         </v-row>
@@ -56,7 +56,7 @@
         mixins: [AuthMixin],
         data: () => ({
             toolbar: false,
-            showDeletePopup: false,
+            msgbox_visible: false,
         }),
         methods: {
             itemClicked(data) {
@@ -77,11 +77,11 @@
                         break;
                 }
             },
-            toggleDeletePopup() {
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox() {
+                this.msgbox_visible = true;
             },
-            handleDeletion() {
-                this.showDeletePopup = false;
+            handleMsgBox() {
+                this.msgbox_visible = false;
                 this.cardItemToolbar('delete')
             }
         },

--- a/src/gui/src/components/common/card/CardNode.vue
+++ b/src/gui/src/components/common/card/CardNode.vue
@@ -27,7 +27,7 @@
                                 <v-col :style="UI.STYLE.card_hover_toolbar">
                                     <v-row v-if="hover" v-bind="UI.CARD.TOOLBAR.COMPACT" :style="UI.STYLE.card_toolbar">
                                         <v-col v-bind="UI.CARD.COL.TOOLS">
-                                            <v-btn v-if="checkPermission(deletePermission)" icon class="red" @click.stop="toggleDeletePopup">
+                                            <v-btn v-if="checkPermission(deletePermission)" icon class="red" @click.stop="showMsgBox">
                                                 <v-icon color="white">{{ UI.ICON.DELETE }}</v-icon>
                                             </v-btn>
                                         </v-col>
@@ -40,8 +40,8 @@
             </v-col>
         </v-row>
         <v-row>
-            <MessageBox class="justify-center" v-if="showDeletePopup"
-                        @buttonYes="handleDeletion" @buttonCancel="showDeletePopup = false"
+            <MessageBox class="justify-center" v-if="msgbox_visible"
+                        @buttonYes="handleMsgBox" @buttonCancel="msgbox_visible = false"
                         :title="$t('common.messagebox.delete')" :message="card.name">
             </MessageBox>
         </v-row>
@@ -61,7 +61,7 @@
         mixins: [AuthMixin],
         data: () => ({
             toolbar: false,
-            showDeletePopup: false,
+            msgbox_visible: false,
         }),
         computed: {
             cardStatus() {
@@ -91,11 +91,11 @@
                         break;
                 }
             },
-            toggleDeletePopup() {
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox() {
+                this.msgbox_visible = true;
             },
-            handleDeletion() {
-                this.showDeletePopup = false;
+            handleMsgBox() {
+                this.msgbox_visible = false;
                 this.cardItemToolbar('delete')
             }
 

--- a/src/gui/src/components/common/card/CardPreset.vue
+++ b/src/gui/src/components/common/card/CardPreset.vue
@@ -23,7 +23,7 @@
                                 <v-col :style="UI.STYLE.card_hover_toolbar">
                                     <v-row v-if="hover" v-bind="UI.CARD.TOOLBAR.COMPACT" :style="UI.STYLE.card_toolbar">
                                         <v-col v-bind="UI.CARD.COL.TOOLS">
-                                            <v-btn v-if="checkPermission(deletePermission)" icon class="red" @click.stop="toggleDeletePopup">
+                                            <v-btn v-if="checkPermission(deletePermission)" icon class="red" @click.stop="showMsgBox">
                                                 <v-icon color="white">{{ UI.ICON.DELETE }}</v-icon>
                                             </v-btn>
                                         </v-col>
@@ -36,8 +36,8 @@
             </v-col>
         </v-row>
         <v-row>
-            <MessageBox class="justify-center" v-if="showDeletePopup"
-                        @buttonYes="handleDeletion" @buttonCancel="showDeletePopup = false"
+            <MessageBox class="justify-center" v-if="msgbox_visible"
+                        @buttonYes="handleMsgBox" @buttonCancel="msgbox_visible = false"
                         :title="$t('common.messagebox.delete')" :message="card.title">
             </MessageBox>
         </v-row>
@@ -56,7 +56,7 @@
         mixins: [AuthMixin],
         data: () => ({
             toolbar: false,
-            showDeletePopup: false,
+            msgbox_visible: false,
         }),
         computed: {
             cardStatus() {
@@ -86,11 +86,11 @@
                         break;
                 }
             },
-            toggleDeletePopup() {
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox() {
+                this.msgbox_visible = true;
             },
-            handleDeletion() {
-                this.showDeletePopup = false;
+            handleMsgBox() {
+                this.msgbox_visible = false;
                 this.cardItemToolbar('delete')
             }
         }

--- a/src/gui/src/components/config/osint_sources/CardGroup.vue
+++ b/src/gui/src/components/config/osint_sources/CardGroup.vue
@@ -24,7 +24,7 @@
                                     <v-row v-if="hover" v-bind="UI.CARD.TOOLBAR.COMPACT" :style="UI.STYLE.card_toolbar">
                                         <v-col v-bind="UI.CARD.COL.TOOLS">
                                             <v-btn v-if="!card.default && checkPermission(deletePermission)" icon class="red"
-                                                   @click.stop="toggleDeletePopup">
+                                                   @click.stop="showMsgBox">
                                                 <v-icon color="white">{{ UI.ICON.DELETE }}</v-icon>
                                             </v-btn>
                                         </v-col>
@@ -37,8 +37,8 @@
             </v-col>
         </v-row>
         <v-row>
-            <MessageBox class="justify-center" v-if="showDeletePopup"
-                        @buttonYes="handleDeletion" @buttonCancel="showDeletePopup = false"
+            <MessageBox class="justify-center" v-if="msgbox_visible"
+                        @buttonYes="handleMsgBox" @buttonCancel="msgbox_visible = false"
                         :title="$t('common.messagebox.delete')" :message="card.name">
             </MessageBox>
         </v-row>
@@ -57,7 +57,7 @@
         mixins: [AuthMixin],
         data: () => ({
             toolbar: false,
-            showDeletePopup: false,
+            msgbox_visible: false,
         }),
         computed: {
             cardName() {
@@ -101,11 +101,11 @@
                         break;
                 }
             },
-            toggleDeletePopup() {
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox() {
+                this.msgbox_visible = true;
             },
-            handleDeletion() {
-                this.showDeletePopup = false;
+            handleMsgBox() {
+                this.msgbox_visible = false;
                 this.cardItemToolbar('delete')
             }
 

--- a/src/gui/src/components/config/osint_sources/CardSource.vue
+++ b/src/gui/src/components/config/osint_sources/CardSource.vue
@@ -40,7 +40,7 @@
                                 <v-col :style="UI.STYLE.card_hover_toolbar">
                                     <v-row v-if="hover" v-bind="UI.CARD.TOOLBAR.COMPACT" :style="UI.STYLE.card_toolbar">
                                         <v-col v-bind="UI.CARD.COL.TOOLS">
-                                            <v-btn v-if="checkPermission(deletePermission)" icon class="red" @click.stop="toggleDeletePopup">
+                                            <v-btn v-if="checkPermission(deletePermission)" icon class="red" @click.stop="showMsgBox">
                                                 <v-icon color="white">{{ UI.ICON.DELETE }}</v-icon>
                                             </v-btn>
                                         </v-col>
@@ -53,8 +53,8 @@
             </v-col>
         </v-row>
         <v-row>
-            <MessageBox class="justify-center" v-if="showDeletePopup"
-                        @buttonYes="handleDeletion" @buttonCancel="showDeletePopup = false"
+            <MessageBox class="justify-center" v-if="msgbox_visible"
+                        @buttonYes="handleMsgBox" @buttonCancel="msgbox_visible = false"
                         :title="$t('common.messagebox.delete')" :message="card.name">
             </MessageBox>
         </v-row>
@@ -73,7 +73,7 @@
         data: () => ({
             toolbar: false,
             selected: false,
-            showDeletePopup: false,
+            msgbox_visible: false,
         }),
         mixins: [AuthMixin],
         computed: {
@@ -115,11 +115,11 @@
                         break;
                 }
             },
-            toggleDeletePopup() {
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox() {
+                this.msgbox_visible = true;
             },
-            handleDeletion() {
-                this.showDeletePopup = false;
+            handleMsgBox() {
+                this.msgbox_visible = false;
                 this.cardItemToolbar('delete')
             }
 

--- a/src/gui/src/components/config/product_types/CardProductType.vue
+++ b/src/gui/src/components/config/product_types/CardProductType.vue
@@ -23,7 +23,7 @@
                                 <v-col :style="UI.STYLE.card_hover_toolbar">
                                     <v-row v-if="hover" v-bind="UI.CARD.TOOLBAR.COMPACT" :style="UI.STYLE.card_toolbar">
                                         <v-col v-bind="UI.CARD.COL.TOOLS">
-                                            <v-btn v-if="checkPermission(deletePermission)" icon class="red" @click.stop="toggleDeletePopup">
+                                            <v-btn v-if="checkPermission(deletePermission)" icon class="red" @click.stop="showMsgBox">
                                                 <v-icon color="white">{{ UI.ICON.DELETE }}</v-icon>
                                             </v-btn>
                                         </v-col>
@@ -36,8 +36,8 @@
             </v-col>
         </v-row>
         <v-row>
-            <MessageBox class="justify-center" v-if="showDeletePopup"
-                        @buttonYes="handleDeletion" @buttonCancel="showDeletePopup = false"
+            <MessageBox class="justify-center" v-if="msgbox_visible"
+                        @buttonYes="handleMsgBox" @buttonCancel="msgbox_visible = false"
                         :title="$t('common.messagebox.delete')" :message="card.title">
             </MessageBox>
         </v-row>
@@ -54,7 +54,7 @@
         props: ['card', 'deletePermission'],
         data: () => ({
             toolbar: false,
-            showDeletePopup: false,
+            msgbox_visible: false,
         }),
         mixins: [AuthMixin],
         methods: {
@@ -76,11 +76,11 @@
                         break;
                 }
             },
-            toggleDeletePopup() {
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox() {
+                this.msgbox_visible = true;
             },
-            handleDeletion() {
-                this.showDeletePopup = false;
+            handleMsgBox() {
+                this.msgbox_visible = false;
                 this.cardItemToolbar('delete')
             }
         }

--- a/src/gui/src/components/config/user/CardUser.vue
+++ b/src/gui/src/components/config/user/CardUser.vue
@@ -23,7 +23,7 @@
                                 <v-col :style="UI.STYLE.card_hover_toolbar">
                                     <v-row v-if="hover" v-bind="UI.CARD.TOOLBAR.COMPACT" :style="UI.STYLE.card_toolbar">
                                         <v-col v-bind="UI.CARD.COL.TOOLS">
-                                            <v-btn v-if="checkPermission(deletePermission)" icon class="red ml-1" @click.stop="toggleDeletePopup">
+                                            <v-btn v-if="checkPermission(deletePermission)" icon class="red ml-1" @click.stop="showMsgBox">
                                                 <v-icon color="white">{{ UI.ICON.DELETE }}</v-icon>
                                             </v-btn>
                                         </v-col>
@@ -36,8 +36,8 @@
             </v-col>
         </v-row>
         <v-row>
-            <MessageBox class="justify-center" v-if="showDeletePopup"
-                        @buttonYes="handleDeletion" @buttonCancel="showDeletePopup = false"
+            <MessageBox class="justify-center" v-if="msgbox_visible"
+                        @buttonYes="handleMsgBox" @buttonCancel="msgbox_visible = false"
                         :title="$t('common.messagebox.delete')" :message="card.title">
             </MessageBox>
         </v-row>
@@ -56,7 +56,7 @@
         mixins: [AuthMixin],
         data: () => ({
             toolbar: false,
-            showDeletePopup: false,
+            msgbox_visible: false,
         }),
         methods: {
             itemClicked(data) {
@@ -77,11 +77,11 @@
                         break;
                 }
             },
-            toggleDeletePopup() {
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox() {
+                this.msgbox_visible = true;
             },
-            handleDeletion() {
-                this.showDeletePopup = false;
+            handleMsgBox() {
+                this.msgbox_visible = false;
                 this.cardItemToolbar('delete')
             }
         }

--- a/src/gui/src/components/publish/CardProduct.vue
+++ b/src/gui/src/components/publish/CardProduct.vue
@@ -23,7 +23,7 @@
                                 <v-col :style="UI.STYLE.card_hover_toolbar">
                                     <v-row v-if="hover" v-bind="UI.CARD.TOOLBAR.COMPACT" :style="UI.STYLE.card_toolbar">
                                         <v-col v-bind="UI.CARD.COL.TOOLS">
-                                            <v-btn v-if="canDelete" icon class="red" @click.stop="toggleDeletePopup" :title="$t('publish.tooltip.delete_item')">
+                                            <v-btn v-if="canDelete" icon class="red" @click.stop="showMsgBox" :title="$t('publish.tooltip.delete_item')">
                                                 <v-icon color="white">{{ UI.ICON.DELETE }}</v-icon>
                                             </v-btn>
                                         </v-col>
@@ -36,8 +36,8 @@
             </v-col>
         </v-row>
         <v-row>
-            <MessageBox class="justify-center" v-if="showDeletePopup"
-                        @buttonYes="handleDeletion" @buttonCancel="showDeletePopup = false"
+            <MessageBox class="justify-center" v-if="msgbox_visible"
+                        @buttonYes="handleMsgBox" @buttonCancel="msgbox_visible = false"
                         :title="$t('common.messagebox.delete')" :message="card.title">
             </MessageBox>
         </v-row>
@@ -55,7 +55,7 @@
         props: ['card'],
         data: () => ({
             toolbar: false,
-            showDeletePopup: false,
+            msgbox_visible: false,
         }),
         mixins: [AuthMixin],
         computed: {
@@ -88,11 +88,11 @@
                         break;
                 }
             },
-            toggleDeletePopup() {
-                this.showDeletePopup = !this.showDeletePopup;
+            showMsgBox() {
+                this.msgbox_visible = true;
             },
-            handleDeletion() {
-                this.showDeletePopup = false;
+            handleMsgBox() {
+                this.msgbox_visible = false;
                 this.cardItemToolbar('delete')
             }
         }

--- a/src/gui/src/components/publish/NewProduct.vue
+++ b/src/gui/src/components/publish/NewProduct.vue
@@ -94,8 +94,8 @@
                         </v-col>
                     </v-row>
                     <v-row>
-                        <MessageBox class="justify-center" v-if="showPublishConfirmation"
-                                    @buttonYes="publishProduct" @buttonCancel="showPublishConfirmation = false"
+                        <MessageBox class="justify-center" v-if="msgbox_visible"
+                                    @buttonYes="publishProduct" @buttonCancel="msgbox_visible = false"
                                     :title="$t('product.publish_confirmation')" :message="product.title">
                         </MessageBox>
                     </v-row>
@@ -147,7 +147,7 @@
                 product_type_id: null,
                 report_items: [],
             },
-            showPublishConfirmation: false,
+            msgbox_visible: false,
         }),
         mixins: [AuthMixin],
         watch: {
@@ -193,11 +193,11 @@
             },
 
             publishConfirmation() {
-                this.showPublishConfirmation = true;
+                this.msgbox_visible = true;
             },
 
             publishProduct() {
-                this.showPublishConfirmation = false;
+                this.msgbox_visible = false;
                 for (let i = 0; i < this.publisher_presets.length; i++) {
                     if (this.publisher_presets[i].selected) {
                         this.$validator.validateAll().then(() => {

--- a/src/gui/src/i18n/cs/messages.js
+++ b/src/gui/src/i18n/cs/messages.js
@@ -764,6 +764,7 @@ const messages_cs = {
             delete_items: "Smazat analýzy",
             publish_items: "Vytvořit z analýz report",
             delete_item: "Smazat analýzu",
+            remove_item: 'Odstranit analýzu',
             publish_item: "Vytvořit report z analýzy",
         }
     },
@@ -826,6 +827,7 @@ const messages_cs = {
             like_item: "To se mi líbí",
             dislike_item: "To se mi nelíbí",
             delete_item: "Smazat novinku",
+            remove_item: 'Odstranit novinku',
         },
         shortcuts: {
             enter_filter_mode: "Zapnut mód zkratek 'filtr'. Ukončete klávesou Escape.",
@@ -1061,7 +1063,8 @@ const messages_cs = {
             yes: "Ano",
             no: "Ne",
             cancel: "Zrušit",
-            delete: "Jste si jisti, že chcete odstranit tuto položku?",
+            delete: "Jste si jisti, že chcete smazat tuto položku?",
+            remove: "Jste si jisti, že chcete odstranit tuto položku?",
         },
     }
 };

--- a/src/gui/src/i18n/en/messages.js
+++ b/src/gui/src/i18n/en/messages.js
@@ -766,6 +766,7 @@ const messages_en = {
             delete_items: 'Delete report items',
             publish_items: 'Create product from report items',
             delete_item: 'Delete report item',
+            remove_item: 'Remove report item',
             publish_item: 'Create product from report item',
         }
     },
@@ -828,6 +829,7 @@ const messages_en = {
             like_item: 'Like news item',
             dislike_item: 'Dislike news item',
             delete_item: 'Delete news item',
+            remove_item: 'Remove news item',
         },
         shortcuts: {
             enter_filter_mode: 'Entered shortcut mode "filter". Exit with Escape.',
@@ -1078,6 +1080,7 @@ const messages_en = {
             no: "No",
             cancel: "Cancel",
             delete: "Are you sure you want to delete following item?",
+            remove: "Are you sure you want to remove following item?",
         },
     }
 };

--- a/src/gui/src/i18n/sk/messages.js
+++ b/src/gui/src/i18n/sk/messages.js
@@ -156,9 +156,10 @@ const messages_sk = {
             yes: "Áno",
             no: "Nie",
             cancel: "Zrušiť",
-            delete: "Ste si istý, že chcete odstrániť túto položku?",
+            delete: "Ste si istý, že chcete zmazať túto položku?",
+            remove: "Ste si istý, že chcete odstrániť túto položku?",
         },
-    }
+    },
 };
 
 export default messages_sk


### PR DESCRIPTION
Added a remove button to products to remove report items.
Added tooltips for remove buttons.
Fixed error: AttributeError: 'OptionEngine' object has no attribute 'execute' (Flask migration). 
Renamed showDeletePopup to showMsgBox due to its more generic meaning, not just for deleting. 
Changed the text message for removing items (delete → remove) as it was misleading.