### PR TITLE
Small fixes (warnings, table selection, linting, README)

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.13']
+        python-version: ['3.13']
     steps:
       - uses: actions/checkout@v4
       - name: lint with black

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,6 +1,6 @@
 # **TaranisNG backend setup**
 1. Install **Postgresql** database and create database e.g. taranisdb
-2. Install **Python 3.10** or later
+2. Install **Python 3.13** or later
 3. In taranis-ng-common, taranis-ng-collectors and taranis-ng-core install and activate python virtual environment:
     `virtualenv -p python3.7 venv`
     `source venv/bin/activate`

--- a/src/gui/src/assets/centralize.css
+++ b/src/gui/src/assets/centralize.css
@@ -487,12 +487,6 @@ span.cs_metric_score {
     margin-right: 0;
 }
 
-/* --- EnumSelector.vue --- */
-tbody tr {
-    user-select: none !important;
-    cursor: pointer;
-}
-
 /* --- Navigation.vue --- */
 .navigation .v-list-item--active:not(.theme--dark) {
     background-color: rgba(255, 255, 255, 0.3);

--- a/src/gui/src/main.js
+++ b/src/gui/src/main.js
@@ -59,10 +59,10 @@ const vuetify = new Vuetify({
 
 Vue.use(VueI18n);
 
-let bash_locale = "$VUE_APP_TARANIS_NG_LOCALE";
+let lang = typeof(process.env.VUE_APP_TARANIS_NG_LOCALE) == "undefined" ? "en" : process.env.VUE_APP_TARANIS_NG_LOCALE
 
 const i18n = new VueI18n({
-    locale: bash_locale,
+    locale: lang, // later we overwrite this to user language
     fallbackLocale: 'en',
     messages
 });

--- a/src/gui/src/services/auth/auth_service.js
+++ b/src/gui/src/services/auth/auth_service.js
@@ -27,7 +27,6 @@ const AuthService = {
     },
 
     hasPermission(permission) {
-
         return store.getters.getPermissions.includes(permission)
     },
 


### PR DESCRIPTION
- Fix warnings on app start: Fall back to translate the keypath with 'en' locale.
- Allow select text in data table (for copying) and add hand cursor
- Removed python linting for 3.10
- Updated Python version in README