### PR TITLE
Fixed TAG CLOUD ignoring stop words

### DIFF
--- a/src/collectors/collectors/web_collector.py
+++ b/src/collectors/collectors/web_collector.py
@@ -91,8 +91,7 @@ class WebCollector(BaseCollector):
         selector = selector_split[1].lstrip()
         return prefix, selector
 
-    @classmethod
-    def __get_element_locator(cls, element_selector):
+    def __get_element_locator(self, element_selector):
         """Extract a single element from the headless browser by selector.
 
         Parameters:
@@ -100,15 +99,14 @@ class WebCollector(BaseCollector):
         Returns:
             locator (tuple): A tuple containing the locator type and the selector.
         """
-        prefix, selector = cls.__get_prefix_and_selector(element_selector)
+        prefix, selector = self.__get_prefix_and_selector(element_selector)
 
-        by = cls.SELECTOR_MAP.get(prefix)
+        by = self.SELECTOR_MAP.get(prefix)
         if by and selector:
             return (by, selector)
         return None
 
-    @classmethod
-    def __find_element_by(cls, driver, element_selector):
+    def __find_element_by(self, driver, element_selector):
         """Extract single element from the headless browser by selector.
 
         Parameters:
@@ -117,9 +115,9 @@ class WebCollector(BaseCollector):
         Returns:
             The extracted element.
         """
-        prefix, selector = cls.__get_prefix_and_selector(element_selector)
+        prefix, selector = self.__get_prefix_and_selector(element_selector)
 
-        by = cls.SELECTOR_MAP.get(prefix)
+        by = self.SELECTOR_MAP.get(prefix)
         if by and selector:
             try:
                 return driver.find_element(by, selector)
@@ -127,8 +125,7 @@ class WebCollector(BaseCollector):
                 return None
         return None
 
-    @classmethod
-    def __find_element_text_by(cls, driver, element_selector, return_none=False):
+    def __find_element_text_by(self, driver, element_selector, return_none=False):
         """Find the text of an element identified by the given selector using the provided driver.
 
         Parameters:
@@ -147,15 +144,20 @@ class WebCollector(BaseCollector):
 
         try:
             if element_selector:
-                ret = cls.__find_element_by(driver, element_selector)
-                return ret.text if ret else failure_retval
+                ret = self.__find_element_by(driver, element_selector)
+                if ret:
+                    if ret.text == "":
+                        self.source.logger.warning(f"Element found, but text content is empty: {element_selector}")
+                    return ret.text
+                else:
+                    self.source.logger.warning(f"Element not found: {element_selector}")
+                    return failure_retval
             else:
                 return failure_retval
         except NoSuchElementException as e:  # noqa F841
             return failure_retval
 
-    @classmethod
-    def __find_elements_by(cls, driver, element_selector):
+    def __find_elements_by(self, driver, element_selector):
         """Extract list of elements from the headless browser by selector.
 
         Parameters:
@@ -164,9 +166,9 @@ class WebCollector(BaseCollector):
         Returns:
             A list of elements found using the given selector.
         """
-        prefix, selector = cls.__get_prefix_and_selector(element_selector)
+        prefix, selector = self.__get_prefix_and_selector(element_selector)
 
-        by = cls.SELECTOR_MAP.get(prefix)
+        by = self.SELECTOR_MAP.get(prefix)
         if by and selector:
             try:
                 return driver.find_elements(by, selector)
@@ -174,8 +176,7 @@ class WebCollector(BaseCollector):
                 return []
         return []
 
-    @classmethod
-    def __safe_find_elements_by(cls, driver, element_selector):
+    def __safe_find_elements_by(self, driver, element_selector):
         """Safely find elements by the given element selector using the provided driver.
 
         Parameters:
@@ -185,13 +186,12 @@ class WebCollector(BaseCollector):
             A list of elements matching the given selector, or None if no elements are found.
         """
         try:
-            elements = cls.__find_elements_by(driver, element_selector)
+            elements = self.__find_elements_by(driver, element_selector)
             return elements if elements else None
         except NoSuchElementException as error:  # noqa F841
             return None
 
-    @classmethod
-    def __wait_for_new_tab(cls, browser, timeout, current_tab):
+    def __wait_for_new_tab(self, browser, timeout, current_tab):
         """Wait for a new tab to open in the browser.
 
         Parameters:
