### PR TITLE
Fixed errors when starting or restarting the entire Taranis (delayed start, between containers)

### DIFF
--- a/src/bots/bots/base_bot.py
+++ b/src/bots/bots/base_bot.py
@@ -106,6 +106,7 @@ class BaseBot:
 
     def initialize(self):
         """Initialize the bot by retrieving bot presets and scheduling jobs based on the preset intervals."""
+        logger.debug(f"{self.name}: Awaiting initialization of CORE (timeout: 20s)")
         time.sleep(20)  # wait for the CORE
         time_manager.cancel_all_jobs()
         response, code = CoreApi.get_bots_presets(self.type)

--- a/src/bots/managers/sse_manager.py
+++ b/src/bots/managers/sse_manager.py
@@ -4,6 +4,7 @@ import os
 import requests
 import sseclient
 import threading
+import time
 from config import Config
 from managers import bots_manager
 from shared.log_manager import logger
@@ -16,6 +17,8 @@ def initialize():
 
         @classmethod
         def run(cls):
+            logger.debug("SSE: Awaiting initialization of CORE (timeout: 20s)")
+            time.sleep(20)  # wait for the CORE
             url = os.getenv("TARANIS_NG_CORE_SSE")
             while True:  # Keep the thread running
                 try:

--- a/src/collectors/collectors/base_collector.py
+++ b/src/collectors/collectors/base_collector.py
@@ -218,6 +218,7 @@ class BaseCollector:
 
     def refresh(self):
         """Refresh the OSINT sources for the collector."""
+        logger.debug(f"{self.name}: Awaiting initialization of CORE (timeout: 20s)")
         time.sleep(20)  # wait for the CORE
         logger.info(f"Core API requested a refresh of OSINT sources for {self.name}...")
 

--- a/src/collectors/managers/collectors_manager.py
+++ b/src/collectors/managers/collectors_manager.py
@@ -20,6 +20,8 @@ status_report_thread = None
 
 def reportStatus():
     """Continuously send status updates to the Core API."""
+    logger.debug("Report status: Awaiting initialization of CORE (timeout: 20s)")
+    time.sleep(20)  # wait for the CORE
     while True:
         logger.debug("Sending status update...")
         response, status_code = CoreApi.update_collector_status()


### PR DESCRIPTION
- Fixed connection error in "Bots/SSE" and "Collector/Report status" when starting or restarting the entire Taranis. Core is not ready yet, and we need to connect a little bit later. Now the start logs are error free.
- Added to logs: "Awaiting initialization of CORE (timeout: 20s)" message to indicate background activity for delayed processes.