### PR TITLE
Fixed error in Presenter: default_value: Field may not be null.

### DIFF
--- a/src/shared/shared/schema/parameter.py
+++ b/src/shared/shared/schema/parameter.py
@@ -40,7 +40,7 @@ class ParameterSchema(Schema):
     name = fields.Str()
     description = fields.Str()
     type = fields.Enum(ParameterType)
-    default_value = fields.Str()
+    default_value = fields.Str(allow_none=True)
 
     @post_load
     def make_parameter(self, data, **kwargs):


### PR DESCRIPTION
This error is caused by #546 Added posibility "refresh" parameters for Presenter, Collector, Bot, and Publisher and their products 