### PR TITLE
added HTTP security headers

### DIFF
--- a/src/gui/extras/default.conf
+++ b/src/gui/extras/default.conf
@@ -12,7 +12,6 @@ server {
     #error_page  404              /404.html;
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header X-XSS-Protection "1; mode=block" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Robots-Tag "noindex, nofollow, noarchive, nosnippet, noimageindex, notranslate" always;
     add_header X-Content-Type-Options "nosniff" always;

--- a/src/gui/extras/default.conf
+++ b/src/gui/extras/default.conf
@@ -8,8 +8,28 @@ server {
         try_files $uri /index.html;
 
     }
-
+    server_tokens off;
     #error_page  404              /404.html;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Robots-Tag "noindex, nofollow, noarchive, nosnippet, noimageindex, notranslate" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(),
+     autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(),
+     document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(),
+     fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(),
+     navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(),
+     sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=(), clipboard-read=(), clipboard-write=(), gamepad=(),
+     speaker-selection=(), conversion-measurement=(), focus-without-user-activation=(), hid=(), idle-detection=(),
+     interest-cohort=(), serial=(), sync-script=(), trust-token-redemption=(), window-placement=(), vertical-scroll=()" always;
+    add_header Referrer-Policy "strict-origin" always;
+    add_header Cross-Origin-Embedder-Policy "require-corp" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Content-Security-Policy "default-src 'self'; font-src https://fonts.gstatic.com:443 'self';
+     script-src-elem 'self' 'unsafe-inline'; style-src-attr 'self' 'unsafe-inline'; style-src-elem https://fonts.googleapis.com:443 'self' 'unsafe-inline'" always;
 
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {


### PR DESCRIPTION
Added following security headers:

- [HSTS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Strict-Transport-Security)
- [X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options)
- [X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options)
- [Permissions-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy)
- [Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy)
- [Cross-Origin-Embedder-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Embedder-Policy)
- [Cross-Origin-Resource-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Resource-Policy)
- [Cross-Origin-Opener-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy)
- [Content-Security-Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy)

Also added:
- [X-Robots-Tag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Robots-Tag)

It would probably be beneficial to look into reasons why "unsafe-inline" in CSP is necessary.