### PR TITLE
Added posibility "refresh" parameters for Presenter, Collector, Bot, and Publisher and their products

### DIFF
--- a/src/core/manage.py
+++ b/src/core/manage.py
@@ -315,7 +315,7 @@ def collector_management(
         for mod in modules:
             col = collector.Collector(mod.name, mod.description, mod.type, [])
             for par in mod.parameters:
-                col.parameters.append(parameter.Parameter(par.key, par.name, par.description, par.type))
+                col.parameters.append(parameter.Parameter(par.key, par.name, par.description, par.type, par.default_value))
             node.collectors.append(col)
 
         db_manager.db.session.add(node)

--- a/src/core/migrations/regenerate_params.py
+++ b/src/core/migrations/regenerate_params.py
@@ -1,0 +1,232 @@
+"""Create, update and delete Collector, Bot, Presenter and Publisher parameters."""
+
+from model.collectors_node import CollectorsNode
+from model.collector import Collector, CollectorParameter
+from model.presenters_node import PresentersNode
+from model.presenter import Presenter, PresenterParameter
+from model.publishers_node import PublishersNode
+from model.publisher import Publisher, PublisherParameter
+from model.bots_node import BotsNode
+from model.bot import Bot, BotParameter
+from model.parameter import Parameter
+from model.parameter_value import ParameterValue
+from model.osint_source import OSINTSource, OSINTSourceParameterValue
+from model.bot_preset import BotPreset, BotPresetParameterValue
+from model.product_type import ProductType, ProductTypeParameterValue
+from model.publisher_preset import PublisherPreset, PublisherPresetParameterValue
+from shared.config_collector import ConfigCollector
+from shared.config_bot import ConfigBot
+from shared.config_presenter import ConfigPresenter
+from shared.config_publisher import ConfigPublisher
+from model import attribute  # noqa: F401  Don't remove this line otherwise relationship problems
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+
+# this allow us add new module/parameters to nodes without deleting and manually recreating it (we don't loose existing data)
+# existing objects like OSINT sources, Bots presets... that depend on these parameters stay untouched and need to be updated/recrated manually
+def RegenerateParameters(type, session):
+    """
+    Create new, update existing, and delete old Collector, Bot, Presenter and Publisher parameters.
+
+    Args:
+        type (str): The type of module to regenerate. Valid values are "collectors", "bots", "presenters", and "publishers".
+        session (sqlalchemy.orm.session.Session): The SQLAlchemy session to use for database operations.
+    """
+    try:
+        match type:
+            case "collectors":
+                def_modules = ConfigCollector().modules
+                db_nodes = session.query(CollectorsNode).all()
+                class_module = Collector
+            case "bots":
+                def_modules = ConfigBot().modules
+                db_nodes = session.query(BotsNode).all()
+                class_module = Bot
+            case "presenters":
+                def_modules = ConfigPresenter().modules
+                db_nodes = session.query(PresentersNode).all()
+                class_module = Presenter
+            case "publishers":
+                def_modules = ConfigPublisher().modules
+                db_nodes = session.query(PublishersNode).all()
+                class_module = Publisher
+            case _:
+                print(f"ERROR: Invalid module type '{type}' to regenerate", flush=True)
+                return
+
+        for db_node in db_nodes:
+            print(f"Regenarating parameters for node: {db_node.name}", flush=True)
+            # create/update
+            db_modules = session.query(class_module).filter_by(node_id=db_node.id).all()
+            for def_mod in def_modules:
+                # create/update module
+                db_mod = next((m for m in db_modules if m.type == def_mod.type), None)
+                if not db_mod:
+                    print(f"+++  {def_mod.type}", flush=True)
+                    db_mod = class_module(name=def_mod.name, description=def_mod.description, type=def_mod.type, parameters=[])
+                    db_mod.node_id = db_node.id
+                    session.add(db_mod)
+                else:
+                    db_mod.name = def_mod.name
+                    db_mod.description = def_mod.description
+                session.commit()
+                # create/update module parameters
+                for def_par in def_mod.parameters:
+                    db_par = next((p for p in db_mod.parameters if p.key == def_par.key), None)
+                    if not db_par:
+                        print(f"+++  {def_mod.type}.{def_par.key}", flush=True)
+                        db_par = Parameter(def_par.key, def_par.name, def_par.description, def_par.type.name, def_par.default_value)
+                        session.add(db_par)
+                        session.commit()
+                        db_mod_par = get_new_mod_param(type, db_mod.id, db_par.id)
+                        session.add(db_mod_par)
+                    else:
+                        db_par.name = def_par.name
+                        db_par.description = def_par.description
+                        db_par.type = def_par.type.name
+                        db_par.default_value = def_par.default_value
+                    session.commit()
+            # delete old module/parameters
+            db_modules = session.query(class_module).filter_by(node_id=db_node.id).all()
+            for db_mod in db_modules:
+                def_mod = next((m for m in def_modules if m.type == db_mod.type), None)
+                if not def_mod:
+                    for db_par in db_mod.parameters:
+                        print(f"---  {db_mod.type}.{db_par.key}", flush=True)
+                        # this delete via DB constraints also osint_source_parameter_value, bot_preset_parameter_value,
+                        # publisher_preset_parameter_value, product_type_parameter_value tables
+                        session.delete(db_par)
+                    print(f"---  {db_mod.type}", flush=True)
+                    session.delete(db_mod)
+                else:
+                    for db_par in db_mod.parameters:
+                        if not any(m.key == db_par.key for m in def_mod.parameters):
+                            print(f"---  {db_mod.type}.{db_par.key}", flush=True)
+                            session.delete(db_par)
+            session.commit()
+
+        # Add new parameter_values in depending objects, delete was processed up via db constraints
+        added = 0
+        match type:
+            case "collectors":
+                caption = "OSINT Sources"
+                query = session.query(Collector, OSINTSource)
+                sources = query.join(OSINTSource, OSINTSource.collector_id == Collector.id).all()
+                for col, osint in sources:
+                    def_mod = next((m for m in def_modules if m.type == col.type), None)
+                    if def_mod:
+                        query = session.query(OSINTSourceParameterValue, ParameterValue, Parameter)
+                        query = query.join(ParameterValue, ParameterValue.id == OSINTSourceParameterValue.parameter_value_id)
+                        query = query.join(Parameter, Parameter.id == ParameterValue.parameter_id)
+                        results = query.filter(OSINTSourceParameterValue.osint_source_id == osint.id).all()
+
+                        db_param_lookup = {param.key: param for _, _, param in results}
+                        for def_par in def_mod.parameters:
+                            if def_par.key not in db_param_lookup:
+                                print(f"+++  {def_par.key}: {osint.name}", flush=True)
+                                db_param = next((p for p in col.parameters if p.key == def_par.key), None)
+                                if db_param:
+                                    added += 1
+                                    db_param_value = ParameterValue(def_par.default_value, db_param)
+                                    osint.parameter_values.append(db_param_value)
+            case "bots":
+                caption = "Bot Presets"
+                query = session.query(Bot, BotPreset)
+                bots = query.join(BotPreset, BotPreset.bot_id == Bot.id).all()
+                for bot, preset in bots:
+                    def_mod = next((m for m in def_modules if m.type == bot.type), None)
+                    if def_mod:
+                        query = session.query(BotPresetParameterValue, ParameterValue, Parameter)
+                        query = query.join(ParameterValue, ParameterValue.id == BotPresetParameterValue.parameter_value_id)
+                        query = query.join(Parameter, Parameter.id == ParameterValue.parameter_id)
+                        results = query.filter(BotPresetParameterValue.bot_preset_id == preset.id).all()
+
+                        db_param_lookup = {param.key: param for _, _, param in results}
+                        for def_par in def_mod.parameters:
+                            if def_par.key not in db_param_lookup:
+                                print(f"+++  {def_par.key}: {preset.name}", flush=True)
+                                db_param = next((p for p in bot.parameters if p.key == def_par.key), None)
+                                if db_param:
+                                    added += 1
+                                    db_param_value = ParameterValue(def_par.default_value, db_param)
+                                    preset.parameter_values.append(db_param_value)
+            case "presenters":
+                caption = "Product Types"
+                query = session.query(Presenter, ProductType)
+                product_types = query.join(ProductType, ProductType.presenter_id == Presenter.id).all()
+                for presenter, prod_type in product_types:
+                    def_mod = next((m for m in def_modules if m.type == presenter.type), None)
+                    if def_mod:
+                        query = session.query(ProductTypeParameterValue, ParameterValue, Parameter)
+                        query = query.join(ParameterValue, ParameterValue.id == ProductTypeParameterValue.parameter_value_id)
+                        query = query.join(Parameter, Parameter.id == ParameterValue.parameter_id)
+                        results = query.filter(ProductTypeParameterValue.product_type_id == prod_type.id).all()
+
+                        db_param_lookup = {param.key: param for _, _, param in results}
+                        for def_par in def_mod.parameters:
+                            if def_par.key not in db_param_lookup:
+                                print(f"+++  {def_par.key}: {prod_type.title}", flush=True)
+                                db_param = next((p for p in presenter.parameters if p.key == def_par.key), None)
+                                if db_param:
+                                    added += 1
+                                    db_param_value = ParameterValue(def_par.default_value, db_param)
+                                    prod_type.parameter_values.append(db_param_value)
+            case "publishers":
+                caption = "Publisher Presets"
+                query = session.query(Publisher, PublisherPreset)
+                publisher_presets = query.join(PublisherPreset, PublisherPreset.publisher_id == Publisher.id).all()
+                for pub, preset in publisher_presets:
+                    def_mod = next((m for m in def_modules if m.type == pub.type), None)
+                    if def_mod:
+                        query = session.query(PublisherPresetParameterValue, ParameterValue, Parameter)
+                        query = query.join(ParameterValue, ParameterValue.id == PublisherPresetParameterValue.parameter_value_id)
+                        query = query.join(Parameter, Parameter.id == ParameterValue.parameter_id)
+                        results = query.filter(PublisherPresetParameterValue.publisher_preset_id == preset.id).all()
+
+                        db_param_lookup = {param.key: param for _, _, param in results}
+                        for def_par in def_mod.parameters:
+                            if def_par.key not in db_param_lookup:
+                                print(f"+++  {def_par.key}: {preset.name}", flush=True)
+                                db_param = next((p for p in pub.parameters if p.key == def_par.key), None)
+                                if db_param:
+                                    added += 1
+                                    db_param_value = ParameterValue(def_par.default_value, db_param)
+                                    preset.parameter_values.append(db_param_value)
+            case _:
+                print(f"ERROR: Invalid module type '{type}' to refresh parameters in depending objects", flush=True)
+                return
+        session.commit()
+        print(f"{caption} parameters: {added} added", flush=True)
+
+    except Exception as e:
+        session.rollback()
+        print(f"Regeneration error: {e}", flush=True)
+        raise Exception("Regeneration failed")  # don't allow migration process continue to next step
+
+
+def get_new_mod_param(type, module_id, parameter_id):
+    """
+    Create a new module parameter based on the type.
+
+    Args:
+        type (str): The type of module. Valid values are "collectors", "bots", "presenters", and "publishers".
+        module_id (int): The ID of the module.
+        parameter_id (int): The ID of the parameter.
+
+    Returns:
+        An instance of the appropriate parameter class based on the type, or None if the type is invalid.
+    """
+    match type:
+        case "collectors":
+            return CollectorParameter(collector_id=module_id, parameter_id=parameter_id)
+        case "bots":
+            return BotParameter(bot_id=module_id, parameter_id=parameter_id)
+        case "presenters":
+            return PresenterParameter(presenter_id=module_id, parameter_id=parameter_id)
+        case "publishers":
+            return PublisherParameter(publisher_id=module_id, parameter_id=parameter_id)
+        case _:
+            print(f"ERROR: Invalid type '{type}' to create module parameter: {type}", flush=True)
+            return None

--- a/src/core/migrations/versions/7a45ba122177_cascade_delete_param.py
+++ b/src/core/migrations/versions/7a45ba122177_cascade_delete_param.py
@@ -1,0 +1,138 @@
+"""add cascade delete to Parameter, Presenter, Collector, Bot and Publisher tables
+
+Revision ID: 7a45ba122177
+Revises: 4cd4c4758a81
+Create Date: 2025-02-21 15:20:44.659875
+
+"""
+
+from alembic import op
+from migrations.regenerate_params import RegenerateParameters
+from sqlalchemy import orm
+from sqlalchemy.orm import declarative_base
+from sqlalchemy import inspect
+import sqlalchemy as sa
+
+Base = declarative_base()
+
+# revision identifiers, used by Alembic.
+revision = "7a45ba122177"
+down_revision = "4cd4c4758a81"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    session = orm.Session(bind=conn)
+
+    delete_previous()
+    # parameter -> collector_parameter, bot_parameter, publisher_parameter
+    op.create_foreign_key(
+        "collector_parameter_parameter_id_fkey", "collector_parameter", "parameter", ["parameter_id"], ["id"], ondelete="CASCADE"
+    )
+    op.create_foreign_key("bot_parameter_parameter_id_fkey", "bot_parameter", "parameter", ["parameter_id"], ["id"], ondelete="CASCADE")
+    op.create_foreign_key(
+        "publisher_parameter_parameter_id_fkey", "publisher_parameter", "parameter", ["parameter_id"], ["id"], ondelete="CASCADE"
+    )
+    # parameter_value -> osint_source_parameter_value, bot_preset_parameter_value, publisher_preset_parameter_value
+    op.create_foreign_key(
+        "osint_source_parameter_value_parameter_value_id_fkey",
+        "osint_source_parameter_value",
+        "parameter_value",
+        ["parameter_value_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "bot_preset_parameter_value_parameter_value_id_fkey",
+        "bot_preset_parameter_value",
+        "parameter_value",
+        ["parameter_value_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "publisher_preset_parameter_value_parameter_value_id_fkey",
+        "publisher_preset_parameter_value",
+        "parameter_value",
+        ["parameter_value_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    # presenter -> presenter_parameter
+    op.create_foreign_key(
+        "presenter_parameter_presenter_id_fkey", "presenter_parameter", "presenter", ["presenter_id"], ["id"], ondelete="CASCADE"
+    )
+    # collector -> collector_parameter
+    op.create_foreign_key(
+        "collector_parameter_collector_id_fkey", "collector_parameter", "collector", ["collector_id"], ["id"], ondelete="CASCADE"
+    )
+    # bot -> bot_parameter
+    op.create_foreign_key("bot_parameter_bot_id_fkey", "bot_parameter", "bot", ["bot_id"], ["id"], ondelete="CASCADE")
+    # publisher -> publisher_parameter
+    op.create_foreign_key(
+        "publisher_parameter_publisher_id_fkey", "publisher_parameter", "publisher", ["publisher_id"], ["id"], ondelete="CASCADE"
+    )
+
+    inspector = inspect(conn)
+    columns = [column["name"] for column in inspector.get_columns("parameter")]
+    if "default_value" not in columns:
+        op.add_column("parameter", sa.Column("default_value", sa.String(), nullable=True))
+
+    # rebuild collectors
+    RegenerateParameters("collectors", session)
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+
+    delete_previous()
+    # parameter -> collector_parameter, bot_parameter, publisher_parameter
+    op.create_foreign_key("collector_parameter_parameter_id_fkey", "collector_parameter", "parameter", ["parameter_id"], ["id"])
+    op.create_foreign_key("bot_parameter_parameter_id_fkey", "bot_parameter", "parameter", ["parameter_id"], ["id"])
+    op.create_foreign_key("publisher_parameter_parameter_id_fkey", "publisher_parameter", "parameter", ["parameter_id"], ["id"])
+    # parameter_value -> osint_source_parameter_value, bot_preset_parameter_value, publisher_preset_parameter_value
+    op.create_foreign_key(
+        "osint_source_parameter_value_parameter_value_id_fkey",
+        "osint_source_parameter_value",
+        "parameter_value",
+        ["parameter_value_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "bot_preset_parameter_value_parameter_value_id_fkey", "bot_preset_parameter_value", "parameter_value", ["parameter_value_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "publisher_preset_parameter_value_parameter_value_id_fkey",
+        "publisher_preset_parameter_value",
+        "parameter_value",
+        ["parameter_value_id"],
+        ["id"],
+    )
+    # presenter -> presenter_parameter
+    op.create_foreign_key("presenter_parameter_presenter_id_fkey", "presenter_parameter", "presenter", ["presenter_id"], ["id"])
+    # collector -> collector_parameter
+    op.create_foreign_key("collector_parameter_collector_id_fkey", "collector_parameter", "collector", ["collector_id"], ["id"])
+    # bot -> bot_parameter
+    op.create_foreign_key("bot_parameter_bot_id_fkey", "bot_parameter", "bot", ["bot_id"], ["id"])
+    # publisher -> publisher_parameter
+    op.create_foreign_key("publisher_parameter_publisher_id_fkey", "publisher_parameter", "publisher", ["publisher_id"], ["id"])
+
+
+def delete_previous():
+    print("Deleting previous constraints...", flush=True)
+    op.drop_constraint("collector_parameter_parameter_id_fkey", "collector_parameter", type_="foreignkey")
+    op.drop_constraint("bot_parameter_parameter_id_fkey", "bot_parameter", type_="foreignkey")
+    op.drop_constraint("publisher_parameter_parameter_id_fkey", "publisher_parameter", type_="foreignkey")
+
+    op.drop_constraint("osint_source_parameter_value_parameter_value_id_fkey", "osint_source_parameter_value", type_="foreignkey")
+    op.drop_constraint("bot_preset_parameter_value_parameter_value_id_fkey", "bot_preset_parameter_value", type_="foreignkey")
+    op.drop_constraint("publisher_preset_parameter_value_parameter_value_id_fkey", "publisher_preset_parameter_value", type_="foreignkey")
+
+    op.drop_constraint("presenter_parameter_presenter_id_fkey", "presenter_parameter", type_="foreignkey")
+    op.drop_constraint("collector_parameter_collector_id_fkey", "collector_parameter", type_="foreignkey")
+    op.drop_constraint("bot_parameter_bot_id_fkey", "bot_parameter", type_="foreignkey")
+    op.drop_constraint("publisher_parameter_publisher_id_fkey", "publisher_parameter", type_="foreignkey")
+    print("Adding new constraints...", flush=True)

--- a/src/core/model/parameter.py
+++ b/src/core/model/parameter.py
@@ -30,6 +30,7 @@ class Parameter(db.Model):
         name (str): Name of parameter.
         description (str): Description of parameter.
         type (ParameterType): Type of parameter.
+        default_value (str): Default value.
     """
 
     id = db.Column(db.Integer, primary_key=True)
@@ -37,10 +38,12 @@ class Parameter(db.Model):
     name = db.Column(db.String(), nullable=False)
     description = db.Column(db.String())
     type = db.Column(db.Enum(ParameterType))
+    default_value = db.Column(db.String(), nullable=True)
 
-    def __init__(self, key, name, description, type):
+    def __init__(self, key, name, description, type, default_value):
         """Initialize Parameter Model."""
         self.key = key
         self.name = name
         self.description = description
         self.type = type
+        self.default_value = default_value

--- a/src/shared/shared/config_base.py
+++ b/src/shared/shared/config_base.py
@@ -20,6 +20,7 @@ class param_type:
     name: str
     description: str
     type: ParameterType
+    default_value: str = ""
 
 
 @dataclass

--- a/src/shared/shared/config_bot.py
+++ b/src/shared/shared/config_bot.py
@@ -17,6 +17,7 @@ class ConfigBot(ConfigBase):
                 "How often and when is this bot doing its job. Examples:<ul><li>10 --- perform the task every 10 minutes</li><li>10:30"
                 " --- perform the task every day at 10:30</li><li>Tuesday,10:30 --- perform the task every Tuesday at 10:30</li></ul>",
                 ParameterType.NUMBER,
+                "180",
             )
         ]
 
@@ -28,9 +29,15 @@ class ConfigBot(ConfigBase):
         mod.parameters = self.add_default()
         mod.parameters.extend(
             [
-                param_type("SOURCE_GROUP", "Source Group", "OSINT Source group to inspect", ParameterType.STRING),
-                param_type("REGULAR_EXPRESSION", "Regular Expression", "Regular expression for data analysis", ParameterType.STRING),
-                param_type("ATTRIBUTE_NAME", "Attribute name", "Name of attribute for extracted data", ParameterType.STRING),
+                param_type("SOURCE_GROUP", "Source Group", "OSINT Source group to inspect", ParameterType.STRING, "Default"),
+                param_type(
+                    "REGULAR_EXPRESSION",
+                    "Regular Expression",
+                    "Regular expression for data analysis",
+                    ParameterType.STRING,
+                    "CVE-\\d{4}-\\d+",
+                ),
+                param_type("ATTRIBUTE_NAME", "Attribute name", "Name of attribute for extracted data", ParameterType.STRING, "CVE"),
             ]
         )
         self.modules.append(mod)

--- a/src/shared/shared/config_collector.py
+++ b/src/shared/shared/config_collector.py
@@ -19,6 +19,7 @@ class ConfigCollector(ConfigBase):
                 "Refresh interval in minutes (0 to disable)",
                 "How often is this collector queried for new data",
                 ParameterType.NUMBER,
+                "180",
             ),
         ]
 
@@ -54,6 +55,7 @@ class ConfigCollector(ConfigBase):
                     "Limit for article links",
                     "OPTIONAL: Maximum number of article links to process. Default: all",
                     ParameterType.NUMBER,
+                    "10",
                 ),
             ]
         )
@@ -173,6 +175,7 @@ class ConfigCollector(ConfigBase):
                     "Limit for article links",
                     "OPTIONAL: Maximum number of article links to process. Default: all",
                     ParameterType.NUMBER,
+                    "10",
                 ),
                 # parsing a single article
                 param_type("TITLE_SELECTOR", "SELECTOR at ARTICLE: Article title", "Selector for article title", ParameterType.STRING),

--- a/src/shared/shared/config_presenter.py
+++ b/src/shared/shared/config_presenter.py
@@ -13,28 +13,68 @@ class ConfigPresenter(ConfigBase):
         self.modules: List[module_type] = []
 
         mod = module_type("HTML_PRESENTER", "HTML Presenter", "Presenter for generating html documents")
-        mod.parameters = [param_type("HTML_TEMPLATE_PATH", "HTML template with its path", "Path of html template file", ParameterType.STRING)]
+        mod.parameters = [
+            param_type(
+                "HTML_TEMPLATE_PATH",
+                "HTML template with its path",
+                "Path of html template file",
+                ParameterType.STRING,
+                "/app/templates/template.html",
+            )
+        ]
         self.modules.append(mod)
 
         mod = module_type("JSON_PRESENTER", "JSON Presenter", "Presenter for generating JSON files")
-        mod.parameters = [param_type("JSON_INDENT", "JSON indent", "Indentation of JSON output", ParameterType.NUMBER)]
+        mod.parameters = [param_type("JSON_INDENT", "JSON indent", "Indentation of JSON output", ParameterType.NUMBER, "4")]
         self.modules.append(mod)
 
         mod = module_type("MESSAGE_PRESENTER", "MESSAGE Presenter", "Presenter for generating message title and body")
         mod.parameters = [
-            param_type("TITLE_TEMPLATE_PATH", "Title template", "Path of message title template file", ParameterType.STRING),
-            param_type("BODY_TEMPLATE_PATH", "Body template", "Path to message body template file", ParameterType.STRING),
+            param_type(
+                "TITLE_TEMPLATE_PATH",
+                "Title template",
+                "Path of message title template file",
+                ParameterType.STRING,
+                "/app/templates/email_subject_template.txt",
+            ),
+            param_type(
+                "BODY_TEMPLATE_PATH",
+                "Body template",
+                "Path to message body template file",
+                ParameterType.STRING,
+                "/app/templates/email_body_template.txt",
+            ),
         ]
         self.modules.append(mod)
 
         mod = module_type("MISP_PRESENTER", "MISP Presenter", "Presenter for generating MISP platform")
-        mod.parameters = [param_type("MISP_TEMPLATE_PATH", "MISP template with its path", "Path of MISP template file", ParameterType.STRING)]
+        mod.parameters = [
+            param_type(
+                "MISP_TEMPLATE_PATH",
+                "MISP template with its path",
+                "Path of MISP template file",
+                ParameterType.STRING,
+                "/app/templates/misp.json",
+            )
+        ]
         self.modules.append(mod)
 
         mod = module_type("PDF_PRESENTER", "PDF Presenter", "Presenter for generating PDF documents")
-        mod.parameters = [param_type("PDF_TEMPLATE_PATH", "Template path", "Path of header template file", ParameterType.STRING)]
+        mod.parameters = [
+            param_type(
+                "PDF_TEMPLATE_PATH", "Template path", "Path of header template file", ParameterType.STRING, "/app/templates/pdf_template.html"
+            )
+        ]
         self.modules.append(mod)
 
         mod = module_type("TEXT_PRESENTER", "TEXT Presenter", "Presenter for generating text documents")
-        mod.parameters = [param_type("TEXT_TEMPLATE_PATH", "TEXT template with its path", "Path of text template file", ParameterType.STRING)]
+        mod.parameters = [
+            param_type(
+                "TEXT_TEMPLATE_PATH",
+                "TEXT template with its path",
+                "Path of text template file",
+                ParameterType.STRING,
+                "/app/templates/template-show-all-data.txt",
+            )
+        ]
         self.modules.append(mod)

--- a/src/shared/shared/config_publisher.py
+++ b/src/shared/shared/config_publisher.py
@@ -15,12 +15,12 @@ class ConfigPublisher(ConfigBase):
         mod = module_type("EMAIL_PUBLISHER", "EMAIL Publisher", "Publisher for publishing by email")
         mod.parameters = [
             param_type("SMTP_SERVER", "SMTP server", "SMTP server for sending emails", ParameterType.STRING),
-            param_type("SMTP_SERVER_PORT", "SMTP server port", "SMTP server port for sending emails", ParameterType.STRING),
+            param_type("SMTP_SERVER_PORT", "SMTP server port", "SMTP server port for sending emails", ParameterType.STRING, "587"),
             param_type("EMAIL_USERNAME", "Email username", "Username for email account", ParameterType.STRING),
             param_type("EMAIL_PASSWORD", "Email password", "Password for email account", ParameterType.STRING),
             param_type("EMAIL_SENDER", "Email sender", "Email address of the sender", ParameterType.STRING),
             param_type("EMAIL_RECIPIENT", "Email recipient", "Email address of the recipient", ParameterType.STRING),
-            param_type("EMAIL_SUBJECT", "Email subject", "Text of email subject", ParameterType.STRING),
+            param_type("EMAIL_SUBJECT", "Email subject", "Text of email subject", ParameterType.STRING, "Security Warning"),
             param_type("EMAIL_MESSAGE", "Email message", "Text of email message", ParameterType.STRING),
             param_type("EMAIL_SIGN", "Email signature", "File used for signing or auto", ParameterType.STRING),
             param_type("EMAIL_SIGN_PASSWORD", "Email signature password", "Password for signing file", ParameterType.STRING),

--- a/src/shared/shared/schema/parameter.py
+++ b/src/shared/shared/schema/parameter.py
@@ -29,6 +29,7 @@ class ParameterSchema(Schema):
         name (fields.Str): The name of the parameter.
         description (fields.Str): A brief description of the parameter.
         type (fields.Enum): The type of the parameter, which is an enumeration of ParameterType.
+        default_value (fields.Str): Default value.
     Methods:
         make_parameter(data, **kwargs):
             Creates a Parameter instance from the deserialized data.
@@ -39,6 +40,7 @@ class ParameterSchema(Schema):
     name = fields.Str()
     description = fields.Str()
     type = fields.Enum(ParameterType)
+    default_value = fields.Str()
 
     @post_load
     def make_parameter(self, data, **kwargs):
@@ -61,7 +63,7 @@ class Parameter:
             Initializes a new Parameter instance.
     """
 
-    def __init__(self, id, key, name, description, type):
+    def __init__(self, id, key, name, description, type, default_value):
         """Initialize a new Parameter instance.
 
         Args:
@@ -76,6 +78,7 @@ class Parameter:
         self.name = name
         self.description = description
         self.type = type
+        self.default_value = default_value
 
 
 class ParameterExportSchema(Schema):


### PR DESCRIPTION
- Added cascade delete for Parameter, Presenter, Collector, Bot and Publisher tables
- Added cascade delete for Parameter_Values tables: osint_source_parameter_value, bot_preset_parameter_value, publisher_preset_parameter_value
- Added a "refresh" functionality for parameters in Presenter, Collector, Bot and Publisher. This can be called in Migration process. It was not possible to this time - you had to delete nodes (and all data) to reflect the new changes. Existing records then miss some new parameters that can cause errors in logs or missing functionality.
- Added default_value to Parameter table. In this moment it's only used for automatic creating of new parameters that are added by migration process. In future we add these default values to GUI.