### PR TITLE
Login page is visible for logged user

### DIFF
--- a/src/gui/src/views/Login.vue
+++ b/src/gui/src/views/Login.vue
@@ -98,6 +98,10 @@
             },
         },
         mounted() {
+            if (this.isAuthenticated()) {
+                this.$router.push('/dashboard');
+                return;
+            }
             if (this.$store.getters.hasExternalLoginUrl) {
                 if (this.$route.query.code !== undefined && this.$route.query.session_state !== undefined) {
                     this.authenticate();


### PR DESCRIPTION
Fix #729 Login page is visible for logged in user
This should not be visible and should just redirect user to dashboard page.