### PR TITLE
Added posibility manualy regenerate all parameters + Fix #572

### DIFF
--- a/src/core/db_migration.py
+++ b/src/core/db_migration.py
@@ -2,11 +2,12 @@
 """Database migration script."""
 
 import sys
-from alembic import command
+from alembic import command, script
+from alembic.runtime.migration import MigrationContext
 from flask import Flask
 from flask_migrate import Migrate
 from managers import db_manager
-
+from migrations.regenerate_params import regenerate_all
 
 command_name = ""
 if len(sys.argv) > 1:
@@ -26,10 +27,22 @@ with app.app_context():
     elif command_name == "current":
         command.current(config)
     elif command_name == "upgrade":
-        command.upgrade(config, revision="+1")
+        connection = db_manager.db.engine.connect()
+        mc = MigrationContext.configure(connection)
+        current_rev = mc.get_current_revision()
+        script_dir = script.ScriptDirectory.from_config(config)
+        head_rev = script_dir.get_current_head()
+        if current_rev != head_rev:
+            command.upgrade(config, revision="+1")
+        else:
+            print("Already at the latest revision:", head_rev, flush=True)
     elif command_name == "downgrade":
         command.downgrade(config, revision="-1")
     elif command_name == "revision":
         command.revision(config)
+    elif command_name == "regenerate":
+        with db_manager.db.engine.begin() as connection:
+            regenerate_all(connection)
     else:
         command.upgrade(config, revision="head")
+    db_manager.db.engine.dispose()


### PR DESCRIPTION
Added: possibility manually regenerate all parameters (just run in core: python db_migration.py regenerate)
Fixed: #572 Error when manually run migration on the already latest version