### PR TITLE
WIP Fix reload after report item is saved

### DIFF
--- a/src/gui/src/components/analyze/ContentDataAnalyze.vue
+++ b/src/gui/src/components/analyze/ContentDataAnalyze.vue
@@ -134,7 +134,7 @@
         },
 
         mounted() {
-            this.updateData(false, false);
+            this.updateData();
 
             this.$root.$on('report-item-updated', this.report_item_updated);
             this.$root.$on('report-items-updated', this.report_item_updated);

--- a/src/gui/src/components/publish/NewProduct.vue
+++ b/src/gui/src/components/publish/NewProduct.vue
@@ -21,7 +21,7 @@
                     <v-spacer></v-spacer>
                     <v-btn v-if="canModify" text dark type="submit" form="form">
                         <v-icon left>mdi-content-save</v-icon>
-                        <span>{{ $t('report_item.save') }}</span>
+                        <span>{{ $t('product.save') }}</span>
                     </v-btn>
                 </v-toolbar>
 


### PR DESCRIPTION
Newly created report item has not been displayed in the list after clicking on save. This fixes it.