### PR TITLE
Better Docker ACME configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ build/
 docker/.env
 docker/secrets/*.txt
 docker/traefik/dynamic/*.yml
+docker/docker-compose.override.yml
 .env.local
 .env.*.local
 src/.env

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -52,7 +52,7 @@ POSTGRES_KEYCLOAK_PASSWORD=supersecret
 # Logging of Taranis-NG and used Python modules
 TARANIS_LOG_LEVEL=DEBUG
 MODULES_LOG_LEVEL=WARN
-# To change Traefik logging, go to traefik.yml and set it there there
+# To change Traefik logging, go to traefik.yml and set it there
 # To change Nginx log level, go to docker-compose.yml and change NGINX_LOG_LEVEL and NGINX_ACCESS_LOG there
 # To change Redis log level, go to docker-compose.yml and change --loglevel there
 

--- a/docker/docker-compose.override.yml.example
+++ b/docker/docker-compose.override.yml.example
@@ -1,0 +1,39 @@
+# Docker Compose Override File - ACME/Let's Encrypt Configuration
+#
+# This file enables the ACME storage volume for automatic HTTPS certificates.
+# Docker Compose automatically uses docker-compose.override.yml if present.
+#
+# Usage:
+#   1. Copy this file: cp docker-compose.override.yml.example docker-compose.override.yml
+#   2. Edit traefik/traefik.yml and uncomment the certificatesResolvers section
+#   3. Start normally: docker compose up -d
+#
+# Note: docker-compose.override.yml is gitignored, so your ACME configuration
+#       won't be tracked or cause merge conflicts. The .example file serves as
+#       documentation and template.
+#
+# Requirements:
+#   - TARANIS_NG_HOSTNAME must be publicly accessible
+#   - Ports 80/443 must be open for ACME challenge validation
+#   - ACME config must be in traefik/traefik.yml (not in dynamic/ files)
+
+services:
+  core:
+    labels:
+      # Enable ACME cert resolver for API endpoint
+      traefik.http.routers.taranis-api-443.tls.certresolver: "myresolver"
+      # Enable ACME cert resolver for SSE endpoint
+      traefik.http.routers.taranis-sse-443.tls.certresolver: "myresolver"
+
+  gui:
+    labels:
+      # Enable ACME cert resolver for GUI endpoint
+      traefik.http.routers.taranis-gui-443.tls.certresolver: "myresolver"
+
+  traefik:
+    volumes:
+      # Enable ACME storage volume for Let's Encrypt certificates
+      - "acme_storage:/letsencrypt"
+
+volumes:
+  acme_storage:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -83,16 +83,12 @@ services:
       traefik.http.routers.taranis-api-443.tls: "true"
       traefik.http.routers.taranis-api-443.tls.domains[0].main: "${TARANIS_NG_HOSTNAME}"
       traefik.http.routers.taranis-api-443.service: "taranis-api"
-      # Uncomment the following line to enable ACME/Let's Encrypt (after enabling in traefik.yml)
-      # traefik.http.routers.taranis-api-443.tls.certresolver: "myresolver"
 
       traefik.http.routers.taranis-sse-443.entrypoints: "websecure"
       traefik.http.routers.taranis-sse-443.rule: "Host(`${TARANIS_NG_HOSTNAME}`) && PathPrefix(`/sse`)"
       traefik.http.routers.taranis-sse-443.tls: "true"
       traefik.http.routers.taranis-sse-443.tls.domains[0].main: "${TARANIS_NG_HOSTNAME}"
       traefik.http.routers.taranis-sse-443.service: "taranis-api"
-      # Uncomment the following line to enable ACME/Let's Encrypt (after enabling in traefik.yml)
-      # traefik.http.routers.taranis-sse-443.tls.certresolver: "myresolver"
     volumes:
       - "core_data:/data"
     logging:
@@ -263,8 +259,6 @@ services:
       traefik.http.routers.taranis-gui-443.tls: "true"
       traefik.http.routers.taranis-gui-443.tls.domains[0].main: "${TARANIS_NG_HOSTNAME}"
       traefik.http.routers.taranis-gui-443.service: "taranis-gui"
-      # Uncomment the following line to enable ACME/Let's Encrypt (after enabling in traefik.yml)
-      # traefik.http.routers.taranis-gui-443.tls.certresolver: "myresolver"
 
     logging:
       driver: "json-file"
@@ -289,8 +283,6 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "./traefik:/etc/traefik:ro"
       - "./tls:/opt/certs"
-      # Uncomment the following line to enable ACME/Let's Encrypt (after enabling in traefik.yml)
-      # - "acme_storage:/letsencrypt"
     logging:
       driver: "json-file"
       options:
@@ -311,4 +303,3 @@ volumes:
   core_data:
   presenters_templates:
   collector_storage:
-  acme_storage:


### PR DESCRIPTION
- ACME config in Docker is now handled by override file which is in gitignore - this enables changes to ACME configuration without triggering git change tracking, the repo only provides example file which needs to be renamed
- ACME must still be configured in traefik.yml - still looking for solution which would enable local changes without git tracking
- documentation
- fixed typo in .env example