### PR TITLE
Fixed error message in Bots (master_id)

### DIFF
--- a/src/core/managers/auth_manager.py
+++ b/src/core/managers/auth_manager.py
@@ -405,6 +405,7 @@ def api_key_required(key_type=None):
                 return error
             api_key = get_api_key()
 
+            master_id = None
             if key_type == "collectors":
                 master_class = CollectorsNode
                 master_id = kwargs.get("collector_id")


### PR DESCRIPTION
Fixed error message in Bots: cannot access local variable 'master_id' where it is not associated with a value. It was caused previous commit.