### PR TITLE
MESSAGE Presenter: added support for custom attachment file names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,13 @@ include = ["src/**/*.py", "src/**/*.wsgi"]
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["BLE001"] # Ignore except Exception
+ignore = [
+    "BLE001",  # Ignore except Exception
+    "ERA001",  # Found commented-out code
+    "TRY300",  # Consider moving this statement to an `else` block of the `try` statement
+    "G004",    # Logging statement uses f-string
+    "TRY401",  # Redundant exception object included in `logging.exception` call (we have own exception logic)
+]
 
 [tool.ruff.lint.per-file-ignores]
 "docker/gunicorn_conf.py" = ["INP001", "S104"]
@@ -66,3 +72,12 @@ docstring-code-format = true
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.ruff.lint.pylint]
+max-args = 10
+max-branches = 20
+max-returns = 10
+max-statements = 80
+
+[tool.ruff.lint.mccabe]
+max-complexity = 15

--- a/src/shared/shared/config_presenter.py
+++ b/src/shared/shared/config_presenter.py
@@ -1,16 +1,16 @@
 """Definition for presenter modules."""
 
-from .config_base import ConfigBase, module_type, param_type
-from typing import List
 from shared.schema.parameter import ParameterType
+
+from .config_base import ConfigBase, module_type, param_type
 
 
 class ConfigPresenter(ConfigBase):
     """Configuration for presenter modules."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize presenter modules."""
-        self.modules: List[module_type] = []
+        self.modules: list[module_type] = []
 
         mod = module_type("HTML_PRESENTER", "HTML Presenter", "Presenter for generating html documents")
         mod.parameters = [
@@ -20,7 +20,7 @@ class ConfigPresenter(ConfigBase):
                 "Path to HTML template file",
                 ParameterType.STRING,
                 "/app/templates/template.html",
-            )
+            ),
         ]
         self.modules.append(mod)
 
@@ -45,6 +45,14 @@ class ConfigPresenter(ConfigBase):
                 "/app/templates/email_body_template.txt",
             ),
             param_type("ATTACHMENT_TEMPLATE_PATH", "Path to PDF attachment template", "Path to PDF template file", ParameterType.STRING, ""),
+            param_type(
+                "ATTACHMENT_FILE_NAME",
+                "Attachment file name",
+                "Leave empty for default file name 'file_YYYYmmddHHMMSS'. Alternatively, you may specify a custom file name or "
+                "provide a template string (e.g., file_{{ data.product.title }}).",
+                ParameterType.STRING,
+                "",
+            ),
         ]
         self.modules.append(mod)
 
@@ -56,15 +64,19 @@ class ConfigPresenter(ConfigBase):
                 "Path to MISP template file",
                 ParameterType.STRING,
                 "/app/templates/misp.json",
-            )
+            ),
         ]
         self.modules.append(mod)
 
         mod = module_type("PDF_PRESENTER", "PDF Presenter", "Presenter for generating PDF documents")
         mod.parameters = [
             param_type(
-                "PDF_TEMPLATE_PATH", "Path to template", "Path to PDF template file", ParameterType.STRING, "/app/templates/pdf_template.html"
-            )
+                "PDF_TEMPLATE_PATH",
+                "Path to template",
+                "Path to PDF template file",
+                ParameterType.STRING,
+                "/app/templates/pdf_template.html",
+            ),
         ]
         self.modules.append(mod)
 
@@ -76,6 +88,6 @@ class ConfigPresenter(ConfigBase):
                 "Path to TEXT template file",
                 ParameterType.STRING,
                 "/app/templates/template-show-all-data.txt",
-            )
+            ),
         ]
         self.modules.append(mod)

--- a/src/shared/shared/schema/presenter.py
+++ b/src/shared/shared/schema/presenter.py
@@ -17,7 +17,7 @@ class PresenterSchema(Schema):
     """Schema for presenter.
 
     Args:
-        Schema (_type_): Base schema class.
+        Schema (Any): Base schema class.
     """
 
     id = fields.Str()
@@ -27,16 +27,52 @@ class PresenterSchema(Schema):
     parameters = fields.List(fields.Nested(ParameterSchema))
 
 
