### PR TITLE
Correct deprecated jwt.decode() in python-keycloak

### DIFF
--- a/src/core/auth/keycloak_authenticator.py
+++ b/src/core/auth/keycloak_authenticator.py
@@ -61,10 +61,7 @@ class KeycloakAuthenticator(BaseAuthenticator):
 
         try:
             # decode token to get user data
-            if old_keycloak:
-                data = jwt.decode(data["access_token"], verify=False)
-            else:
-                data = jwt.decode(data["access_token"], options={"verify_signature": False}, algorithms=["RS256"])
+            data = jwt.decode(data["access_token"], options={"verify_signature": False}, algorithms=["RS256"])
 
         except Exception as ex:
             msg = "Keycloak returned invalid access_token"


### PR DESCRIPTION
There was change in jwt.decode() function by upgrading python-keycloak library