### PR TITLE
Add HTML display support for WEB-collected news items

### DIFF
--- a/src/core/model/news_item.py
+++ b/src/core/model/news_item.py
@@ -21,8 +21,7 @@ from model.osint_source import OSINTSource, OSINTSourceGroup
 from model.tag_cloud import TagCloud
 from sqlalchemy import and_, func, or_, orm
 
-from shared import common
-from shared.common import TZ, strip_html
+from shared.common import TZ, remove_empty_html_tags, simplify_html_text, smart_truncate, strip_html
 from shared.schema.acl_entry import ItemType
 from shared.schema.news_item import NewsItemAggregateSchema, NewsItemAttributeSchema, NewsItemDataSchema, NewsItemRemoteSchema, NewsItemSchema
 
@@ -963,10 +962,10 @@ class NewsItemAggregate(db.Model):
         if not news_item_data.hash:
             news_item_data.hash = news_item_data.id
         # sanitize news item from user manual input
-        news_item_data.title = common.smart_truncate(common.strip_html(news_item_data.title), 200)
-        news_item_data.review = common.smart_truncate(common.strip_html(news_item_data.review))
-        news_item_data.content = common.simplify_html_text(news_item_data.content)
-        news_item_data.author = common.strip_html(news_item_data.author)
+        news_item_data.title = smart_truncate(strip_html(news_item_data.title), 200)
+        news_item_data.review = smart_truncate(strip_html(news_item_data.review))
+        news_item_data.content = remove_empty_html_tags(simplify_html_text(news_item_data.content))
+        news_item_data.author = strip_html(news_item_data.author)
         db.session.add(news_item_data)
         cls.create_new_for_all_groups(news_item_data)
         TagCloud.generate_tag_cloud_words(news_item_data)

--- a/src/gui/src/components/assess/NewsItemSingleDetail.vue
+++ b/src/gui/src/components/assess/NewsItemSingleDetail.vue
@@ -108,7 +108,7 @@
                                         </span>
                                     </v-row>
                                     <v-row class="py-4">
-                                        <span class="body-2 grey--text text--darken-1" v-html="formattedContent"></span>
+                                        <span class="body-2 grey--text text--darken-1" v-html="news_item.news_items[0].news_item_data.content"></span>
                                     </v-row>
                                 </v-col>
 
@@ -200,11 +200,6 @@ export default {
 
         multiSelectActive() {
             return this.$store.getters.getMultiSelect
-        },
-        formattedContent() {
-            const content = this.news_item.news_items[0].news_item_data.content || '';
-            // Replace newlines with <br> for cases the text does not contain HTML formatting
-            return content.replace(/\n/g, "<br>");
         },
     },
     data: () => ({

--- a/src/shared/shared/common.py
+++ b/src/shared/shared/common.py
@@ -82,7 +82,7 @@ def remove_empty_html_tags(html_string: str) -> str:
             if not tag.get_text(strip=True) and not tag.find_all():
                 tag.decompose()
                 changed = True
-    return str(soup)
+    return str(soup).strip()
 
 
 def strip_html(html_string: str) -> str:
@@ -97,6 +97,27 @@ def strip_html(html_string: str) -> str:
     """
     soup = BeautifulSoup(html_string, "html.parser")
     return soup.get_text(separator=" ", strip=True)
+
+
+def text_to_simple_html(text: str) -> str:
+    """Convert a plain text string into a simple, safe HTML fragment.
+
+    - Escapes HTML special characters.
+    - Converts CRLF / CR / LF to <br>.
+
+    Args:
+        text: input string (None treated as empty).
+
+    Returns:
+        A safe HTML fragment (surrounded by <p></p>).
+    """
+    if not text:
+        return ""
+
+    escaped = strip_html(text)
+    normalized = escaped.replace("\r\n", "\n").replace("\r", "\n")
+    with_br = normalized.replace("\n", "<br>")
+    return f"<p>{with_br}</p>"
 
 
 def smart_truncate(content: str, length: int = 500, suffix: str = " [...]") -> str:

--- a/src/shared/shared/schema/news_item.py
+++ b/src/shared/shared/schema/news_item.py
@@ -4,7 +4,7 @@ import datetime
 
 from marshmallow import EXCLUDE, Schema, fields, post_load
 
-from shared import common
+from shared.common import clean_whitespace, strip_html
 from shared.schema.acl_entry import ACLEntryStatusSchema
 
 
@@ -121,7 +121,7 @@ class NewsItemData:
     @property
     def content_plaintext(self) -> str:
         """Return plain text version of content."""
-        return common.strip_html(self.content) if self.content else ""
+        return strip_html(self.content) if self.content else ""
 
     def print_news_item(self, logger: object) -> None:
         """Print news item details using the provided logger."""
@@ -130,7 +130,7 @@ class NewsItemData:
         if self.review:
             logger.debug(f"__ Review   : {self.review[:100]}")
         if self.content:
-            logger.debug(f"__ Content  : {common.clean_whitespace(self.content)[:100]}")
+            logger.debug(f"__ Content  : {clean_whitespace(self.content)[:100]}")
         if self.published:
             logger.debug(f"__ Published: {self.published}")
 


### PR DESCRIPTION
- Added HTML content support for WEB-type collected items
- Works only on new items; old crawled text remains plain text (losing line breaks)
- Added extra strip() step to remove_empty_html_tags output — removes useless leading and trailing whitespace
- Remove empty html tags on manual user news item input
- New function text_to_simple_html for future using (formatting other collectors content to display properly line breaks in news feed)