### PR TITLE
Exclude html tags from new items indexing and some mastodon fixes

### DIFF
--- a/src/core/model/news_item.py
+++ b/src/core/model/news_item.py
@@ -22,7 +22,7 @@ from model.tag_cloud import TagCloud
 from sqlalchemy import and_, func, or_, orm
 
 from shared import common
-from shared.common import TZ
+from shared.common import TZ, strip_html
 from shared.schema.acl_entry import ItemType
 from shared.schema.news_item import NewsItemAggregateSchema, NewsItemAttributeSchema, NewsItemDataSchema, NewsItemRemoteSchema, NewsItemSchema
 
@@ -1479,7 +1479,7 @@ class NewsItemAggregateSearchIndex(db.Model):
         for news_item in aggregate.news_items:
             data += " " + news_item.news_item_data.title
             data += " " + news_item.news_item_data.review
-            data += " " + news_item.news_item_data.content
+            data += " " + strip_html(news_item.news_item_data.content)
             data += " " + news_item.news_item_data.author
             data += " " + news_item.news_item_data.link
 

--- a/src/publishers/publishers/mastodon_publisher.py
+++ b/src/publishers/publishers/mastodon_publisher.py
@@ -45,12 +45,17 @@ class MASTODONPublisher(BasePublisher):
             visibility = publisher_input.param_key_values["VISIBILITY"]
             sensitive = read_bool_parameter("SENSITIVE", default_value=False, object_dict=publisher_input)
 
+            spoiler_text = None
             status = None
 
             if publisher_input.message_title:
                 spoiler_text = b64decode(publisher_input.message_title, validate=True).decode("UTF-8")
             if publisher_input.message_body:
                 status = b64decode(publisher_input.message_body, validate=True).decode("UTF-8")
+
+            if not status:
+                self.logger.warning("Status is empty, publication skipped.")
+                return
 
             if spoiler_text in ["", "None"]:
                 spoiler_text = None


### PR DESCRIPTION
- mastodon publisher: fixed crash on empty status
- mastodon publisher: add skip message instead failed post
- don't store html tags for new items searching