### PR TITLE
Fix 'NewsItemData' object has no attribute 'content_plaintext' + Add review for title if it's empty

### DIFF
--- a/src/collectors/collectors/base_collector.py
+++ b/src/collectors/collectors/base_collector.py
@@ -9,7 +9,6 @@ from http import HTTPStatus
 from typing import ClassVar
 from urllib.parse import urlparse
 
-import pytz
 import socks
 from dateutil.parser import parse as date_parse
 from remote.core_api import CoreApi
@@ -314,7 +313,7 @@ class BaseCollector:
 def not_modified(source: object) -> bool:
     """Check if the content has been modified since the given date using the If-Modified-Since and Last-Modified headers."""
     if source.last_collected.tzinfo is None:
-        source.last_collected = source.last_collected.replace(tzinfo=pytz.UTC)
+        source.last_collected = source.last_collected.replace(tzinfo=TZ)
     last_collected_str = source.last_collected.strftime("%a, %d %b %Y %H:%M:%S GMT")
     headers = {"If-Modified-Since": last_collected_str}
     if source.user_agent:
@@ -356,7 +355,7 @@ def _not_modified_http_error(source: object, http_error: object, log_prefix: str
     if http_error.code == HTTPStatus.NOT_MODIFIED:
         source.logger.debug(f"{log_prefix} NOT modified since {last_collected_str_fmt}")
         return True
-    if http_error.code in [401, 429, 403]:
+    if http_error.code in [HTTPStatus.UNAUTHORIZED, HTTPStatus.TOO_MANY_REQUESTS, HTTPStatus.FORBIDDEN]:
         source.logger.info(f"{log_prefix} HTTP {http_error.code} {http_error.reason} for {source.url}. Continuing...")
         return False
     source.logger.exception(f"{log_prefix} HTTP error occurred")

--- a/src/collectors/collectors/web_collector.py
+++ b/src/collectors/collectors/web_collector.py
@@ -442,7 +442,7 @@ class WebCollector(BaseCollector):
                 browser = self.__get_headless_driver_firefox()
             else:
                 browser = self.__get_headless_driver_chrome()
-            browser.implicitly_wait(15)  # how long to wait for elements when selector doesn't match
+            browser.implicitly_wait(7)  # how long to wait for elements when selector doesn't match
             return browser
         except Exception as error:
             self.source.logger.exception(f"Get headless driver failed: {error}")
@@ -706,7 +706,10 @@ class WebCollector(BaseCollector):
         if self.word_limit > 0:
             review = " ".join(re.compile(r"\s+").split(review)[: self.word_limit])
 
-        title = smart_truncate(title, 200)
+        if not title:
+            self.source.logger.debug("Using review for title")
+            title = review
+        title = smart_truncate(title, 100)
         review = smart_truncate(review)
 
         extracted_date = None

--- a/src/core/model/news_item.py
+++ b/src/core/model/news_item.py
@@ -159,6 +159,11 @@ class NewsItemData(db.Model):
         self.osint_source_id = osint_source_id
         self.updated = datetime.now(TZ)
 
+    @property
+    def content_plaintext(self) -> str:
+        """Return plain text version of content."""
+        return strip_html(self.content) if self.content else ""
+
     @classmethod
     def allowed_with_acl(cls, news_item_data_id: str, user: User, see: bool, access: bool, modify: bool) -> bool:
         """Check if user is allowed to access news item data.
@@ -1478,7 +1483,7 @@ class NewsItemAggregateSearchIndex(db.Model):
         for news_item in aggregate.news_items:
             data += " " + news_item.news_item_data.title
             data += " " + news_item.news_item_data.review
-            data += " " + strip_html(news_item.news_item_data.content)
+            data += " " + news_item.news_item_data.content_plaintext
             data += " " + news_item.news_item_data.author
             data += " " + news_item.news_item_data.link
 

--- a/src/shared/shared/schema/news_item.py
+++ b/src/shared/shared/schema/news_item.py
@@ -4,7 +4,7 @@ import datetime
 
 from marshmallow import EXCLUDE, Schema, fields, post_load
 
-from shared.common import clean_whitespace, strip_html
+from shared.common import clean_whitespace
 from shared.schema.acl_entry import ACLEntryStatusSchema
 
 
@@ -117,11 +117,6 @@ class NewsItemData:
         self.content = content
         self.osint_source_id = osint_source_id
         self.attributes = attributes
-
-    @property
-    def content_plaintext(self) -> str:
-        """Return plain text version of content."""
-        return strip_html(self.content) if self.content else ""
 
     def print_news_item(self, logger: object) -> None:
         """Print news item details using the provided logger."""


### PR DESCRIPTION
- Fixed 'NewsItemData' object has no attribute 'content_plaintext' (caused by previous changes)
- replaced HTTP codes constants with readable enumerator
- Small TimeZone fix
- In WEB collector use beginning of the review for title if it's empty
- Decreased waiting time for find element in web collector from 15 -> 7 sec