+class PresenterInputProduct:
+    """Real data holding object presented by PresenterInputProductSchema."""
+
+    def __init__(self, title: str, description: str, product_type: str, product_type_description: str, user: UserSchemaBase, id: str) -> None:  # noqa: A002
+        """Initialize the "presenter input product".
+
+        Args:
+            title (str): Title of the product.
+            description (str): Description of the product.
+            product_type (str): Basicaly name of the product.
+            product_type_description (str): Product description.
+            user (UserSchemaBase): Data about the user who created the product.
+            id (str): Id.
+        """
+        self.title = title
+        self.description = description
+        self.product_type = product_type
+        self.product_type_description = product_type_description
+        self.user = user
+        self.id = id
+
+    @classmethod
+    def make_from_product(cls, product: "PresenterInputProductSchema") -> "PresenterInputProduct":
+        """Make a PresenterInputProduct object from a Product object.
+
+        Args:
+            product (PresenterInputProductSchema): Product object.
+
+        Returns:
+            PresenterInputProduct: Object.
+        """
+        return PresenterInputProduct(
+            product.title,
+            product.description,
+            product.product_type.title,
+            product.product_type.description,
+            product.user,
+            product.id,
+        )
+
+
 class PresenterInputProductSchema(Schema):
     """Schema for "presenter input product".
 
-    A dumbed down product suitable for presenters.
-
     Args:
-        Schema (_type_): Base schema class.
-
-    Returns:
-        _type_: _description_
+        Schema (Any): Base schema class.
     """
 
     title = fields.Str()
@@ -47,96 +83,38 @@ class PresenterInputProductSchema(Schema):
     id = fields.Str()
 
     @post_load
-    def make(self, data, **kwargs):
+    def make(self, data: dict, **kwargs) -> PresenterInputProduct:  # noqa: ANN003, ARG002
         """Make a PresenterInputProduct object from JSON data.
 
         Args:
-            data (_type_): JSON data.
+            data (dict): JSON data.
+            **kwargs: Additional arguments.
 
         Returns:
-            _type_: PresenterInputProduct object.
+            PresenterInputProduct: Object.
         """
         return PresenterInputProduct(**data)
-
-
-class PresenterInputSchema(Schema):
-    """Schema for "presenter input".
-
-    A complex package of data for presenters.
-
-    Args:
-        Schema (_type_): Base schema class.
-
-    Returns:
-        _type_: _description_
-    """
-
-    type = fields.Str()
-    parameter_values = fields.List(fields.Nested(ParameterValueSchema))
-    reports = fields.List(fields.Nested(ReportItemSchema))
-    report_types = fields.List(fields.Nested(ReportItemTypeSchema))
-    product = fields.Nested(PresenterInputProductSchema)
-
-    @post_load
-    def make(self, data, **kwargs):
-        """Make a PresenterInput object from JSON data.
-
-        Args:
-            data (_type_): JSON data.
-
-        Returns:
-            _type_: PresenterInput object.
-        """
-        return PresenterInput(**data)
-
-
-class PresenterInputProduct:
-    """Real data holding object presented by PresenterInputProductSchema."""
-
-    def __init__(self, title, description, product_type, product_type_description, user, id):
-        """Initialize the "presenter input product".
-
-        Args:
-            title (_type_): Title of the product.
-            description (_type_): Description of the product.
-            product_type (_type_): Basicaly name of the product.
-            product_type_description (_type_): Product description.
-            user (_type_): Data about the user who created the product.
-        """
-        self.title = title
-        self.description = description
-        self.product_type = product_type
-        self.product_type_description = product_type_description
-        self.user = user
-        self.id = id
-
-    @classmethod
-    def make_from_product(cls, product):
-        """Make a PresenterInputProduct object from a Product object.
-
-        Args:
-            product (_type_): Product object.
-
-        Returns:
-            _type_: PresenterInputProduct object.
-        """
-        return PresenterInputProduct(
-            product.title, product.description, product.product_type.title, product.product_type.description, product.user, product.id
-        )
 
 
 class PresenterInput:
     """Class for "presenter input"."""
 
