### PR TITLE
Improve log clarity in Check-if-modified

### DIFF
--- a/src/bots/bots/base_bot.py
+++ b/src/bots/bots/base_bot.py
@@ -117,7 +117,8 @@ class BaseBot:
 
             for preset in self.bot_presets:
                 preset.last_error_message = None
-                preset.logger = create_logger(log_prefix=f"{self.name} '{preset.name}'")
+                preset.log_prefix = f"{self.name} '{preset.name}'"
+                preset.logger = create_logger(log_prefix=preset.log_prefix)
                 preset.logger.stored_message_levels = ["error", "exception", "warning", "critical"]
                 interval = preset.parameter_values["REFRESH_INTERVAL"]
                 # do not schedule if no interval is set

--- a/src/collectors/collectors/rss_collector.py
+++ b/src/collectors/collectors/rss_collector.py
@@ -64,7 +64,7 @@ class RSSCollector(BaseCollector):
 
         # Check if the feed has been modified since the last collection
         if last_collected:
-            if BaseCollector.not_modified(feed_url, last_collected, opener, user_agent):
+            if BaseCollector.not_modified(feed_url, last_collected, self.source.log_prefix, opener, user_agent):
                 return None
 
         self.source.logger.debug(f"Fetching feed from URL: {feed_url}")

--- a/src/collectors/collectors/web_collector.py
+++ b/src/collectors/collectors/web_collector.py
@@ -476,7 +476,7 @@ class WebCollector(BaseCollector):
         opener = urllib.request.build_opener(proxy_handler).open if proxy_handler else urllib.request.urlopen
         not_modified = False
         if self.last_collected:
-            if not_modified := BaseCollector.not_modified(self.web_url, self.last_collected, opener, self.user_agent):
+            if not_modified := BaseCollector.not_modified(self.web_url, self.last_collected, self.source.log_prefix, opener, self.user_agent):
                 self.source.logger.info("Will not collect the feed because nothing has changed.")
                 BaseCollector.publish([], self.source)
 


### PR DESCRIPTION
Fixed missing source name in Check-if-modified log message. In multithreaded execution, adjacent log lines made it difficult to associate messages with their respective sources.