@@ -655,7 +655,7 @@ class WebCollector(BaseCollector):
         """
         current_url = browser.current_url
 
-        # self.source.logger.warning(scope.get_attribute("outerHTML"))
+        # print(browser.page_source, flush=True)
 
         title = self.__find_element_text_by(scope, self.selectors["title"])
 

--- a/src/core/api/dashboard.py
+++ b/src/core/api/dashboard.py
@@ -22,9 +22,9 @@ class Dashboard(Resource):
             (dict): The dashboard data.
         """
         try:
-            tag_cloud_day = 0
+            number_of_days = 0
             if "tag_cloud_day" in request.args and request.args["tag_cloud_day"]:
-                tag_cloud_day = min(int(request.args["tag_cloud_days"]), 7)
+                number_of_days = min(int(request.args["tag_cloud_days"]), 7)
         except Exception as ex:
             msg = "Get Dashboard failed"
             logger.exception(f"{msg}: {ex}")
@@ -36,7 +36,7 @@ class Dashboard(Resource):
         report_items_in_progress = ReportItem.count_all(False)
         total_database_items = total_news_items + total_products + report_items_completed + report_items_in_progress
         latest_collected = NewsItemData.latest_collected()
-        grouped_words = TagCloud.get_grouped_words(tag_cloud_day)
+        grouped_words = TagCloud.get_grouped_words(number_of_days)
         return {
             "total_news_items": total_news_items,
             "total_products": total_products,

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -68,7 +68,6 @@ class Config(object):
     DB_PASSWORD = read_secret("postgres_password")
     SQLALCHEMY_DATABASE_URI = f"postgresql+psycopg://{DB_USER}:{DB_PASSWORD}@{DB_URL}/{DB_DATABASE}"
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    SQLALCHEMY_ECHO = os.getenv("DEBUG_SQL", "false").lower() == "true"  # DEBUG SQL Queries
 
     if "DB_POOL_SIZE" in os.environ:
         DB_POOL_SIZE = os.getenv("DB_POOL_SIZE")

--- a/src/core/managers/log_manager.py
+++ b/src/core/managers/log_manager.py
@@ -28,6 +28,10 @@ gunicorn_logger.setLevel(logging_level)
 # setup syslog logger
 sys_logger = logging.getLogger("SysLogger")
 sys_logger.setLevel(logging_level)
+# DEBUG SQL Queries
+if os.getenv("DEBUG_SQL", "false").lower() == "true":
+    sql_logger = logging.getLogger("sqlalchemy.engine")
+    sql_logger.setLevel(logging.INFO)
 
 
 # LOG_SENSITIVE_DATA=no (or undefined) - remove sensitive data

--- a/src/core/model/tag_cloud.py
+++ b/src/core/model/tag_cloud.py
@@ -57,14 +57,14 @@ class TagCloud(db.Model):
         db.session.commit()
 
     @classmethod
-    def get_grouped_words(cls, tag_cloud_day):
+    def get_grouped_words(cls, number_of_days):
         """
         Retrieve grouped words from the tag cloud for a specific day.
 
-        :param tag_cloud_day: The number of days ago to filter the tag cloud.
+        :param number_of_days: The number of days ago to filter the tag cloud.
         :return: List of grouped words with their quantities.
         """
-        day_filter = (datetime.datetime.now() - datetime.timedelta(days=tag_cloud_day)).date()
+        day_filter = (datetime.datetime.now() - datetime.timedelta(days=number_of_days)).date()
         stopwords = WordListEntry.stopwords_subquery()
         grouped_words = (
             db.session.query(TagCloud.word, label("word_quantity", func.sum(TagCloud.word_quantity)))

--- a/src/core/model/word_list.py
+++ b/src/core/model/word_list.py
@@ -398,10 +398,9 @@ class WordListEntry(db.Model):
         """
         return (
             db.session.query(func.lower(WordListEntry.value))
-            .distinct()
             .group_by(WordListEntry.value)
             .join(WordListCategory, WordListCategory.id == WordListEntry.word_list_category_id)
             .join(WordList, WordList.id == WordListCategory.word_list_id)
-            .filter(WordList.use_for_stop_words is True)
+            .filter(WordList.use_for_stop_words == True)  # noqa: E712
             .scalar_subquery()
         )


### PR DESCRIPTION
- fixed bug that TAG CLOUD doesn't take in account stop words
- remove redundant .distinct() from TAG CLOUD query (there is already .group_by)
- remove SQL duplicity logs when SQL debugging is ON
- web collector added warnings: "Element found, but text content is empty", "Element not found" that can help you find wrong defined selectors
- web collector: changed rest of functions and removed @classmethod attribute. Now is unified