-    def __init__(self, type, product, parameter_values=None, reports=None, report_types=None):
+    def __init__(
+        self,
+        type: str,  # noqa: A002
+        product: PresenterInputProductSchema,
+        parameter_values: list | None = None,
+        reports: list | None = None,
+        report_types: list | None = None,
+    ) -> None:
         """Initialize the "presenter input".
 
         Args:
-            type (_type_): Which presenter to use (e.g. PDF presenter)
-            product (_type_): Product consisting of report items.
-            parameter_values (_type_, optional): Arguments for the presenter (e.g. template path). Defaults to None.
-            reports (_type_, optional): Report items themselves. Defaults to None.
-            report_types (_type_, optional): Description of the report item types used. Defaults to None.
+            type (str): Which presenter to use (e.g. PDF presenter)
+            product (PresenterInputProductSchema): Product consisting of report items.
+            parameter_values (list, optional): Arguments for the presenter (e.g. template path). Defaults to None.
+            reports (list, optional): Report items themselves. Defaults to None.
+            report_types (list, optional): Description of the report item types used. Defaults to None.
         """
         # Creating from JSON data.
         if parameter_values is not None:
@@ -152,19 +130,26 @@ class PresenterInput:
         self.report_types = list(report_types.values())
         self.product = PresenterInputProduct.make_from_product(product)
 
-    def load(self, type, product, parameter_values, reports, report_types):
+    def load(
+        self,
+        type: str,  # noqa: A002
+        product: PresenterInputProductSchema,
+        parameter_values: list,
+        reports: list,
+        report_types: list,
+    ) -> None:
         """Load data from JSON.
 
         Args:
-            type (_type_): _description_
-            product (_type_): _description_
-            parameter_values (_type_): The same arguments, parsed differently.
-            reports (_type_): _description_
-            report_types (_type_): _description_
+            type (str): Type
+            product (PresenterInputProductSchema): Product
+            parameter_values (list): The same arguments, parsed differently.
+            reports (list): Reports
+            report_types (list): Report types
         """
         self.type = type
         self.parameter_values = parameter_values
-        self.param_key_values = dict()
+        self.param_key_values = {}
         for pv in parameter_values:
             self.param_key_values.update({pv.parameter.key: pv.value})
         self.reports = reports
@@ -172,47 +157,75 @@ class PresenterInput:
         self.product = product
 
 
+class PresenterInputSchema(Schema):
+    """Schema for "presenter input".
+
+    Args:
+        Schema (Any): Base schema class.
+    """
+
+    type = fields.Str()
+    parameter_values = fields.List(fields.Nested(ParameterValueSchema))
+    reports = fields.List(fields.Nested(ReportItemSchema))
+    report_types = fields.List(fields.Nested(ReportItemTypeSchema))
+    product = fields.Nested(PresenterInputProductSchema)
+
+    @post_load
+    def make(self, data: dict, **kwargs) -> PresenterInput:  # noqa: ANN003, ARG002
+        """Make a PresenterInput object from JSON data.
+
+        Args:
+            data (dict): JSON data.
+            **kwargs: Additional arguments.
+
+        Returns:
+            PresenterInput: Object.
+        """
+        return PresenterInput(**data)
+
+
+class PresenterOutput:
+    """Class for "presenter output"."""
+
+    def __init__(self, mime_type: str, data: str, message_body: str, message_title: str, att_file_name: str) -> None:
+        """Initialize the "presenter output".
+
+        Args:
+            mime_type (str): MIME type of the output.
+            data (str): The data itself.
+            message_body (str): Body of the message.
+            message_title (str): Title of the message.
+            att_file_name (str): Attached file name.
+        """
+        self.mime_type = mime_type
+        self.data = data
+        self.message_body = message_body
+        self.message_title = message_title
+        self.att_file_name = att_file_name
+
+
 class PresenterOutputSchema(Schema):
     """Schema for "presenter output".
 
     Args:
-        Schema (_type_): Base schema class.
-
-    Returns:
-        _type_: _description_
+        Schema (Any): Base schema class.
     """
 
     mime_type = fields.Str()
     data = fields.Str()
     message_body = fields.Str()
     message_title = fields.Str()
+    att_file_name = fields.Str()
 
     @post_load
-    def make(self, data, **kwargs):
+    def make(self, data: dict, **kwargs) -> PresenterOutput:  # noqa: ANN003, ARG002
         """Make a PresenterOutput object from JSON data.
 
         Args:
-            data (_type_): JSON data.
+            data (dict): JSON data.
+            **kwargs: Additional arguments.
 
         Returns:
-            _type_: PresenterOutput object.
+            PresenterOutput: Object.
         """
         return PresenterOutput(**data)
