### PR TITLE
Fix error in Bots: ModuleNotFoundError: No module named 'bs4'

### DIFF
--- a/src/bots/requirements.txt
+++ b/src/bots/requirements.txt
@@ -1,3 +1,4 @@
+beautifulsoup4==4.13.4  # used in common
 Flask==3.1.0
 Flask-Cors==5.0.1
 Flask-RESTful==0.3.10


### PR DESCRIPTION
Fix error in Bots: ModuleNotFoundError: No module named 'bs4' (BeautifulSoup) due moving print_news_item to news_item.py.