### PR TITLE
uv and ruff in GitHub Actions

### DIFF
--- a/.github/workflows/docker_build_shared.yaml
+++ b/.github/workflows/docker_build_shared.yaml
@@ -20,11 +20,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-      - name: build
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Build
         working-directory: src/shared
         run: |
-          python -m pip install --upgrade pip setuptools wheel build
-          python -m build
+          uv pip install --upgrade build
+          uv build
       - name: Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,4 +1,4 @@
-name: linting
+name: Linting
 
 on:
   workflow_dispatch:
@@ -6,15 +6,14 @@ on:
 
 jobs:
   lint:
-    name: lint & check formatting
+    name: Code linting and formatting
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.13']
     steps:
-      - uses: actions/checkout@v4
-      - name: lint with black
-        uses: rickstaa/action-black@v1
+      - uses: actions/checkout@v5
+      - name: ruff-action
+        uses: astral-sh/ruff-action@v3.5.1
         with:
-          black_args: "src --check"
-          fail_on_error: false
+          args: "format --check --diff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,15 @@ classifiers = [
 "Issue Tracker" = "https://github.com/SK-CERT/Taranis-NG/issues"
 "Changelog" = "https://github.com/SK-CERT/Taranis-NG/blob/main/CHANGELOG.md"
 
+[tool.uv]
+required-version = "0.8.14"
+
 [tool.ruff]
+required-version = "0.12.11"
 line-length = 142
 target-version = "py313"
 fix = true
+include = ["src/**/*.py"]
 
 [tool.ruff.lint]
 select = ["ALL"]


### PR DESCRIPTION
- uses uv and ruff for GitHub Actions
- ruff should fail because the code is not formatted properly - this will be addressed in following commits