### PR TITLE
Remote node connection errors

### DIFF
--- a/src/core/api/analyze.py
+++ b/src/core/api/analyze.py
@@ -63,7 +63,7 @@ class ReportItems(Resource):
 
             group = None
             if "group" in request.args and request.args["group"]:
-                group = int(request.args["group"])
+                group = request.args["group"]
 
             offset = None
             if "offset" in request.args and request.args["offset"]:

--- a/src/core/managers/remote_manager.py
+++ b/src/core/managers/remote_manager.py
@@ -1,3 +1,5 @@
+"""Remote manager, Server-Sent Events (SSE) handling."""
+
 import requests
 import sseclient
 import threading
@@ -5,6 +7,7 @@ import time
 import json
 
 from managers import sse_manager
+from managers.log_manager import logger
 from model.news_item import NewsItemAggregate
 from model.remote import RemoteAccess, RemoteNode
 from model.report_item import ReportItem
@@ -14,67 +17,101 @@ event_handlers = {}
 
 
 class EventThread(threading.Thread):
+    """Thread to handle Server-Sent Events (SSE) from a remote node."""
+
     app = None
 
     def __init__(self, remote_node, event_handler):
+        """
+        Initialize the EventThread.
+
+        Args:
+            remote_node (RemoteNode): The remote node to connect to.
+            event_handler (threading.Event): The event handler to manage thread events.
+        """
         threading.Thread.__init__(self)
         self.remote_node = remote_node
         self.event_handler = event_handler
 
     def run(self):
-        while not self.event_handler.is_set():
+        """Run the thread to listen for SSE events and handle them accordingly."""
+        attempt = 1
+        retries = 3
+        while not self.event_handler.is_set() and attempt <= retries:
             try:
-                response = requests.get(
-                    self.remote_node.events_url + "?channel=remote&access_key=" + self.remote_node.access_key,
-                    stream=True)
+                response = requests.get(self.remote_node.events_url + "?channel=remote&api_key=" + self.remote_node.access_key, stream=True)
+                if response.status_code != 200:
+                    response_text = ""
+                    if response:
+                        response_text = " ".join(response.text.strip().splitlines())[:200]
+                    logger.error(f"Could not connect to SSE. Code: {response.status_code}. Response: {response_text}")
+                    return
                 client = sseclient.SSEClient(response)
                 for event in client.events():
-                    data = json.loads(event.data)
-                    if event.event == 'remote_access_disconnect':
-                        if self.remote_node.event_id in data:
-                            with EventThread.app.app_context():
-                                self.remote_node.disconnect()
-                            return
-
-                    elif event.event == 'remote_access_news_items_updated':
-                        if self.remote_node.sync_news_items and self.remote_node.osint_source_group_id is not None:
+                    try:
+                        data = json.loads(event.data)
+                        logger.debug(f"SSE event received: {event.event}, data: {data}")
+                        if event.event == "remote_access_disconnect":
                             if self.remote_node.event_id in data:
-                                data, status_code = RemoteApi(self.remote_node.remote_url,
-                                                              self.remote_node.access_key).get_news_items()
-                                if status_code == 200:
-                                    with EventThread.app.app_context():
-                                        NewsItemAggregate.add_remote_news_items(data['news_items'],
-                                                                                self.remote_node,
-                                                                                self.remote_node.osint_source_group_id)
+                                with EventThread.app.app_context():
+                                    self.remote_node.disconnect()
+                                return
 
-                                    RemoteApi(self.remote_node.remote_url,
-                                              self.remote_node.access_key).confirm_news_items_sync(
-                                        {'last_sync_time': data['last_sync_time']})
+                        elif event.event == "remote_access_news_items_updated":
+                            if self.remote_node.sync_news_items and self.remote_node.osint_source_group_id is not None:
+                                if self.remote_node.event_id in data:
+                                    data, status_code = RemoteApi(self.remote_node.remote_url, self.remote_node.access_key).get_news_items()
+                                    if status_code == 200:
+                                        with EventThread.app.app_context():
+                                            NewsItemAggregate.add_remote_news_items(
+                                                data["news_items"], self.remote_node, self.remote_node.osint_source_group_id
+                                            )
 
-                                    with EventThread.app.app_context():
-                                        sse_manager.sse_manager.news_items_updated()
+                                        RemoteApi(self.remote_node.remote_url, self.remote_node.access_key).confirm_news_items_sync(
+                                            {"last_sync_time": data["last_sync_time"]}
+                                        )
 
-                    elif event.event == 'remote_access_report_items_updated':
-                        if self.remote_node.sync_report_items:
-                            if self.remote_node.event_id in data:
-                                data, status_code = RemoteApi(self.remote_node.remote_url,
-                                                              self.remote_node.access_key).get_report_items()
-                                if status_code == 200:
-                                    with EventThread.app.app_context():
-                                        ReportItem.add_remote_report_items(data['report_items'], self.remote_node.name)
+                                        with EventThread.app.app_context():
+                                            sse_manager.sse_manager.news_items_updated()
+                                    else:
+                                        logger.error(f"Get remote news items failed. Code: {status_code}")
 
-                                    RemoteApi(self.remote_node.remote_url,
-                                              self.remote_node.access_key).confirm_report_items_sync(
-                                        {'last_sync_time': data['last_sync_time']})
+                        elif event.event == "remote_access_report_items_updated":
+                            if self.remote_node.sync_report_items:
+                                if self.remote_node.event_id in data:
+                                    data, status_code = RemoteApi(self.remote_node.remote_url, self.remote_node.access_key).get_report_items()
+                                    if status_code == 200:
+                                        with EventThread.app.app_context():
+                                            ReportItem.add_remote_report_items(data["report_items"], self.remote_node.name)
 
