### PR TITLE
Unify button order in news item screens

### DIFF
--- a/src/gui/src/components/assess/NewsItemAggregateDetail.vue
+++ b/src/gui/src/components/assess/NewsItemAggregateDetail.vue
@@ -15,9 +15,6 @@
                             <v-btn v-if="canModify" small icon @click.stop="cardItemToolbar('ungroup')" :title="$t('assess.tooltip.ungroup_item')">
                                 <v-icon small color="accent">mdi-ungroup</v-icon>
                             </v-btn>
-                            <v-btn v-if="canDelete" small icon @click.stop="showMsgBox" :title="$t('assess.tooltip.delete_item')">
-                                <v-icon small color="accent">mdi-delete</v-icon>
-                            </v-btn>
                             <v-btn v-if="canCreateReport" small icon @click.stop="cardItemToolbar('new')" :title="$t('assess.tooltip.analyze_item')">
                                 <v-icon small color="accent">mdi-file-outline</v-icon>
                             </v-btn>
@@ -32,6 +29,9 @@
                             </v-btn>
                             <v-btn v-if="canModify" small icon @click.stop="cardItemToolbar('unlike')" :title="$t('assess.tooltip.dislike_item')">
                                 <v-icon small :color="buttonStatus(news_item.me_dislike)">mdi-thumb-down</v-icon>
+                            </v-btn>
+                            <v-btn v-if="canDelete" small icon @click.stop="showMsgBox" :title="$t('assess.tooltip.delete_item')">
+                                <v-icon small color="accent">mdi-delete</v-icon>
                             </v-btn>
                         </div>
 

--- a/src/gui/src/components/assess/NewsItemDetail.vue
+++ b/src/gui/src/components/assess/NewsItemDetail.vue
@@ -14,9 +14,6 @@
                             <v-btn v-if="canModify" small icon @click.stop="cardItemToolbar('ungroup')" :title="$t('assess.tooltip.ungroup_item')">
                                 <v-icon small color="accent">mdi-ungroup</v-icon>
                             </v-btn>
-                            <v-btn v-if="canDelete" small icon @click.stop="showMsgBox" :title="$t('assess.tooltip.delete_item')">
-                                <v-icon small color="accent">mdi-delete</v-icon>
-                            </v-btn>
                             <a v-if="canAccess" :href="news_item.news_item_data.link" target="_blank" rel="noreferrer" :title="$t('assess.tooltip.open_source')">
                                 <v-btn small icon>
                                     <v-icon small color="accent">mdi-open-in-app</v-icon>
@@ -33,6 +30,9 @@
                             </v-btn>
                             <v-btn v-if="canModify" small icon @click.stop="cardItemToolbar('unlike')" :title="$t('assess.tooltip.dislike_item')">
                                 <v-icon small :color="buttonStatus(news_item.me_dislike)">mdi-thumb-down</v-icon>
+                            </v-btn>
+                            <v-btn v-if="canDelete" small icon @click.stop="showMsgBox" :title="$t('assess.tooltip.delete_item')">
+                                <v-icon small color="accent">mdi-delete</v-icon>
                             </v-btn>
                         </div>
 

--- a/src/gui/src/components/assess/NewsItemSingleDetail.vue
+++ b/src/gui/src/components/assess/NewsItemSingleDetail.vue
@@ -12,9 +12,6 @@
                         <v-spacer></v-spacer>
 
                         <div v-if="!multiSelectActive && !analyze_selector">
-                            <v-btn v-if="canDelete" small icon @click.stop="showMsgBox()" :title="$t('assess.tooltip.delete_item')">
-                                <v-icon small color="accent">mdi-delete</v-icon>
-                            </v-btn>
                             <a v-if="canAccess" :href="news_item.news_items[0].news_item_data.link" rel="noreferrer" target="_blank" :title="$t('assess.tooltip.open_source')">
                                 <v-btn small icon>
                                     <v-icon small color="accent">mdi-open-in-app</v-icon>
@@ -35,6 +32,9 @@
                             </v-btn>
                             <v-btn v-if="canModify" small icon @click.stop="cardItemToolbar('unlike')" :title="$t('assess.tooltip.dislike_item')">
                                 <v-icon small :color="buttonStatus(news_item.me_dislike)">mdi-thumb-down</v-icon>
+                            </v-btn>
+                            <v-btn v-if="canDelete" small icon @click.stop="showMsgBox()" :title="$t('assess.tooltip.delete_item')">
+                                <v-icon small color="accent">mdi-delete</v-icon>
                             </v-btn>
                         </div>
 


### PR DESCRIPTION
Unify buttons (delete) in same order as in main news item screen. Now it's same in Single news item detail, Aggregate Detail and News item detail screen. 
Issue #39 Assess: Order of action buttons in CardAssess and NewsItemDetail differ 