### PR TITLE
Assess button improvements and fixes (VUE3)

### DIFF
--- a/src/gui-v3/src/components/assess/AssessItemActions.vue
+++ b/src/gui-v3/src/components/assess/AssessItemActions.vue
@@ -4,6 +4,7 @@
         <v-btn
             v-if="showOpenLink && hasLink"
             icon
+            :disabled="disabled"
             :size="size"
             :variant="variant"
             :href="itemLink"
@@ -21,6 +22,7 @@
         <v-btn
             v-if="showCreateReport && canCreateReport"
             icon
+            :disabled="disabled"
             :size="size"
             :variant="variant"
             :title="t('assess.tooltip.analyze_item')"
@@ -35,6 +37,7 @@
         <v-btn
             v-if="showUngroup && canModify"
             icon
+            :disabled="disabled"
             :size="size"
             :variant="variant"
             :title="t('assess.tooltip.ungroup_item')"
@@ -49,6 +52,7 @@
         <v-btn
             v-if="canModify"
             icon
+            :disabled="disabled"
             :size="size"
             :variant="variant"
             :title="t('assess.tooltip.like_item')"
@@ -58,14 +62,15 @@
                 {{ item.me_like ? ICONS.LIKE : ICONS.LIKE_OUTLINE }}
             </v-icon>
         </v-btn>
-        <v-label v-if="showCounts && canModify && item.likes > 0" class="text-caption text-disabled">
-            {{ item.likes }}
-        </v-label>
+        <span v-if="showCounts && canModify" class="vote-count" :class="{ 'is-empty': Number(item.likes || 0) === 0 }">
+            {{ Number(item.likes || 0) > 0 ? Number(item.likes || 0) : '0' }}
+        </span>
 
         <!-- Dislike -->
         <v-btn
             v-if="canModify"
             icon
+            :disabled="disabled"
             :size="size"
             :variant="variant"
             :title="t('assess.tooltip.dislike_item')"
@@ -75,14 +80,15 @@
                 {{ item.me_dislike ? ICONS.UNLIKE : ICONS.UNLIKE_OUTLINE }}
             </v-icon>
         </v-btn>
-        <v-label v-if="showCounts && canModify && item.dislikes > 0" class="text-caption text-disabled">
-            {{ item.dislikes }}
-        </v-label>
+        <span v-if="showCounts && canModify" class="vote-count" :class="{ 'is-empty': Number(item.dislikes || 0) === 0 }">
+            {{ Number(item.dislikes || 0) > 0 ? Number(item.dislikes || 0) : '0' }}
+        </span>
 
         <!-- Important -->
         <v-btn
             v-if="canModify"
             icon
+            :disabled="disabled"
             :size="size"
             :variant="variant"
             :title="t('assess.tooltip.important_item')"
@@ -97,6 +103,7 @@
         <v-btn
             v-if="canModify"
             icon
+            :disabled="disabled"
             :size="size"
             :variant="variant"
             :title="t('assess.tooltip.read_item')"
@@ -111,6 +118,7 @@
         <ActionButton
             v-if="canDelete"
             action="delete"
+            :disabled="disabled"
             :size="size"
             :variant="variant"
             :title="t('assess.tooltip.delete_item')"
@@ -166,6 +174,7 @@
             showUngroup?: boolean
             showCounts?: boolean
             showOpenLink?: boolean
+            disabled?: boolean
         }>(),
         {
             size: 'small',
@@ -174,7 +183,8 @@
             showCreateReport: false,
             showUngroup: false,
             showCounts: false,
-            showOpenLink: true
+            showOpenLink: true,
+            disabled: false
         }
     )
 
@@ -220,5 +230,19 @@
         display: flex;
         align-items: center;
         gap: 4px;
+    }
+
+    .vote-count {
+        min-width: 0.75rem;
+        text-align: center;
+        font-size: 0.75rem;
+        color: rgb(var(--v-theme-on-surface));
+        opacity: 0.7;
+        margin-left: -0.5rem;
+        margin-right: -0.2rem;
+    }
+
+    .vote-count.is-empty {
+        visibility: hidden;
     }
 </style>

