### PR TITLE
Fixed authentification for collectors when exists multiple nodes

### DIFF
--- a/src/core/managers/auth_manager.py
+++ b/src/core/managers/auth_manager.py
@@ -407,6 +407,7 @@ def api_key_required(key_type=None):
 
             if key_type == "collectors":
                 master_class = CollectorsNode
+                master_id = kwargs.get("collector_id")
             elif key_type == "publishers":
                 master_class = PublishersNode
             elif key_type == "bots":
@@ -423,7 +424,12 @@ def api_key_required(key_type=None):
             #         class_name = frame.frame.f_locals['self'].__class__.__name__
             #         break
             # print(f"api_key_required: {key_type},  {class_name}.{fn.__name__}", flush=True)
-            validated_object = master_class.get_by_api_key(api_key)
+            if master_id:
+                # in case the same api_key is used for different nodes, we also need to check the node ID (if available)
+                validated_object = master_class.get_by_api_key_id(api_key, master_id)
+            else:
+                # return first node with valid api_key
+                validated_object = master_class.get_by_api_key(api_key)
             if not validated_object:
                 api_key = log_manager.sensitive_value(api_key)
                 log_manager.store_auth_error_activity(f"Incorrect api key: {api_key} for external access with type '{key_type}'")

--- a/src/core/model/collectors_node.py
+++ b/src/core/model/collectors_node.py
@@ -77,6 +77,18 @@ class CollectorsNode(db.Model):
         return cls.query.filter_by(api_key=api_key).first()
 
     @classmethod
+    def get_by_api_key_id(cls, api_key, id):
+        """Get a node by API key and node ID (more nodes can have the same key).
+
+        Args:
+            api_key (str): The API key
+            id (str): The ID of the collectors node
+        Returns:
+            (CollectorsNode): The CollectorsNode object
+        """
+        return cls.query.filter_by(api_key=api_key, id=id).first()
+
+    @classmethod
     def get_all(cls):
         """Get all nodes.
 


### PR DESCRIPTION
Fixed verification for collectors in case when more nodes share the same API_KEY. Warning: "Collector ID does not match"