-                                    with EventThread.app.app_context():
-                                        sse_manager.sse_manager.report_items_updated()
+                                        RemoteApi(self.remote_node.remote_url, self.remote_node.access_key).confirm_report_items_sync(
+                                            {"last_sync_time": data["last_sync_time"]}
+                                        )
 
-            except Exception:
-                time.sleep(5)
+                                        with EventThread.app.app_context():
+                                            sse_manager.sse_manager.report_items_updated()
+                                    else:
+                                        logger.error(f"Get remote report items failed. Code: {status_code}")
+
+                    except Exception as ex:
+                        logger.exception(f"SSE processing failed: {ex}")
+
+            except Exception as ex:
+                logger.warning(f"Waiting for connection to SSE: {ex}. Attempt {attempt} of {retries}.")
+
+            time.sleep(5)
+            attempt += 1
+
+        logger.error("Could not connect to SSE.")
 
 
 def connect_to_events(remote_node):
+    """
+    Connect to SSE events for a given remote node.
+
+    Args:
+        remote_node (RemoteNode): The remote node to connect to.
+    """
     event_handler = threading.Event()
     event_thread = EventThread(remote_node, event_handler)
     event_handlers[remote_node.id] = event_handler
@@ -82,15 +119,39 @@ def connect_to_events(remote_node):
 
 
 def disconnect_from_events(remote_node):
+    """
+    Disconnect from SSE events for a given remote node.
+
+    Args:
+        remote_node (RemoteNode): The remote node to disconnect from.
+    """
     if remote_node.id in event_handlers:
         event_handlers[remote_node.id].set()
 
 
 def verify_access_key(access_key):
+    """
+    Verify if the given access key exists.
+
+    Args:
+        access_key (str): The access key to verify.
+
+    Returns:
+        bool: True if the access key exists, False otherwise.
+    """
     return RemoteAccess.exists_by_access_key(access_key)
 
 
 def connect_to_node(node_id):
+    """
+    Connect to a remote node by its ID.
+
+    Args:
+        node_id (int): The ID of the remote node to connect to.
+
+    Returns:
+        tuple: A tuple containing the access information and status code.
+    """
     remote_node = RemoteNode.find(node_id)
     access_info, status_code = RemoteApi(remote_node.remote_url, remote_node.access_key).connect()
     if status_code == 200:
@@ -104,11 +165,23 @@ def connect_to_node(node_id):
 
 
 def disconnect_from_node(node_id):
+    """
+    Disconnect from a remote node by its ID.
+
+    Args:
+        node_id (int): The ID of the remote node to disconnect from.
+    """
     remote_node = RemoteNode.find(node_id)
     RemoteApi(remote_node.remote_url, remote_node.access_key).disconnect()
 
 
 def initialize(app):
+    """
+    Initialize the remote manager with the given application context.
+
+    Args:
+        app: The application context to use.
+    """
     EventThread.app = app
     remote_nodes, count = RemoteNode.get(None)
     for remote_node in remote_nodes:

--- a/src/core/model/news_item.py
+++ b/src/core/model/news_item.py
@@ -75,7 +75,7 @@ class NewsItemData(db.Model):
 
     collected = db.Column(db.DateTime)
     published = db.Column(db.String())
-    updated = db.Column(db.DateTime, default=datetime.now())
+    updated = db.Column(db.DateTime)
 
     attributes = db.relationship("NewsItemAttribute", secondary="news_item_data_news_item_attribute", lazy="selectin")
 
@@ -100,6 +100,7 @@ class NewsItemData(db.Model):
         self.content = content
         self.attributes = attributes
         self.osint_source_id = osint_source_id
+        self.updated = datetime.now()
 
     @classmethod
     def allowed_with_acl(cls, news_item_data_id, user, see, access, modify):
@@ -154,7 +155,7 @@ class NewsItemData(db.Model):
         Returns:
             News item data
         """
-        return cls.query.filter(NewsItemData.hash == hash).all()
+        return cls.query.filter(NewsItemData.hash == hash).first()
 
     @classmethod
     def count_all(cls):
@@ -243,7 +244,6 @@ class NewsItemData(db.Model):
             osint_source_ids.add(osint_source.id)
 
         last_sync_time = datetime.now()
-
         query = cls.query.filter(
             NewsItemData.updated >= last_synced, NewsItemData.updated <= last_sync_time, NewsItemData.osint_source_id.in_(osint_source_ids)
         )
@@ -342,7 +342,7 @@ class NewsItem(db.Model):
         result = query.all()
         total_relevance = 0
         for row in result:
-            total_relevance += int(row._mapping[0])
+            total_relevance += int(row[0])
 
         return total_relevance
 


### PR DESCRIPTION
- Fixed crash (KeyError: 0) on some actions caused by last SqlAlchemy migration
- Fixed crash on creating remote groups for report items 
- Fixed endless loop when you try connect to remote node with bad SSE link (both servers are after overloaded)
- Added better logging to SSE (messages)
- Fixed bug when you create News Item Data and Updated column don't reflect current time
- Fixed find_by_hash function for News items that was not working
- Fixed find_by_uuid function for Report items that was not working
- Fixed add_remote_report_items function that was not working. It's still unfinished from the past but don't crash now and create all passed data on remote side. This needs to be finished someday!