### PR TITLE
Specify Traefik version

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -277,7 +277,7 @@ services:
       - "gui"
       - "core"
     restart: unless-stopped
-    image: "traefik:latest"
+    image: "traefik:3.6.7"
     environment:
       TZ: "${TZ}"
     ports:


### PR DESCRIPTION
Specify the version of Traefik. With "latest", Traefik won't get updated unless the docker image is deleted. Also gives us control over the used version. Should be already configured in dependabot.yml, so we should get automatic PRs with new versions as with Python dependencies.