--- a/src/gui-v3/src/components/assess/CardAssess.vue
+++ b/src/gui-v3/src/components/assess/CardAssess.vue
@@ -127,7 +127,7 @@
     import { useI18n } from 'vue-i18n'
     import { useAssessStore } from '@/stores/assess'
     import { useAuth } from '@/composables/useAuth'
-    import { deleteNewsItemAggregate, groupAction } from '@/api/assess'
+    import { deleteNewsItemAggregate } from '@/api/assess'
     import { ICONS } from '@/config/ui-constants'
     import BaseCard from '@/components/common/BaseCard.vue'
     import AssessItemActions from '@/components/assess/AssessItemActions.vue'
@@ -211,8 +211,6 @@
     const childNewsItems = computed(() => props.card.news_items ?? [])
 
     const multiSelectActive = computed(() => assessStore.getMultiSelect)
-    const currentGroupId = computed(() => String(assessStore.getCurrentGroup || ''))
-
     const selectedColor = computed(() => {
         return assessStore.selectedItems.has(props.card.id) ? 'orange-lighten-4' : ''
     })
@@ -251,8 +249,6 @@
     const handleCardAction = (action: string): void => {
         if (action === 'delete') {
             handleDelete()
-        } else if (action === 'ungroup') {
-            handleUngroup()
         } else {
             updateCard(action)
         }
@@ -268,28 +264,6 @@
 
     const deleteChildItem = (item: AssessCard): void => {
         emit('delete-item', item)
-    }
-
-    const handleUngroup = async (): Promise<void> => {
-        try {
-            opened.value = false
-            await groupAction({
-                group: currentGroupId.value,
-                action: 'UNGROUP',
-                items: [{ type: 'AGGREGATE', id: props.card.id }]
-            })
-            emit('update-item', props.card, 'refresh')
-        } catch (error: unknown) {
-            console.error('Error ungrouping news item aggregate:', error)
-            window.dispatchEvent(
-                new CustomEvent('notification', {
-                    detail: {
-                        type: 'error',
-                        message: t('assess.error_updating')
-                    }
-                })
-            )
-        }
     }
 
     const handleDelete = async (): Promise<void> => {

--- a/src/gui-v3/src/components/assess/ContentDataAssess.vue
+++ b/src/gui-v3/src/components/assess/ContentDataAssess.vue
@@ -55,6 +55,7 @@
         <NewsItemDetailDialog
             v-model="detailDialog"
             :news-item="selectedItem"
+            :actions-disabled="detailActionPending"
             :multi-select-active="multiSelectActive"
             @action="handleDetailAction"
             @delete="handleDetailDelete"
@@ -141,9 +142,11 @@
     const news_items_data_loaded = ref(false)
     const detailDialog = ref(false)
     const selectedItem = ref<NewsItem | null>(null)
+    const detailActionPending = ref(false)
     const reportsListDialogRef = ref<any>(null)
     const reportItemModalRef = ref<any>(null)
     const current_group_id = ref('')
+    const detailActionRequestId = ref(0)
     const lastIntersectTime = ref(0)
     const INTERSECT_DEBOUNCE_MS = 500
     const filter = ref<FilterState>({
@@ -206,10 +209,83 @@
         detailDialog.value = true
     }
 
+    const normalizeId = (id: string | number | undefined): string => String(id ?? '')
+
+    const toDetailNewsItem = (news_item: NewsItem): NewsItem => {
+        if (news_item.entityType === 'news_item') {
+            const nestedData = (news_item['news_item_data'] as Record<string, unknown> | undefined) || {}
+
+            return {
+                ...news_item,
+                entityType: 'news_item',
+                title: (nestedData['title'] as string) || (news_item['title'] as string) || '',
+                description: (nestedData['review'] as string) || (news_item['description'] as string) || '',
+                comments: (news_item['comments'] as string) || '',
+                created: (nestedData['collected'] as string) || (news_item['created'] as string) || '',
+                read: Boolean(news_item['read']),
+                important: Boolean(news_item['important']),
+                likes: Number(news_item['likes'] || 0),
+                dislikes: Number(news_item['dislikes'] || 0),
+                me_like: Boolean(news_item['me_like']),
+                me_dislike: Boolean(news_item['me_dislike']),
+                link: (nestedData['link'] as string) || '',
+                news_items: [news_item]
+            }
+        }
+
+        return news_item
+    }
+
+    const findUpdatedSelectedItem = (currentItem: NewsItem): NewsItem | null => {
+        const currentId = normalizeId(currentItem.id)
+
+        if (currentItem.entityType === 'news_item') {
+            // Child item dialogs must resolve from nested items first.
+            for (const aggregate of news_items_data.value) {
+                const nestedItems = Array.isArray(aggregate['news_items']) ? (aggregate['news_items'] as NewsItem[]) : []
+                const nestedMatch = nestedItems.find((item) => normalizeId(item.id) === currentId)
+                if (nestedMatch) {
+                    return toDetailNewsItem({ ...nestedMatch, entityType: 'news_item' })
+                }
+            }
+        }
+
+        // Aggregate dialogs (or fallback) resolve from top-level list.
+        const topLevelMatch = news_items_data.value.find((item) => normalizeId(item.id) === currentId)
+        if (topLevelMatch) {
+            return toDetailNewsItem(topLevelMatch)
+        }
+
+        // Fallback for child items if entity type metadata is missing.
+        for (const aggregate of news_items_data.value) {
+            const nestedItems = Array.isArray(aggregate['news_items']) ? (aggregate['news_items'] as NewsItem[]) : []
+            const nestedMatch = nestedItems.find((item) => normalizeId(item.id) === currentId)
+            if (nestedMatch) {
+                return toDetailNewsItem({ ...nestedMatch, entityType: 'news_item' })
+            }
+        }
+
+        return null
+    }
+
     const showReportsForItem = (card: NewsItem): void => {
         if (reportsListDialogRef.value) {
             reportsListDialogRef.value.open(card)
         }
+    }
+
+    const isAggregateInUseError = (error: unknown): boolean => {
+        const responseData = (error as AxiosError)?.response?.data
+        const responseError =
+            responseData && typeof responseData === 'object' && 'error' in responseData
+                ? (responseData as { error?: string }).error
+                : undefined
+
+        return (
+            responseData === 'aggregate_in_use' ||
+            responseError === 'aggregate_in_use' ||
+            (typeof responseData === 'string' && responseData.includes('aggregate_in_use'))
+        )
     }
 
     const handleViewReportDetail = (report: unknown): void => {
@@ -223,6 +299,18 @@
         const { action, newsItem } = payload
         const group_id = current_group_id.value || getNormalizedGroupId()
         const isChildNewsItem = newsItem.entityType === 'news_item'
+        const isToolbarAction = ['like', 'dislike', 'important', 'read', 'ungroup'].includes(action)
+
+        if (isToolbarAction && detailActionPending.value) {
+            return
+        }
+
+        const requestId = detailActionRequestId.value + 1
+        detailActionRequestId.value = requestId
+
+        if (isToolbarAction) {
+            detailActionPending.value = true
+        }
 
         try {
             switch (action) {
@@ -301,9 +389,14 @@
             // Reload current view
             await updateData(false, true)
 
+            // Ignore stale completions from older requests.
+            if (requestId !== detailActionRequestId.value) {
+                return
+            }
+
             // Update the selected item in the dialog to show fresh data with updated colors
             if (selectedItem.value && action !== 'delete') {
-                const updatedItem = news_items_data.value.find((item) => item.id === selectedItem.value?.id)
+                const updatedItem = findUpdatedSelectedItem(selectedItem.value)
                 if (updatedItem) {
                     selectedItem.value = updatedItem
                 }
@@ -315,12 +408,28 @@
                 })
             )
         } catch (error) {
+            if (isAggregateInUseError(error)) {
+                window.dispatchEvent(
+                    new CustomEvent('notification', {
+                        detail: {
+                            type: 'error',
+                            message: t('error.aggregate_in_use')
+                        }
+                    })
+                )
+                return
+            }
+
             console.error('Error handling detail action:', error)
             window.dispatchEvent(
                 new CustomEvent('notification', {
                     detail: { type: 'error', loc: 'assess.error_updating' }
                 })
             )
+        } finally {
+            if (isToolbarAction && requestId === detailActionRequestId.value) {
+                detailActionPending.value = false
+            }
         }
     }
 
@@ -410,6 +519,21 @@
                         await assessStore.readNewsItemAggregate(group_id, news_item.id)
                     }
                     break
+                case 'ungroup':
+                    if (isChildNewsItem) {
+                        await groupAction({
+                            group: group_id,
+                            action: 'UNGROUP',
+                            items: [{ type: 'ITEM', id: news_item.id }]
+                        })
+                    } else {
+                        await groupAction({
+                            group: group_id,
+                            action: 'UNGROUP',
+                            items: [{ type: 'AGGREGATE', id: news_item.id }]
+                        })
+                    }
+                    break
                 case 'create-report':
                     if (reportItemModalRef.value) {
                         reportItemModalRef.value.openDialog([news_item])
@@ -428,6 +552,18 @@
                 })
             )
         } catch (error) {
+            if (isAggregateInUseError(error)) {
+                window.dispatchEvent(
+                    new CustomEvent('notification', {
+                        detail: {
+                            type: 'error',
+                            message: t('error.aggregate_in_use')
+                        }
+                    })
+                )
+                return
+            }
+
             console.error('Error updating item:', error)
             window.dispatchEvent(
                 new CustomEvent('notification', {

--- a/src/gui-v3/src/components/assess/NewsItemDetailDialog.vue
+++ b/src/gui-v3/src/components/assess/NewsItemDetailDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-dialog v-model="isOpen" max-width="90vh" max-height="90vh" scrollable @update:model-value="handleClose">
+    <v-dialog v-model="isOpen" max-width="90vw" max-height="90vh" scrollable @update:model-value="handleClose">
         <v-card style="min-height: 70vh; display: flex; flex-direction: column">
             <!-- Toolbar -->
             <v-toolbar color="primary" dark>
@@ -15,9 +15,11 @@
                 <AssessItemActions
                     v-if="!multiSelectActive"
                     :item="newsItem"
+                    :disabled="actionsDisabled"
                     size="small"
                     variant="text"
                     icon-size="small"
+                    show-counts
                     show-create-report
                     :show-ungroup="isAggregate"
                     @action="handleDialogAction"
@@ -100,7 +102,7 @@
                     <v-divider class="my-4" />
 
                     <div v-if="hasLink" class="text-caption">
-                        <strong>Link:</strong>
+                        <strong>Link: </strong>
                         <a :href="newsItemLink" target="_blank" rel="noreferrer">
                             {{ newsItemLink }}
                         </a>
@@ -214,11 +216,13 @@
             modelValue?: boolean
             newsItem?: NewsItemModel | null
             multiSelectActive?: boolean
+            actionsDisabled?: boolean
         }>(),
         {
             modelValue: false,
             newsItem: () => ({}),
-            multiSelectActive: false
+            multiSelectActive: false,
+            actionsDisabled: false
         }
     )
 

--- a/src/gui-v3/src/components/common/ToolbarGroup.vue
+++ b/src/gui-v3/src/components/common/ToolbarGroup.vue
@@ -24,7 +24,7 @@
             <!-- View-specific action buttons -->
             <template v-if="view === 'assess'">
                 <!-- Group -->
-                <v-btn v-if="canModify && canGroupActions" icon size="small" :disabled="selectedCount === 0" @click="handleAction('GROUP')">
+                <v-btn v-if="canModify && canGroupActions" icon size="small" :disabled="selectedCount < 2" @click="handleAction('GROUP')">
                     <v-tooltip activator="parent" location="bottom">
                         {{ t('assess.tooltip.group_items') }}
                     </v-tooltip>
@@ -32,7 +32,13 @@
                 </v-btn>
 
                 <!-- Ungroup -->
-                <v-btn v-if="canModify && canGroupActions" icon size="small" :disabled="selectedCount === 0" @click="handleAction('UNGROUP')">
+                <v-btn
+                    v-if="canModify && canGroupActions"
+                    icon
+                    size="small"
+                    :disabled="selectedCount === 0 || !canUngroupSelection"
+                    @click="handleAction('UNGROUP')"
+                >
                     <v-tooltip activator="parent" location="bottom">
                         {{ t('assess.tooltip.ungroup_items') }}
                     </v-tooltip>
@@ -154,6 +160,12 @@
         params?: Record<string, unknown>
     }
 
+    type ApiErrorShape = {
+        response?: {
+            data?: unknown
+        }
+    }
+
     const props = withDefaults(
         defineProps<{
             view: ViewMode
@@ -218,6 +230,35 @@
     const canCreateProduct = computed(() => {
         if (props.view === 'analyze') return checkPermission(PERMISSIONS.PUBLISH_CREATE)
         return false
+    })
+
+    const normalizeSelectionType = (rawType: unknown): 'AGGREGATE' | 'ITEM' => {
+        const typeValue = String(rawType || '').toUpperCase()
+        if (typeValue.includes('AGGREGATE')) {
+            return 'AGGREGATE'
+        }
+        return 'ITEM'
+    }
+
+    const canUngroupSelection = computed(() => {
+        if (props.view !== 'assess') {
+            return false
+        }
+
+        const selection = assessStore.getSelection as SelectionItem[]
+
+        return selection.some((selectedItem) => {
+            const normalizedType = normalizeSelectionType(selectedItem.type)
+
+            // Single item selections can be ungrouped from their parent aggregate.
+            if (normalizedType === 'ITEM') {
+                return true
+            }
+
+            // Aggregate can only be ungrouped when it actually contains multiple news items.
+            const aggregate = selectedItem.item as { news_items?: unknown[] } | undefined
+            return Array.isArray(aggregate?.news_items) && aggregate.news_items.length > 1
+        })
     })
 
     // Disable group actions when the current group is exactly "all"
@@ -475,7 +516,41 @@
 
     const handleAction = async (type: string): Promise<void> => {
         const selection = assessStore.getSelection as SelectionItem[]
-        const items = selection.map((s) => ({ type: s.type, id: s.id }))
+
+        const getErrorKey = (error: unknown): string => {
+            const responseData = (error as ApiErrorShape | undefined)?.response?.data
+
+            if (responseData && typeof responseData === 'object' && 'error' in responseData) {
+                const errorValue = (responseData as { error?: unknown }).error
+                if (typeof errorValue === 'string' && errorValue.trim().length > 0) {
+                    return errorValue
+                }
+            }
+
+            if (typeof responseData === 'string') {
+                const normalized = responseData.trim()
+                if (normalized.toLowerCase().includes('<html')) {
+                    return 'server_error'
+                }
+                if (normalized.length > 0) {
+                    return normalized
+                }
+            }
+
+            return 'server_error'
+        }
+
+        const items = selection.map((s) => ({ type: normalizeSelectionType(s.type), id: s.id }))
+
+        if (type === 'GROUP' && items.length < 2) {
+            notify({ type: 'warning', message: 'Select at least two items to group.' })
+            return
+        }
+
+        if (type === 'UNGROUP' && !canUngroupSelection.value) {
+            notify({ type: 'warning', message: 'No grouped items selected.' })
+            return
+        }
 
         if (items.length > 0) {
             const group_id = (route.params['groupId'] as string | undefined) || null
@@ -504,8 +579,7 @@
                 emit('update-data')
             } catch (error: unknown) {
                 console.error('Error performing action:', error)
-                const responseData = (error as { response?: { data?: string } } | undefined)?.response?.data
-                notify({ type: 'error', loc: `error.${responseData || 'server_error'}` })
+                notify({ type: 'error', loc: `error.${getErrorKey(error)}` })
             }
         }
     }


### PR DESCRIPTION
- appearance of like/dislike counters does not move position of buttons
- state of buttons in news item dialog and on the card should now be in sync (maybe could be simplified and sped up?)
- grouping and ungrouping should work
- grouping button is active only when multiple items are selected
- ungrouping button is active only when aggregate is selected
- the width of news item dialog changes with the width of the browser window, not height
- some minor tweaks