-
-
-class PresenterOutput:
-    """Class for "presenter output"."""
-
-    def __init__(self, mime_type, data, message_body, message_title):
-        """Initialize the "presenter output".
-
-        Args:
-            mime_type (_type_): MIME type of the output.
-            data (_type_): The data itself.
-            message_body (_type_): Body of the message.
-            message_title (_type_): Title of the message.
-        """
-        self.mime_type = mime_type
-        self.data = data
-        self.message_body = message_body
-        self.message_title = message_title

--- a/src/shared/shared/schema/publisher.py
+++ b/src/shared/shared/schema/publisher.py
@@ -16,45 +16,21 @@ class PublisherSchema(Schema):
     parameters = fields.List(fields.Nested(ParameterSchema))
 
 
-class PublisherInputSchema(Schema):
-    """Schema for Publisher Input."""
-
-    name = fields.Str()
-    type = fields.Str()
-    parameter_values = fields.List(fields.Nested(ParameterValueSchema))
-    mime_type = fields.Str(allow_none=True)
-    data = fields.Str(allow_none=True)
-    message_title = fields.Str(allow_none=True)
-    message_body = fields.Str(allow_none=True)
-    recipients = fields.List(fields.String, allow_none=True)
-
-    @post_load
-    def make(self, data, **kwargs):
-        """Create a PublisherInput object from the deserialized data.
-
-        Args:
-            data (dict): The deserialized data.
-            **kwargs: Additional keyword arguments.
-        Returns:
-            PublisherInput: The PublisherInput object.
-        """
-        return PublisherInput(**data)
-
-
 class PublisherInput:
     """Publisher Input class."""
 
     def __init__(
         self,
-        name,
-        type,
-        parameter_values,
-        mime_type,
-        data,
-        message_title,
-        message_body,
-        recipients,
-    ):
+        name: str,
+        type: str,  # noqa: A002
+        parameter_values: list,
+        mime_type: str,
+        data: str,
+        message_title: str,
+        message_body: str,
+        recipients: list,
+        att_file_name: str,
+    ) -> None:
         """Initialize the PublisherInput object.
 
         Args:
@@ -66,6 +42,7 @@ class PublisherInput:
             message_title (str): The title of the message.
             message_body (str): The body of the message.
             recipients (list): The list of recipients.
+            att_file_name (str): The attachment file name.
         """
         self.name = name
         self.type = type
@@ -75,7 +52,35 @@ class PublisherInput:
         self.message_title = message_title
         self.message_body = message_body
         self.recipients = recipients
+        self.att_file_name = att_file_name
 
-        self.param_key_values = dict()
+        self.param_key_values = {}
         for pv in parameter_values:
             self.param_key_values.update({pv.parameter.key: pv.value})
+
+
+class PublisherInputSchema(Schema):
+    """Schema for Publisher Input."""
+
+    name = fields.Str()
+    type = fields.Str()
+    parameter_values = fields.List(fields.Nested(ParameterValueSchema))
+    mime_type = fields.Str(allow_none=True)
+    data = fields.Str(allow_none=True)
+    message_title = fields.Str(allow_none=True)
+    message_body = fields.Str(allow_none=True)
+    recipients = fields.List(fields.String, allow_none=True)
+    att_file_name = fields.Str(allow_none=True)
+
+    @post_load
+    def make(self, data: dict, **kwargs) -> PublisherInput:  # noqa: ANN003, ARG002
+        """Create a PublisherInput object from the deserialized data.
+
+        Args:
+            data (dict): The deserialized data.
+            **kwargs: Additional arguments.
+
+        Returns:
+            PublisherInput: The PublisherInput object.
+        """
+        return PublisherInput(**data)


### PR DESCRIPTION
- Introduced new parameter for specifying attachment file name.
- Defaults to `file_YYYYmmddHHMMSS` if left empty.
- Supports static strings or Jinja templates (e.g. `file_{{ data.product.title }}`).
- Field becomes available after first DB update or manual run of `CORE/db_migration.py regenerate`.