### PR TITLE
Corrected prettier formatting (VUE3)

### DIFF
--- a/src/gui-v3/.prettierrc
+++ b/src/gui-v3/.prettierrc
@@ -3,10 +3,7 @@
     "singleQuote": true,
     "printWidth": 142,
     "trailingComma": "none",
-    "arrowParens": "always",
-    "endOfLine": "lf",
     "tabWidth": 4,
-    "useTabs": false,
     "vueIndentScriptAndStyle": true,
-    "htmlWhitespaceSensitivity": "ignore"
+    "quoteProps": "consistent"
 }


### PR DESCRIPTION
- htmlWhitespaceSensitivity: ignore -> css (default). All whitespace was considered insignificant. This break app functionality (removing/adding spaces in formatted strings)
- quoteProps: as-needed -> consistent (here was strange behavior. See "3.1")
- removed setting with default values