### PR TITLE
Sorting of OSINT sources unintuitive #19

### DIFF
--- a/src/core/model/osint_source.py
+++ b/src/core/model/osint_source.py
@@ -186,7 +186,7 @@ class OSINTSource(db.Model):
                 )
             )
 
-        return query.order_by(db.asc(OSINTSource.name)).all(), query.count()
+        return query.order_by(func.lower(OSINTSource.name)).all(), query.count()
 
     @classmethod
     def get_by_id(cls, id):


### PR DESCRIPTION
OSINT sources are sorted a < z < A < Z. Ignorance of case is more intuitive in this case.