### PR TITLE
Fix error in Presenters: ModuleNotFoundError: No module named 'bs4'

### DIFF
--- a/src/presenters/requirements.txt
+++ b/src/presenters/requirements.txt
@@ -1,3 +1,4 @@
+beautifulsoup4==4.13.4  # used in common
 cvss==3.4
 Flask==3.1.0
 Flask-Cors==5.0.1


### PR DESCRIPTION
Fix error in Presenters: ModuleNotFoundError: No module named 'bs4' (BeautifulSoup) due moving print_news_item to news_item.py.