### PR TITLE
Report Attributes (VUE3)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,5 +31,3 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
-    env:
-        FORCE_COLOR: "1"

--- a/src/gui-v3/eslint.config.js
+++ b/src/gui-v3/eslint.config.js
@@ -54,6 +54,44 @@ const sharedGlobals = {
     withDefaults: 'readonly'
 }
 
+const generalRules = {
+    'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'no-unused-vars': 'off',
+    'prefer-const': 'warn',
+    'no-var': 'error'
+}
+
+const vueRules = {
+    'vue/multi-word-component-names': 'off',
+    'vue/no-v-html': 'off',
+    'vue/require-default-prop': 'off',
+    'vue/require-prop-types': 'off',
+    'vue/valid-v-slot': 'off',
+    'vue/no-mutating-props': 'off',
+    'vue/no-template-shadow': 'off',
+    'vue/prop-name-casing': 'off',
+    'vue/no-required-prop-with-default': 'off',
+    'vue/singleline-html-element-content-newline': 'off',
+    'vue/multiline-html-element-content-newline': 'off',
+    'vue/max-attributes-per-line': [
+        'warn',
+        {
+            singleline: 3,
+            multiline: 1
+        }
+    ],
+    'vue/html-indent': [
+        'warn',
+        4,
+        {
+            attribute: 1,
+            baseIndent: 1,
+            closeBracket: 0
+        }
+    ]
+}
+
 export default [
     js.configs.recommended,
     ...pluginVue.configs['flat/recommended'],
@@ -64,43 +102,7 @@ export default [
             sourceType: 'module',
             globals: sharedGlobals
         },
-        rules: {
-            // Vue specific
-            'vue/multi-word-component-names': 'off',
-            'vue/no-v-html': 'off',
-            'vue/require-default-prop': 'off',
-            'vue/require-prop-types': 'off',
-            'vue/valid-v-slot': 'off',
-            'vue/no-mutating-props': 'off',
-            'vue/no-template-shadow': 'off',
-            'vue/prop-name-casing': 'off',
-            'vue/no-required-prop-with-default': 'off',
-            'vue/max-attributes-per-line': [
-                'warn',
-                {
-                    singleline: 3,
-                    multiline: 1
-                }
-            ],
-            'vue/html-indent': [
-                'warn',
-                4,
-                {
-                    attribute: 1,
-                    baseIndent: 1,
-                    closeBracket: 0
-                }
-            ],
-            'vue/singleline-html-element-content-newline': 'off',
-            'vue/multiline-html-element-content-newline': 'off',
-
-            // JavaScript/General
-            'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
-            'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-            'no-unused-vars': 'off',
-            'prefer-const': 'warn',
-            'no-var': 'error'
-        }
+        rules: generalRules
     },
     {
         files: ['**/*.vue'],
@@ -115,19 +117,8 @@ export default [
             globals: sharedGlobals
         },
         rules: {
-            'no-unused-vars': 'off',
-            'vue/multi-word-component-names': 'off',
-            'vue/valid-v-slot': 'off',
-            'vue/no-mutating-props': 'off',
-            'vue/html-indent': [
-                'warn',
-                4,
-                {
-                    attribute: 1,
-                    baseIndent: 1,
-                    closeBracket: 0
-                }
-            ]
+            ...generalRules,
+            ...vueRules
         }
     },
     {
@@ -141,13 +132,7 @@ export default [
             },
             globals: sharedGlobals
         },
-        rules: {
-            'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
-            'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-            'no-unused-vars': 'off',
-            'prefer-const': 'warn',
-            'no-var': 'error'
-        }
+        rules: generalRules
     },
     {
         files: ['**/*.{js,ts,vue}'],

--- a/src/gui-v3/eslint.config.js
+++ b/src/gui-v3/eslint.config.js
@@ -118,7 +118,16 @@ export default [
             'no-unused-vars': 'off',
             'vue/multi-word-component-names': 'off',
             'vue/valid-v-slot': 'off',
-            'vue/no-mutating-props': 'off'
+            'vue/no-mutating-props': 'off',
+            'vue/html-indent': [
+                'warn',
+                4,
+                {
+                    attribute: 1,
+                    baseIndent: 1,
+                    closeBracket: 0
+                }
+            ]
         }
     },
     {

--- a/src/gui-v3/index.html
+++ b/src/gui-v3/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex, notranslate" />
     <meta name="theme-color" content="#3f92dd" />
+    <meta name="color-scheme" content="light dark" />
     <meta name="description" content="Taranis NG - Open-Source Intelligence Platform" />
     <meta name="keywords" content="OSINT, intelligence, analysis, threat intelligence" />
     <link rel="icon" href="favicon.ico">

--- a/src/gui-v3/package.json
+++ b/src/gui-v3/package.json
@@ -17,7 +17,7 @@
         "test": "vitest",
         "test:unit": "vitest run",
         "test:ui": "vitest --ui",
-        "test:coverage": "vitest run",
+        "test:coverage": "vitest run --coverage",
         "test:e2e": "playwright test",
         "test:e2e:ui": "playwright test --ui --config=playwright.ui.config.js",
         "test:e2e:ui:remote": "playwright test --ui --ui-host=127.0.0.1 --ui-port=9323 --config=playwright.ui.config.js",

--- a/src/gui-v3/src/App.vue
+++ b/src/gui-v3/src/App.vue
@@ -39,14 +39,17 @@
     const navVisible = ref(true)
     const isAuth = computed(() => authStore.isAuthenticated)
 
-    // Watch theme changes and apply dark-mode class to HTML element for PrimeVue
+    // Watch theme changes and apply dark-mode/light-mode classes to HTML element.
+    // These override the prefers-color-scheme CSS fallback once the user's preference is known.
     watch(
         () => theme.global.name.value,
         (newTheme) => {
             if (newTheme === 'dark') {
                 document.documentElement.classList.add('dark-mode')
+                document.documentElement.classList.remove('light-mode')
             } else {
                 document.documentElement.classList.remove('dark-mode')
+                document.documentElement.classList.add('light-mode')
             }
             console.log('[App] Theme changed to:', newTheme, 'HTML classes:', document.documentElement.className)
         },

--- a/src/gui-v3/src/components/analyze/NewReportItem.vue
+++ b/src/gui-v3/src/components/analyze/NewReportItem.vue
@@ -1,7 +1,7 @@
 <template>
     <v-row>
         <v-btn v-if="showButton && canCreate" color="primary" variant="elevated" @click="addEmptyReportItem">
-            <v-icon start>mdi-plus</v-icon>
+            <v-icon start> mdi-plus </v-icon>
             <span>{{ t('common.add_btn') }}</span>
         </v-btn>
 
@@ -31,7 +31,7 @@
                 <v-progress-circular indeterminate size="64" />
             </v-overlay>
 
-            <v-card>
+            <v-card class="d-flex flex-column" style="height: 100vh">
                 <v-toolbar color="primary" dark data-dialog="report-item">
                     <v-btn icon data-btn="cancel" @click="cancel">
                         <v-icon>mdi-close-circle</v-icon>
@@ -59,17 +59,24 @@
                     />
 
                     <v-btn v-if="!edit" variant="text" @click="addReportItem">
-                        <v-icon start>mdi-content-save</v-icon>
+                        <v-icon start> mdi-content-save </v-icon>
                         <span>{{ t('common.save') }}</span>
                     </v-btn>
                 </v-toolbar>
 
-                <v-row no-gutters>
-                    <v-col :cols="verticalView ? 6 : 12" :style="verticalView ? 'height: calc(100vh - 3em); overflow-y: auto;' : ''">
+                <!-- Row fills the space left below the toolbar; columns scroll internally so the
+                     toolbar stays fixed and there is no overflow when the form is empty. -->
+                <v-row no-gutters class="flex-grow-1" style="min-height: 0">
+                    <v-col :cols="verticalView ? 6 : 12" style="height: 100%; overflow-y: auto">
                         <v-form ref="formRef" class="px-4" @submit.prevent="addReportItem">
                             <v-row no-gutters>
-                                <v-col v-if="edit" cols="12">
-                                    <span class="text-caption text-grey">ID: {{ report_item.uuid }}</span>
+                                <!-- Always rendered so create mode reserves the same vertical space
+                                     the ID line occupies when editing; a non-breaking space holds the line. -->
+                                <v-col cols="12">
+                                    <span class="text-caption text-grey">
+                                        <template v-if="edit">ID: {{ report_item.uuid }}</template>
+                                        <template v-else>&nbsp;</template>
+                                    </span>
                                 </v-col>
                                 <v-col cols="4" class="pr-3">
                                     <v-combobox
@@ -170,18 +177,20 @@
                                                     <v-expansion-panel
                                                         v-for="attribute_item in attribute_group.attribute_group_items"
                                                         :key="attribute_item.attribute_group_item.id"
-                                                        class="item-panel"
+                                                        :class="['item-panel', { 'item-panel--half': isHalfWidth(attribute_item) }]"
                                                     >
                                                         <v-expansion-panel-title class="pa-2 font-weight-bold text-primary rounded-0">
-                                                            <v-row>
-                                                                <span>{{ attribute_item.attribute_group_item.title }}</span>
+                                                            <div class="d-flex align-center w-100">
+                                                                <span class="text-truncate">{{
+                                                                    attribute_item.attribute_group_item.title
+                                                                }}</span>
                                                                 <span
                                                                     v-if="getAttributeMeta(attribute_item)"
-                                                                    class="attribute-meta text-medium-emphasis ml-2"
+                                                                    class="attribute-meta text-medium-emphasis text-no-wrap ml-auto mr-2"
                                                                 >
                                                                     {{ getAttributeMeta(attribute_item) }}
                                                                 </span>
-                                                            </v-row>
+                                                            </div>
                                                         </v-expansion-panel-title>
                                                         <v-expansion-panel-text class="pt-0">
                                                             <v-row align="center">
@@ -233,12 +242,7 @@
                         </v-form>
                     </v-col>
 
-                    <v-col
-                        v-if="verticalView"
-                        :cols="6"
-                        style="height: calc(100vh - 3em); overflow-y: auto"
-                        class="pa-5 taranis-ng-vertical-view"
-                    >
+                    <v-col v-if="verticalView" :cols="6" style="height: 100%; overflow-y: auto" class="pa-5 taranis-ng-vertical-view">
                         <NewsItemSelector
                             ref="newsItemSelectorRef"
                             attach=".taranis-ng-vertical-view"
@@ -774,6 +778,13 @@
         news_item_aggregates.value = Array.isArray(items) ? [...items] : []
     }
 
+    // Compact attribute types that only need a narrow field, so two can share a row.
+    const HALF_WIDTH_TYPES = ['DATE', 'CWE', 'CVE']
+    const isHalfWidth = (attributeItem) => {
+        const type = attributeItem?.attribute_group_item?.attribute?.type
+        return HALF_WIDTH_TYPES.includes(type)
+    }
+
     const getAttributeMeta = (attributeItem) => {
         const values = Array.isArray(attributeItem?.values) ? attributeItem.values : []
         let latest: Record<string, unknown> | null = null
@@ -1049,5 +1060,19 @@
         font-size: 0.8rem;
         font-weight: 400;
         text-transform: none;
+    }
+
+    /* Let the panel list wrap so compact attributes can pair up two-per-row.
+       8px gap; each half-panel is 50% minus half the gap. */
+    .items {
+        gap: 8px;
+        align-items: flex-start;
+        justify-content: flex-start;
+    }
+
+    .item-panel--half {
+        flex: 1 1 calc(50% - 4px);
+        max-width: calc(50% - 4px);
+        border-radius: 4px;
     }
 </style>

--- a/src/gui-v3/src/components/analyze/NewsItemSelector.vue
+++ b/src/gui-v3/src/components/analyze/NewsItemSelector.vue
@@ -11,7 +11,7 @@
                     <v-toolbar-title>{{ t('assess.attached_news_items') }}</v-toolbar-title>
                     <v-spacer />
                     <v-btn @click="handleAdd">
-                        <v-icon start>mdi-plus-box</v-icon>
+                        <v-icon start> mdi-plus-box </v-icon>
                         {{ t('common.add_items') }}
                     </v-btn>
                 </v-toolbar>
@@ -73,8 +73,13 @@
                         <!-- Content Slot -->
                         <template #content>
                             <div class="d-flex align-center" style="gap: 12px">
-                                <!-- News Item Content -->
-                                <div class="flex-grow-1">
+                                <!-- News Item Content (click to read) -->
+                                <div
+                                    class="flex-grow-1"
+                                    style="cursor: pointer"
+                                    :title="t('assess.read_news_item')"
+                                    @click="openDetail(item)"
+                                >
                                     <!-- Source and Date Info -->
                                     <div class="text-caption text-grey mb-2">
                                         <v-row align="center" no-gutters>
@@ -103,6 +108,20 @@
                                     <div class="text-body-2 mb-3">
                                         {{ item.description }}
                                     </div>
+
+                                    <!-- Aggregate: expand to reveal the child news items (like Assess) -->
+                                    <v-btn
+                                        v-if="getNewsItemCount(item) > 1"
+                                        size="small"
+                                        color="primary"
+                                        variant="outlined"
+                                        @click.stop="toggleExpand(item.id)"
+                                    >
+                                        <v-icon start>
+                                            {{ isExpanded(item.id) ? ICONS.ARROW_DOWN_DROP_CIRCLE : ICONS.ARROW_RIGHT_DROP_CIRCLE }}
+                                        </v-icon>
+                                        {{ t('card_item.aggregated_items') }}: {{ getNewsItemCount(item) }}
+                                    </v-btn>
                                 </div>
 
                                 <!-- Remove Button on the Right, Centered -->
@@ -120,6 +139,17 @@
                             </div>
                         </template>
                     </BaseCard>
+
+                    <!-- Child news items of the aggregate; click one to read it. -->
+                    <div v-if="isExpanded(item.id) && getNewsItemCount(item) > 1" class="mt-1">
+                        <CardAssessItem
+                            v-for="child in item.news_items"
+                            :key="child.id"
+                            :news-item="child"
+                            :analyze-selector="true"
+                            @show-detail="openDetail"
+                        />
+                    </div>
                 </v-col>
             </v-row>
         </v-container>
@@ -128,7 +158,7 @@
         <v-dialog v-model="showRemoveConfirm" max-width="500">
             <v-card>
                 <v-card-title class="d-flex align-center">
-                    <v-icon color="primary" class="mr-2">mdi-help-circle</v-icon>
+                    <v-icon color="primary" class="mr-2"> mdi-help-circle </v-icon>
                     {{ t('common.messagebox.remove') }}
                 </v-card-title>
                 <v-card-text>
@@ -145,6 +175,10 @@
                 </v-card-actions>
             </v-card>
         </v-dialog>
+
+        <!-- News item reader. Contained to the right column in side-by-side mode;
+             a normal centered modal otherwise. Read-only (actions hidden). -->
+        <NewsItemDetailDialog v-model="detailDialog" :news-item="detailItem" :contained="verticalView" multi-select-active />
     </v-container>
 </template>
 
@@ -152,11 +186,14 @@
     import { ref, computed, nextTick, onMounted, onUnmounted, watch } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useAssessStore } from '@/stores/assess'
+    import { useConfigStore } from '@/stores/config'
     import { useAuth } from '@/composables/useAuth'
     import { PERMISSIONS } from '@/services/auth/permissions'
     import { updateReportItem, getReportItemData } from '@/api/analyze'
     import { ICONS } from '@/config/ui-constants'
     import ToolbarFilterAssess from '@/components/assess/ToolbarFilterAssess.vue'
+    import NewsItemDetailDialog from '@/components/assess/NewsItemDetailDialog.vue'
+    import CardAssessItem from '@/components/assess/CardAssessItem.vue'
     import ContentDataAssess from '@/components/assess/ContentDataAssess.vue'
     import BaseCard from '@/components/common/BaseCard.vue'
 
@@ -166,6 +203,7 @@
         description?: string
         in_reports_count?: number
         news_items?: Array<{
+            id: number | string
             news_item_data?: {
                 osint_source_name?: string
                 source?: string
@@ -173,6 +211,7 @@
                 link?: string
                 [key: string]: unknown
             }
+            [key: string]: unknown
         }>
         [key: string]: unknown
     }
@@ -218,6 +257,7 @@
 
     const { t } = useI18n()
     const assessStore = useAssessStore()
+    const configStore = useConfigStore()
     const { checkPermission, getUserId } = useAuth()
 
     // Refs
@@ -226,6 +266,8 @@
 
     // Reactive state
     const selectorOpen = ref<boolean>(false)
+    const detailDialog = ref<boolean>(false)
+    const detailItem = ref<SelectorItem | null>(null)
     const value = ref<SelectorItem[]>(props.values || [])
     const selectedItems = ref<SelectorItem[]>(props.values || [])
     const groups = ref<SelectorGroup[]>([])
@@ -255,6 +297,20 @@
 
     const getNewsItemCount = (item: SelectorItem): number => {
         return item.news_items?.length ?? 0
+    }
+
+    // Open the news item for reading. In side-by-side mode the dialog is contained to the
+    // right-hand column so the user can read it next to the report form.
+    const openDetail = (item: SelectorItem): void => {
+        detailItem.value = item
+        detailDialog.value = true
+    }
+
+    // Track which aggregate cards are expanded to reveal their child news items.
+    const expandedItems = ref<Record<string, boolean>>({})
+    const isExpanded = (id: string | number): boolean => !!expandedItems.value[String(id)]
+    const toggleExpand = (id: string | number): void => {
+        expandedItems.value[String(id)] = !expandedItems.value[String(id)]
     }
 
     // Methods
@@ -459,12 +515,23 @@
 
     // Lifecycle
     onMounted(async () => {
-        // Load groups (OSINT sources for Assess)
-        // TODO: Load from store or API
-        groups.value = [
-            { id: 'all', title: 'All', icon: 'mdi-folder', translate: false },
-            { id: 'unread', title: 'assess.unread', icon: 'mdi-email-multiple', color: 'primary', translate: true }
-        ]
+        // Load the same OSINT source groups the Assess view shows in its sidebar
+        // (includes the leading "All" category). Read/unread is handled by the toolbar filter.
+        try {
+            await configStore.loadOSINTSourceGroupsAssess({ search: '' })
+            groups.value = configStore.osintSourceGroupsForAssess.map((g) => {
+                const group: SelectorGroup = {
+                    id: String(g.id),
+                    title: g.title,
+                    icon: g.icon,
+                    translate: !!g.translate
+                }
+                if (g.color) group.color = g.color
+                return group
+            })
+        } catch (error) {
+            console.error('Error loading OSINT source groups:', error)
+        }
 
         const firstGroup = groups.value[0]
         selectedGroupId.value = firstGroup ? firstGroup.id : ''

--- a/src/gui-v3/src/components/analyze/RemoteReportItemSelector.vue
+++ b/src/gui-v3/src/components/analyze/RemoteReportItemSelector.vue
@@ -2,7 +2,7 @@
     <v-container>
         <!-- Activate Button -->
         <v-btn v-if="canModify && groups.length > 0" variant="elevated" size="small" class="mb-4" @click="openSelector">
-            <v-icon start>mdi-plus</v-icon>
+            <v-icon start> mdi-plus </v-icon>
             {{ t('report_item.select_remote') }}
         </v-btn>
 
@@ -17,7 +17,7 @@
                     <v-toolbar-title>{{ t('report_item.select_remote') }}</v-toolbar-title>
                     <v-spacer />
                     <v-btn @click="handleAdd">
-                        <v-icon start>mdi-plus-box</v-icon>
+                        <v-icon start> mdi-plus-box </v-icon>
                         {{ t('common.add') }}
                     </v-btn>
                 </v-toolbar>
@@ -64,8 +64,7 @@
         <RemoteReportItem ref="remoteReportItemDialog" />
 
         <!-- Selected Items Display -->
-        <div v-if="!selectorOpen" class="selected-items-container ml-4">
-            <v-spacer style="height: 8px" />
+        <div v-if="!selectorOpen" class="selected-items-container ml-4 pt-2">
             <CardAnalyze
                 v-for="item in value"
                 :key="item.id"

--- a/src/gui-v3/src/components/assess/NewsItemDetailDialog.vue
+++ b/src/gui-v3/src/components/assess/NewsItemDetailDialog.vue
@@ -1,5 +1,14 @@
 <template>
-    <v-dialog v-model="isOpen" max-width="90vw" max-height="90vh" scrollable @update:model-value="handleClose">
+    <!-- contained renders the dialog inside its positioned ancestor (e.g. the side-by-side
+         right column) instead of as a centered, full-screen-overlay modal. -->
+    <v-dialog
+        v-model="isOpen"
+        :contained="contained"
+        :max-width="contained ? '100%' : '90vw'"
+        max-height="90vh"
+        scrollable
+        @update:model-value="handleClose"
+    >
         <v-card style="min-height: 70vh; display: flex; flex-direction: column">
             <!-- Toolbar -->
             <v-toolbar color="primary" dark>
@@ -217,12 +226,14 @@
             newsItem?: NewsItemModel | null
             multiSelectActive?: boolean
             actionsDisabled?: boolean
+            contained?: boolean
         }>(),
         {
             modelValue: false,
             newsItem: () => ({}),
             multiSelectActive: false,
-            actionsDisabled: false
+            actionsDisabled: false,
+            contained: false
         }
     )
 

--- a/src/gui-v3/src/components/common/CalculatorCVSS.vue
+++ b/src/gui-v3/src/components/common/CalculatorCVSS.vue
@@ -1,5 +1,13 @@
 <template>
-    <v-btn variant="text" size="small" :disabled="disabled" :title="$t('report_item.tooltip.cvss_detail')" @click.prevent="openDialog">
+    <!-- Compact icon button so it fits inside a text field's append-inner slot -->
+    <v-btn
+        icon
+        variant="text"
+        density="compact"
+        :disabled="disabled"
+        :title="$t('report_item.tooltip.cvss_detail')"
+        @click.prevent="openDialog"
+    >
         <v-icon>{{ ICONS.CALCULATOR }}</v-icon>
     </v-btn>
 
@@ -35,17 +43,24 @@
                         placeholder="Enter CVSS vector string..."
                         @update:model-value="onVectorInput"
                     />
-                    <v-row justify="center" no-gutters>
-                        <v-col
-                            v-for="scoreItem in scoreDisplay"
-                            :key="scoreItem.name"
-                            class="pa-0 mx-1 severity-box"
-                            :class="scoreItem.severityClass"
-                        >
-                            <span class="text-body-2 text-white">{{ scoreItem.label }}</span>
-                            <span class="text-body-2 text-white font-weight-bold text-uppercase">{{ scoreItem.severityLabel }}</span>
-                            <br />
-                            <span class="text-h5 font-weight-medium score-value">{{ scoreItem.score }}</span>
+                    <v-row no-gutters class="ga-1">
+                        <v-col v-for="scoreItem in scoreDisplay" :key="scoreItem.name">
+                            <v-sheet
+                                :color="scoreItem.color"
+                                rounded
+                                height="96"
+                                class="pa-2 text-center text-white d-flex flex-column justify-center"
+                            >
+                                <div class="text-body-2 text-truncate">
+                                    {{ scoreItem.label }}
+                                </div>
+                                <div class="text-body-2 font-weight-bold text-uppercase text-truncate">
+                                    {{ scoreItem.severityLabel }}
+                                </div>
+                                <div class="text-h5 font-weight-medium mt-1">
+                                    {{ scoreItem.score }}
+                                </div>
+                            </v-sheet>
                         </v-col>
                     </v-row>
                 </v-sheet>
@@ -58,7 +73,7 @@
                     :key="groupIndex"
                     variant="outlined"
                     class="mb-4"
-                    :class="`metric-group-${group.severityClass}`"
+                    :style="{ borderLeft: `4px solid ${group.color}` }"
                 >
                     <v-card-title class="text-uppercase text-body-1 font-weight-bold pa-3">
                         {{ group.label }}
@@ -123,7 +138,16 @@
     import { ref, computed, watch, nextTick, triggerRef } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { ICONS } from '@/config/ui-constants'
-    import { VERSION_CLASSES, createInstance, stripParentheses, detectVersion, getSeverityRating, calculateScoreItems } from './cvss-utils'
+    import {
+        VERSION_CLASSES,
+        createInstance,
+        stripParentheses,
+        detectVersion,
+        getSeverityRating,
+        buildScoreItems,
+        calculateScoreItems,
+        SEVERITY_COLORS
+    } from './cvss-utils'
 
     const { t, te } = useI18n()
 
@@ -133,6 +157,7 @@
         name: string
         label: string
         score: string | number
+        color: string
         severityLabel: string
         severityClass: string
     }
@@ -201,15 +226,15 @@
         'Attack Complexity': 'attack_complexity',
         'Privileges Required': 'privileges_required',
         'User Interaction': 'user_interaction',
-        Scope: 'scope',
+        'Scope': 'scope',
         'Confidentiality Impact': 'confidentiality',
-        Confidentiality: 'confidentiality',
+        'Confidentiality': 'confidentiality',
         'Integrity Impact': 'integrity',
-        Integrity: 'integrity',
+        'Integrity': 'integrity',
         'Availability Impact': 'availability',
-        Availability: 'availability',
+        'Availability': 'availability',
         'Exploit Code Maturity': 'exploitability_code_maturity',
-        Exploitability: 'exploitability_code_maturity',
+        'Exploitability': 'exploitability_code_maturity',
         'Remediation Level': 'remediation_level',
         'Report Confidence': 'report_confidence',
         'Confidentiality Requirement': 'confidentiality_requirement',
@@ -224,7 +249,7 @@
         'Modified Integrity': 'modified_integrity',
         'Modified Availability': 'modified_availability',
         // CVSS 2.0 specific
-        Authentication: 'authentication',
+        'Authentication': 'authentication',
         'Collateral Damage Potential': 'collateral_damage_potential',
         'Target Distribution': 'target_distribution',
         // CVSS 4.0 specific
@@ -242,70 +267,70 @@
         'Modified Subsequent System Integrity': 'modified_subsequent_system_integrity',
         'Modified Subsequent System Availability': 'modified_subsequent_system_availability',
         'Modified Attack Requirements': 'modified_attack_requirements',
-        Safety: 'safety',
-        Automatable: 'automatable',
-        Recovery: 'recovery',
+        'Safety': 'safety',
+        'Automatable': 'automatable',
+        'Recovery': 'recovery',
         'Value Density': 'value_density',
         'Vulnerability Response Effort': 'vulnerability_response_effort',
         'Provider Urgency': 'provider_urgency'
     }
 
     const VALUE_NAME_TO_I18N: Record<string, string> = {
-        Network: 'network',
-        Adjacent: 'adjacent',
+        'Network': 'network',
+        'Adjacent': 'adjacent',
         'Adjacent Network': 'adjacent_network',
-        Local: 'local',
-        Physical: 'physical',
-        Low: 'low',
-        High: 'high',
-        None: 'none',
-        Required: 'required',
-        Unchanged: 'unchanged',
-        Changed: 'changed',
+        'Local': 'local',
+        'Physical': 'physical',
+        'Low': 'low',
+        'High': 'high',
+        'None': 'none',
+        'Required': 'required',
+        'Unchanged': 'unchanged',
+        'Changed': 'changed',
         'Not Defined': 'not_defined',
-        Medium: 'medium',
-        Unproven: 'unproven',
+        'Medium': 'medium',
+        'Unproven': 'unproven',
         'Proof-of-Concept': 'proof_of_concept',
         'Proof of Concept': 'proof_of_concept',
-        Functional: 'functional',
+        'Functional': 'functional',
         'Official Fix': 'official_fix',
         'Temporary Fix': 'temporary_fix',
-        Workaround: 'workaround',
-        Unavailable: 'unavailable',
-        Unknown: 'unknown',
-        Reasonable: 'reasonable',
-        Confirmed: 'confirmed',
+        'Workaround': 'workaround',
+        'Unavailable': 'unavailable',
+        'Unknown': 'unknown',
+        'Reasonable': 'reasonable',
+        'Confirmed': 'confirmed',
         // CVSS 2.0 specific
-        Multiple: 'multiple',
-        Single: 'single',
+        'Multiple': 'multiple',
+        'Single': 'single',
         // CVSS 4.0 specific
-        Present: 'present',
-        Active: 'active',
-        Passive: 'passive',
-        Attacked: 'attacked',
+        'Present': 'present',
+        'Active': 'active',
+        'Passive': 'passive',
+        'Attacked': 'attacked',
         'Not Attacked': 'not_attacked',
-        Clear: 'clear',
-        Green: 'green',
-        Amber: 'amber',
-        Red: 'red',
-        Negligible: 'negligible',
-        Diffuse: 'diffuse',
-        Concentrated: 'concentrated',
-        Automatic: 'automatic',
-        User: 'user',
-        Irrecoverable: 'irrecoverable',
-        Automatable: 'automatable'
+        'Clear': 'clear',
+        'Green': 'green',
+        'Amber': 'amber',
+        'Red': 'red',
+        'Negligible': 'negligible',
+        'Diffuse': 'diffuse',
+        'Concentrated': 'concentrated',
+        'Automatic': 'automatic',
+        'User': 'user',
+        'Irrecoverable': 'irrecoverable',
+        'Automatable': 'automatable'
     }
 
     // Labels for metric group cards (more specific than score labels)
     const CATEGORY_GROUP_LABELS: Record<string, string> = {
-        base: 'cvss_calculator.base_score',
-        temporal: 'cvss_calculator.temporal_score',
-        environmental: 'cvss_calculator.environmental_score',
-        threat: 'cvss_calculator.threat_score',
+        'base': 'cvss_calculator.base_score',
+        'temporal': 'cvss_calculator.temporal_score',
+        'environmental': 'cvss_calculator.environmental_score',
+        'threat': 'cvss_calculator.threat_score',
         'environmental-base': 'cvss_calculator.environmental_base_score',
         'environmental-security-requirement': 'cvss_calculator.environmental_security_requirement_score',
-        supplemental: 'cvss_calculator.supplemental_score'
+        'supplemental': 'cvss_calculator.supplemental_score'
     }
 
     const CATEGORY_TOOLTIP_KEYS: Record<string, string> = {
@@ -356,10 +381,17 @@
         }
     })
 
-    // Computed: score display items for header
-    // Uses the vector string to create a fresh instance (same as attribute display)
+    // Computed: score display items for header — driven directly from the live
+    // instance so scores are always present regardless of version or text input state.
     const scoreDisplay = computed<ScoreItem[]>(() => {
-        return (calculateScoreItems(vectorInput.value, t, te) || []) as ScoreItem[]
+        // Prefer parsing the actual vector string: a fresh instance computes every metric
+        // (incl. CVSS 4.0 threat/environmental) correctly.
+        const fromVector = calculateScoreItems(vectorInput.value, t, te) as ScoreItem[] | null
+        if (fromVector) return fromVector
+        // Fallback for when there is no parseable vector yet (e.g. a freshly opened
+        // calculator with a version selected but nothing typed): use the live instance.
+        if (!scores.value) return []
+        return buildScoreItems(scores.value, selectedVersion.value, t, te)
     })
 
     function getScoreTypeForCategory(categoryName: string): string {
@@ -423,6 +455,7 @@
             label: string
             tooltipKey: string | null
             severityClass: string
+            color: string
             metrics: MetricUi[]
         }> = []
 
@@ -440,6 +473,7 @@
                 label: labelKey ? t(labelKey) : category.name,
                 tooltipKey: tooltipKey && te(tooltipKey) ? tooltipKey : null,
                 severityClass: severity.name,
+                color: SEVERITY_COLORS[severity.name as keyof typeof SEVERITY_COLORS] ?? SEVERITY_COLORS.na,
                 metrics: mapComponents(components)
             })
         }
@@ -552,54 +586,5 @@
     .vector-input {
         max-width: 800px;
         font-family: monospace;
-    }
-
-    .severity-box {
-        border-radius: 4px;
-        padding: 4px 8px;
-        max-width: 280px;
-        transition:
-            background-color 250ms,
-            color 250ms;
-    }
-
-    .severity-none {
-        background-color: #53aa33;
-    }
-    .severity-na {
-        background-color: #9e9e9e;
-    }
-    .severity-low {
-        background-color: #ffcb0d;
-    }
-    .severity-medium {
-        background-color: #f9a009;
-    }
-    .severity-high {
-        background-color: #df3d03;
-    }
-    .severity-critical {
-        background-color: red;
-    }
-
-    .score-value {
-        display: block;
-        line-height: 1.4;
-    }
-
-    .metric-group-none {
-        border-left: 4px solid #53aa33;
-    }
-    .metric-group-low {
-        border-left: 4px solid #ffcb0d;
-    }
-    .metric-group-medium {
-        border-left: 4px solid #f9a009;
-    }
-    .metric-group-high {
-        border-left: 4px solid #df3d03;
-    }
-    .metric-group-critical {
-        border-left: 4px solid red;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeAttachment.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeAttachment.vue
@@ -113,6 +113,6 @@
 
     .value-holder {
         width: 100%;
-        margin-bottom: 4px;
+        margin-bottom: 2px;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeBoolean.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeBoolean.vue
@@ -90,6 +90,6 @@
 
     .value-holder {
         width: 100%;
-        margin-bottom: 4px;
+        margin-bottom: 2px;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeCPE.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeCPE.vue
@@ -12,6 +12,7 @@
                 <AttributeValueLayout
                     v-if="!readOnly && canModify && !value.remote"
                     :del-button="true"
+                    embed-delete
                     :occurrence="attributeGroup.min_occurrence"
                     :values="values"
                     :val-index="index"
@@ -20,18 +21,23 @@
                     <template #col_left>
                         <span v-if="values.length > 1" class="cpe-number text--disabled">{{ index + 1 }}.</span>
                     </template>
-                    <template #col_middle>
+                    <template #col_middle="{ delVisible, onDelete }">
                         <v-text-field
                             v-model="value.value"
                             density="compact"
                             variant="outlined"
+                            hide-details="auto"
                             label="cpe:2.3:a:vendor:product:version:..."
                             :class="getLockedStyle(index)"
                             :disabled="value.locked || !canModify"
                             @focus="onFocus(index)"
                             @blur="onBlur(index)"
                             @keyup="onKeyUp(index)"
-                        />
+                        >
+                            <template #append-inner>
+                                <AttributeFieldDeleteButton :visible="delVisible" @delete="onDelete" />
+                            </template>
+                        </v-text-field>
                     </template>
                 </AttributeValueLayout>
             </div>
@@ -43,6 +49,7 @@
     import { onMounted } from 'vue'
     import AttributeItemLayout from './AttributeItemLayout.vue'
     import AttributeValueLayout from './AttributeValueLayout.vue'
+    import AttributeFieldDeleteButton from '@/components/common/buttons/AttributeFieldDeleteButton.vue'
     import { useAttributes } from './useAttributes'
 
     type AttributeValueItem = {
@@ -106,6 +113,6 @@
 
     .value-holder {
         width: 100%;
-        margin-bottom: 4px;
+        margin-bottom: 2px;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeCVE.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeCVE.vue
@@ -15,6 +15,7 @@
                 <AttributeValueLayout
                     v-if="!readOnly && canModify && !value.remote"
                     :del-button="true"
+                    embed-delete
                     :occurrence="attributeGroup.min_occurrence"
                     :values="values"
                     :val-index="index"
@@ -23,18 +24,23 @@
                     <template #col_left>
                         <span v-if="values.length > 1" class="cve-number text--disabled">{{ index + 1 }}.</span>
                     </template>
-                    <template #col_middle>
+                    <template #col_middle="{ delVisible, onDelete }">
                         <v-text-field
                             v-model="value.value"
                             density="compact"
                             variant="outlined"
+                            hide-details="auto"
                             label="CVE-YYYY-NNNNN"
                             :class="getLockedStyle(index)"
                             :disabled="value.locked || !canModify"
                             @focus="onFocus(index)"
                             @blur="onBlur(index)"
                             @keyup="onKeyUp(index)"
-                        />
+                        >
+                            <template #append-inner>
+                                <AttributeFieldDeleteButton :visible="delVisible" @delete="onDelete" />
+                            </template>
+                        </v-text-field>
                     </template>
                 </AttributeValueLayout>
             </div>
@@ -47,6 +53,7 @@
     import { ICONS } from '@/config/ui-constants'
     import AttributeItemLayout from './AttributeItemLayout.vue'
     import AttributeValueLayout from './AttributeValueLayout.vue'
+    import AttributeFieldDeleteButton from '@/components/common/buttons/AttributeFieldDeleteButton.vue'
     import { useAttributes } from './useAttributes'
 
     type AttributeValueItem = {
@@ -104,6 +111,6 @@
 
     .value-holder {
         width: 100%;
-        margin-bottom: 4px;
+        margin-bottom: 2px;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeCVSS.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeCVSS.vue
@@ -1,37 +1,37 @@
 <template>
     <AttributeItemLayout :add-button="addButtonVisible" :values="values" @add-value="add">
         <template #content>
-            <div v-for="(value, index) in values" :key="`${value.index}-${index}`" class="value-holder">
+            <div v-for="(value, index) in values" :key="`${value.index}-${index}`" class="w-100 mb-1">
                 <!-- Read-only or remote -->
-                <span v-if="readOnly || value.remote" class="numbered-cvss-value">
-                    <span v-if="values.length > 1" class="cvss-number text--disabled">{{ index + 1 }}.</span>
+                <div v-if="readOnly || value.remote" class="numbered-cvss-value d-flex align-center w-100 py-2">
+                    <span
+                        v-if="values.length > 1"
+                        class="mr-2 text-disabled"
+                        :style="{ userSelect: 'none', minWidth: '24px', display: 'inline-block' }"
+                        >{{ index + 1 }}.</span
+                    >
                     <v-chip :color="getCVSSColor(value.value)" size="small" class="mr-2">
                         {{ value.value }}
                     </v-chip>
                     <span class="text-caption text-grey">{{ getCVSSSeverity(value.value) }}</span>
-                </span>
+                </div>
 
                 <!-- Editable -->
                 <AttributeValueLayout
                     v-if="!readOnly && canModify && !value.remote"
                     :del-button="true"
+                    embed-delete
                     :occurrence="attributeGroup.min_occurrence"
                     :values="values"
                     :val-index="index"
                     @del-value="del(index)"
                 >
-                    <template #col_left>
-                        <CalculatorCVSS
-                            :model-value="value.value"
-                            :disabled="value.locked || !canModify"
-                            @update:model-value="updateFromCalculator(index, $event)"
-                        />
-                    </template>
-                    <template #col_middle>
+                    <template #col_middle="{ delVisible, onDelete }">
                         <v-text-field
                             v-model="value.value"
                             density="compact"
                             variant="outlined"
+                            hide-details="auto"
                             label="CVSS Vector / Score"
                             :rules="[vectorRule]"
                             :class="getLockedStyle(index)"
@@ -39,31 +39,38 @@
                             @focus="onFocus(index)"
                             @blur="onBlur(index)"
                             @keyup="onKeyUp(index)"
-                        />
+                        >
+                            <template #append-inner>
+                                <CalculatorCVSS
+                                    :model-value="value.value"
+                                    :disabled="value.locked || !canModify"
+                                    @update:model-value="updateFromCalculator(index, $event)"
+                                />
+                                <AttributeFieldDeleteButton :visible="delVisible" @delete="onDelete" />
+                            </template>
+                        </v-text-field>
 
-                        <!-- Score display for vector strings (always rendered to reserve space) -->
-                        <div class="score-display" :style="{ visibility: getVectorScores(value.value) ? 'visible' : 'hidden' }">
-                            <v-row justify="center" no-gutters>
-                                <template v-if="getVectorScores(value.value)">
-                                    <v-col
-                                        v-for="scoreItem in getVectorScores(value.value)"
-                                        :key="scoreItem.name"
-                                        class="pa-0 mx-1 severity-box"
-                                        :class="scoreItem.severityClass"
-                                    >
-                                        <span class="text-body-2 text-white">{{ scoreItem.label }}</span>
-                                        <span class="text-body-2 text-white font-weight-bold text-uppercase">
-                                            {{ scoreItem.severityLabel }}
-                                        </span>
-                                        <br />
-                                        <span class="text-subtitle-1 font-weight-medium score-value">{{ scoreItem.score }}</span>
-                                    </v-col>
-                                </template>
-                                <template v-else>
-                                    <v-col class="pa-0 mx-1 severity-box severity-na" style="min-height: 48px">&nbsp;</v-col>
-                                </template>
-                            </v-row>
-                        </div>
+                        <!-- Score display — always rendered at fixed height to keep layout stable -->
+                        <v-row no-gutters class="mb-2 ga-1">
+                            <v-col v-for="scoreItem in getVectorScores(value.value) ?? placeholderScores" :key="scoreItem.name">
+                                <v-sheet
+                                    :color="scoreItem.color"
+                                    rounded
+                                    height="88"
+                                    class="pa-2 text-center text-white d-flex flex-column justify-center"
+                                >
+                                    <div class="text-body-2 text-truncate">
+                                        {{ scoreItem.label }}
+                                    </div>
+                                    <div class="text-body-2 font-weight-bold text-uppercase text-truncate">
+                                        {{ scoreItem.severityLabel }}
+                                    </div>
+                                    <div class="text-subtitle-1 font-weight-medium mt-1">
+                                        {{ scoreItem.score }}
+                                    </div>
+                                </v-sheet>
+                            </v-col>
+                        </v-row>
                     </template>
                 </AttributeValueLayout>
             </div>
@@ -72,13 +79,15 @@
 </template>
 
 <script setup lang="ts">
-    import { onMounted } from 'vue'
+    import { computed, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
     import AttributeItemLayout from './AttributeItemLayout.vue'
     import AttributeValueLayout from './AttributeValueLayout.vue'
+    import AttributeFieldDeleteButton from '@/components/common/buttons/AttributeFieldDeleteButton.vue'
     import CalculatorCVSS from '../CalculatorCVSS.vue'
     import { useAttributes } from './useAttributes'
-    import { calculateScoreItems, detectVersion, createInstance, stripParentheses } from '../cvss-utils'
+    import { calculateScoreItems, detectVersion, createInstance, stripParentheses, SEVERITY_COLORS } from '../cvss-utils'
+    import type { ScoreItem } from '../cvss-utils'
 
     const { t, te } = useI18n()
 
@@ -120,12 +129,41 @@
         }
     })
 
+    const NA_COLOR = SEVERITY_COLORS.na
+
+    // Placeholder boxes use real translated labels + '–' so all three text lines
+    // are always present and the box height never changes between states.
+    const placeholderScores = computed<ScoreItem[]>(() => [
+        {
+            name: 'base',
+            label: t('cvss_calculator.base_score'),
+            score: '–',
+            color: NA_COLOR,
+            severityClass: 'severity-na',
+            severityLabel: '–'
+        },
+        {
+            name: 'temporal',
+            label: t('cvss_calculator.temporal_score'),
+            score: '–',
+            color: NA_COLOR,
+            severityClass: 'severity-na',
+            severityLabel: '–'
+        },
+        {
+            name: 'environmental',
+            label: t('cvss_calculator.environmental_score'),
+            score: '–',
+            color: NA_COLOR,
+            severityClass: 'severity-na',
+            severityLabel: '–'
+        }
+    ])
+
     const vectorRule = (value: string | null | undefined): true | string => {
         if (!value || value === '') return true
         const cleaned = stripParentheses(value ?? '') ?? ''
-        // Accept plain numeric scores (0.0 - 10.0)
         if (/^(10(\.0)?|[0-9](\.[0-9])?)$/.test(cleaned)) return true
-        // Validate vector strings using the library
         try {
             const version = detectVersion(cleaned)
             if (typeof version !== 'string' || version.length === 0) return t('cvss_calculator.validator')
@@ -138,14 +176,12 @@
 
     function updateFromCalculator(index: number, vectorValue: string): void {
         const item = props.values[index]
-        if (!item) {
-            return
-        }
+        if (!item) return
         item.value = vectorValue
         onKeyUp(index)
     }
 
-    function getVectorScores(value: string | null | undefined): any {
+    function getVectorScores(value: string | null | undefined): ScoreItem[] | null {
         return calculateScoreItems(value ?? '', t, te)
     }
 
@@ -167,57 +203,3 @@
         return 'None'
     }
 </script>
-
-<style scoped>
-    .cvss-number {
-        margin-right: 8px;
-        user-select: none;
-        min-width: 24px;
-        display: inline-block;
-    }
-
-    .numbered-cvss-value {
-        display: flex;
-        align-items: center;
-        width: 100%;
-        padding: 8px 0;
-    }
-
-    .value-holder {
-        width: 100%;
-        margin-bottom: 4px;
-    }
-
-    .score-display {
-        margin-bottom: 8px;
-    }
-
-    .severity-box {
-        border-radius: 4px;
-        padding: 4px 8px;
-        max-width: 200px;
-        text-align: center;
-        transition: background-color 250ms;
-    }
-
-    .severity-none {
-        background-color: #53aa33;
-    }
-    .severity-low {
-        background-color: #ffcb0d;
-    }
-    .severity-medium {
-        background-color: #f9a009;
-    }
-    .severity-high {
-        background-color: #df3d03;
-    }
-    .severity-critical {
-        background-color: red;
-    }
-
-    .score-value {
-        display: block;
-        line-height: 1.4;
-    }
-</style>

--- a/src/gui-v3/src/components/common/attribute/AttributeCWE.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeCWE.vue
@@ -19,6 +19,7 @@
                 <AttributeValueLayout
                     v-if="!readOnly && canModify && !value.remote"
                     :del-button="true"
+                    embed-delete
                     :occurrence="attributeGroup.min_occurrence"
                     :values="values"
                     :val-index="index"
@@ -27,18 +28,23 @@
                     <template #col_left>
                         <span v-if="values.length > 1" class="cwe-number text--disabled">{{ index + 1 }}.</span>
                     </template>
-                    <template #col_middle>
+                    <template #col_middle="{ delVisible, onDelete }">
                         <v-text-field
                             v-model="value.value"
                             density="compact"
                             variant="outlined"
+                            hide-details="auto"
                             label="CWE-NNN"
                             :class="getLockedStyle(index)"
                             :disabled="value.locked || !canModify"
                             @focus="onFocus(index)"
                             @blur="onBlur(index)"
                             @keyup="onKeyUp(index)"
-                        />
+                        >
+                            <template #append-inner>
+                                <AttributeFieldDeleteButton :visible="delVisible" @delete="onDelete" />
+                            </template>
+                        </v-text-field>
                     </template>
                 </AttributeValueLayout>
             </div>
@@ -51,6 +57,7 @@
     import { ICONS } from '@/config/ui-constants'
     import AttributeItemLayout from './AttributeItemLayout.vue'
     import AttributeValueLayout from './AttributeValueLayout.vue'
+    import AttributeFieldDeleteButton from '@/components/common/buttons/AttributeFieldDeleteButton.vue'
     import { useAttributes } from './useAttributes'
 
     type AttributeValueItem = {
@@ -113,6 +120,6 @@
 
     .value-holder {
         width: 100%;
-        margin-bottom: 4px;
+        margin-bottom: 2px;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeDate.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeDate.vue
@@ -11,24 +11,30 @@
                 <AttributeValueLayout
                     v-if="!readOnly && canModify && !value.remote"
                     :del-button="true"
+                    embed-delete
                     :occurrence="attributeGroup.min_occurrence"
                     :values="values"
                     :val-index="index"
                     @del-value="del(index)"
                 >
-                    <template #col_middle>
+                    <template #col_middle="{ delVisible, onDelete }">
                         <v-text-field
                             v-model="value.value"
                             type="date"
                             density="compact"
                             variant="outlined"
+                            hide-details="auto"
                             :label="$t('attribute.value')"
                             :disabled="value.locked || !canModify"
-                            style="max-width: 200px"
+                            style="max-width: 240px"
                             @focus="onFocus(index)"
                             @blur="onBlur(index)"
                             @update:model-value="onEdit(index)"
-                        />
+                        >
+                            <template #append-inner>
+                                <AttributeFieldDeleteButton :visible="delVisible" @delete="onDelete" />
+                            </template>
+                        </v-text-field>
                     </template>
                 </AttributeValueLayout>
             </div>
@@ -41,6 +47,7 @@
     import { useI18n } from 'vue-i18n'
     import AttributeItemLayout from './AttributeItemLayout.vue'
     import AttributeValueLayout from './AttributeValueLayout.vue'
+    import AttributeFieldDeleteButton from '@/components/common/buttons/AttributeFieldDeleteButton.vue'
     import { useAttributes } from './useAttributes'
 
     type AttributeValueItem = {
@@ -101,6 +108,6 @@
 
     .value-holder {
         width: 100%;
-        margin-bottom: 4px;
+        margin-bottom: 2px;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeDateTime.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeDateTime.vue
@@ -12,16 +12,18 @@
                 <AttributeValueLayout
                     v-if="!readOnly && canModify && !value.remote"
                     :del-button="true"
+                    embed-delete
                     :occurrence="attributeGroup.min_occurrence"
                     :values="values"
                     :val-index="index"
                     @del-value="del(index)"
                 >
-                    <template #col_middle>
+                    <template #col_middle="{ delVisible, onDelete }">
                         <v-text-field
                             v-model="value.value"
                             density="compact"
                             variant="outlined"
+                            hide-details="auto"
                             type="datetime-local"
                             :label="$t('attribute.value')"
                             :class="getLockedStyle(index)"
@@ -29,7 +31,11 @@
                             @focus="onFocus(index)"
                             @blur="onBlur(index)"
                             @keyup="onKeyUp(index)"
-                        />
+                        >
+                            <template #append-inner>
+                                <AttributeFieldDeleteButton :visible="delVisible" @delete="onDelete" />
+                            </template>
+                        </v-text-field>
                     </template>
                 </AttributeValueLayout>
             </div>
@@ -40,6 +46,7 @@
 <script setup lang="ts">
     import AttributeItemLayout from './AttributeItemLayout.vue'
     import AttributeValueLayout from './AttributeValueLayout.vue'
+    import AttributeFieldDeleteButton from '@/components/common/buttons/AttributeFieldDeleteButton.vue'
     import { useAttributes } from './useAttributes'
 
     type AttributeValueItem = {
@@ -108,6 +115,6 @@
 
     .value-holder {
         width: 100%;
-        margin-bottom: 4px;
+        margin-bottom: 2px;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeEnum.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeEnum.vue
@@ -11,23 +11,29 @@
                 <AttributeValueLayout
                     v-if="!readOnly && canModify && !value.remote"
                     :del-button="true"
+                    embed-delete
                     :occurrence="attributeGroup.min_occurrence"
                     :values="values"
                     :val-index="index"
                     @del-value="del(index)"
                 >
-                    <template #col_middle>
+                    <template #col_middle="{ delVisible, onDelete }">
                         <v-select
                             v-model="value.value"
                             :items="attributeGroup.attribute?.enum_values || []"
                             density="compact"
                             variant="outlined"
+                            hide-details="auto"
                             :label="$t('attribute.value')"
                             :disabled="value.locked || !canModify"
                             @focus="onFocus(index)"
                             @blur="onBlur(index)"
                             @update:model-value="onEdit(index)"
-                        />
+                        >
+                            <template #append-inner>
+                                <AttributeFieldDeleteButton :visible="delVisible" @delete="onDelete" />
+                            </template>
+                        </v-select>
                     </template>
                 </AttributeValueLayout>
             </div>
@@ -36,9 +42,11 @@
 </template>
 
 <script setup lang="ts">
+    import { onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
     import AttributeItemLayout from './AttributeItemLayout.vue'
     import AttributeValueLayout from './AttributeValueLayout.vue'
+    import AttributeFieldDeleteButton from '@/components/common/buttons/AttributeFieldDeleteButton.vue'
     import { useAttributes } from './useAttributes'
 
     type AttributeValueItem = {
@@ -76,6 +84,13 @@
     const { t } = useI18n()
 
     const { canModify, addButtonVisible, add, del, getLockedStyle, onFocus, onBlur, onEdit } = useAttributes(props)
+
+    // Always show one (possibly empty) field, even when the attribute starts with no values.
+    onMounted(() => {
+        if (props.values?.length === 0 && canModify.value && !props.readOnly) {
+            add()
+        }
+    })
 </script>
 
 <style scoped>
@@ -88,6 +103,6 @@
 
     .value-holder {
         width: 100%;
-        margin-bottom: 4px;
+        margin-bottom: 2px;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeItemLayout.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeItemLayout.vue
@@ -1,22 +1,20 @@
 <template>
-    <v-row justify="center" class="attribute-item-layout pt-2">
-        <v-row no-gutters>
+    <!-- Inner rows must be w-100: without a width, each row's flex-basis is its content's
+         max-content size, so rows can end up sharing a flex line (off-center content) and the
+         content width tracks text length (layout jumps when values change). -->
+    <v-row justify="center" class="attribute-item-layout pt-1">
+        <v-row no-gutters class="w-100">
             <slot name="header">
                 <v-row justify="center">
                     <!-- SORT -->
                     <v-chip-group v-if="values.length > 1" active-class="success" color="" class="pr-4">
-                        <v-chip size="small" class="px-0 mr-1" :title="t('report_item.tooltip.sort_time')" @click="sort(false)">
-                            <v-icon class="px-2" size="small">
+                        <v-chip class="mr-1" :title="t('report_item.tooltip.sort_time')" @click="sort(false)">
+                            <v-icon class="px-1">
                                 {{ ICONS.CLOCK }}
                             </v-icon>
                         </v-chip>
-                        <v-chip
-                            size="small"
-                            class="px-0 mr-1"
-                            :title="t('report_item.tooltip.sort_user')"
-                            @click="sort(true, currentUserName)"
-                        >
-                            <v-icon class="px-2" size="small">
+                        <v-chip class="mr-1" :title="t('report_item.tooltip.sort_user')" @click="sort(true, currentUserName)">
+                            <v-icon class="px-1">
                                 {{ ICONS.ACCOUNT }}
                             </v-icon>
                         </v-chip>
@@ -24,17 +22,17 @@
                 </v-row>
             </slot>
         </v-row>
-        <v-row class="ml-0 mr-4">
+        <v-row class="ml-0 mr-4 w-100">
             <slot name="content" />
         </v-row>
-        <v-row class="ml-3 mr-5">
+        <v-row class="ml-3 mr-5 w-100">
             <slot name="footer" class="pr-0">
                 <v-btn
                     v-if="addButton"
                     variant="flat"
                     size="small"
                     block
-                    class="mt-2"
+                    class="mt-1"
                     :title="t('report_item.tooltip.add_value')"
                     @click="handleAdd"
                 >
@@ -53,6 +51,7 @@
 
     type ItemValue = {
         id?: number | string
+        last_updated?: unknown
         user?: {
             name?: string
         }
@@ -84,12 +83,26 @@
     const sort = (sortByUser: boolean, userName?: string): void => {
         props.values.sort((a: ItemValue, b: ItemValue) => {
             if (sortByUser && userName) {
-                if (userName === a.user?.name && userName !== b.user?.name) {
-                    return -1
-                } else if (userName !== a.user?.name && userName === b.user?.name) {
-                    return 1
+                // Current user's values first, then everyone else's.
+                const aMine = a.user?.name === userName
+                const bMine = b.user?.name === userName
+                if (aMine !== bMine) {
+                    return aMine ? -1 : 1
+                }
+            } else {
+                // Newest first by last_updated timestamp.
+                const aTime = Date.parse(String(a.last_updated ?? ''))
+                const bTime = Date.parse(String(b.last_updated ?? ''))
+                const aValid = !Number.isNaN(aTime)
+                const bValid = !Number.isNaN(bTime)
+                if (aValid && bValid && aTime !== bTime) {
+                    return bTime - aTime
+                }
+                if (aValid !== bValid) {
+                    return aValid ? -1 : 1
                 }
             }
+            // Stable fallback: by id.
             const aId = a.id ?? ''
             const bId = b.id ?? ''
             if (aId < bId) return -1

--- a/src/gui-v3/src/components/common/attribute/AttributeNumber.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeNumber.vue
@@ -12,6 +12,7 @@
                 <AttributeValueLayout
                     v-if="!readOnly && canModify && !value.remote"
                     :del-button="true"
+                    embed-delete
                     :occurrence="attributeGroup.min_occurrence"
                     :values="values"
                     :val-index="index"
@@ -20,19 +21,24 @@
                     <template #col_left>
                         <span v-if="values.length > 1" class="number-index text--disabled">{{ index + 1 }}.</span>
                     </template>
-                    <template #col_middle>
+                    <template #col_middle="{ delVisible, onDelete }">
                         <v-text-field
                             v-model.number="value.value"
                             type="number"
                             density="compact"
                             variant="outlined"
+                            hide-details="auto"
                             :label="$t('attribute.value')"
                             :class="getLockedStyle(index)"
                             :disabled="value.locked || !canModify"
                             @focus="onFocus(index)"
                             @blur="onBlur(index)"
                             @keyup="onKeyUp(index)"
-                        />
+                        >
+                            <template #append-inner>
+                                <AttributeFieldDeleteButton :visible="delVisible" @delete="onDelete" />
+                            </template>
+                        </v-text-field>
                     </template>
                 </AttributeValueLayout>
             </div>
@@ -44,6 +50,7 @@
     import { useI18n } from 'vue-i18n'
     import AttributeItemLayout from './AttributeItemLayout.vue'
     import AttributeValueLayout from './AttributeValueLayout.vue'
+    import AttributeFieldDeleteButton from '@/components/common/buttons/AttributeFieldDeleteButton.vue'
     import { useAttributes } from './useAttributes'
 
     type AttributeValueItem = {
@@ -102,6 +109,6 @@
 
     .value-holder {
         width: 100%;
-        margin-bottom: 4px;
+        margin-bottom: 2px;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeRadio.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeRadio.vue
@@ -135,7 +135,7 @@
 
     .value-holder {
         width: 100%;
-        margin-bottom: 4px;
+        margin-bottom: 2px;
     }
 
     .radio-single-row :deep(.v-selection-control-group) {

--- a/src/gui-v3/src/components/common/attribute/AttributeString.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeString.vue
@@ -12,6 +12,7 @@
                 <AttributeValueLayout
                     v-if="!readOnly && canModify && !value.remote"
                     :del-button="true"
+                    embed-delete
                     :occurrence="attributeGroup.min_occurrence"
                     :values="values"
                     :val-index="index"
@@ -20,18 +21,23 @@
                     <template #col_left>
                         <span v-if="values.length > 1" class="string-number text--disabled">{{ index + 1 }}.</span>
                     </template>
-                    <template #col_middle>
+                    <template #col_middle="{ delVisible, onDelete }">
                         <v-text-field
                             v-model="value.value"
                             density="compact"
                             variant="outlined"
+                            hide-details="auto"
                             :label="$t('attribute.value')"
                             :class="getLockedStyle(index)"
                             :disabled="value.locked || !canModify"
                             @focus="onFocus(index)"
                             @blur="onBlur(index)"
                             @keyup="onKeyUp(index)"
-                        />
+                        >
+                            <template #append-inner>
+                                <AttributeFieldDeleteButton :visible="delVisible" @delete="onDelete" />
+                            </template>
+                        </v-text-field>
                     </template>
                 </AttributeValueLayout>
             </div>
@@ -40,9 +46,11 @@
 </template>
 
 <script setup lang="ts">
+    import { onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
     import AttributeItemLayout from './AttributeItemLayout.vue'
     import AttributeValueLayout from './AttributeValueLayout.vue'
+    import AttributeFieldDeleteButton from '@/components/common/buttons/AttributeFieldDeleteButton.vue'
     import { useAttributes } from './useAttributes'
 
     type AttributeValueItem = {
@@ -77,6 +85,13 @@
     const { t } = useI18n()
 
     const { canModify, addButtonVisible, add, del, getLockedStyle, onFocus, onBlur, onKeyUp } = useAttributes(props)
+
+    // Always show one (possibly empty) field, even when the attribute starts with no values.
+    onMounted(() => {
+        if (props.values?.length === 0 && canModify.value && !props.readOnly) {
+            add()
+        }
+    })
 </script>
 
 <style scoped>
@@ -101,6 +116,6 @@
 
     .value-holder {
         width: 100%;
-        margin-bottom: 4px;
+        margin-bottom: 2px;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeTLP.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeTLP.vue
@@ -1,57 +1,71 @@
 <template>
     <AttributeItemLayout :add-button="addButtonVisible" :values="values" @add-value="add">
         <template #content>
-            <div v-for="(value, index) in values" :key="`${value.index}-${index}`" class="tlp-holder">
+            <div v-for="(value, index) in values" :key="`${value.index}-${index}`" class="w-100">
                 <!-- Read-only or remote -->
-                <div v-if="readOnly || value.remote" class="tlp-display">
-                    <div class="tlp-badge" :style="getTLPStyle(value.value)">
+                <div v-if="readOnly || value.remote" class="tlp-display d-flex align-center ga-3 py-2">
+                    <v-sheet :style="getTLPStyle(value.value)" rounded class="tlp-badge px-3 py-1 text-body-2 font-weight-bold">
                         {{ value.value || '—' }}
-                    </div>
-                    <span class="tlp-description">{{ getTLPDescription(value.value) }}</span>
+                    </v-sheet>
+                    <span class="tlp-description text-body-2 text-medium-emphasis">{{ getTLPDescription(value.value) }}</span>
                 </div>
 
                 <!-- Editable -->
-                <AttributeValueLayout
+                <div
                     v-if="!readOnly && canModify && !value.remote"
-                    :del-button="true"
-                    :occurrence="attributeGroup.min_occurrence"
-                    :values="values"
-                    :val-index="index"
-                    @del-value="del(index)"
+                    class="w-100 pt-2 pb-1"
+                    @mouseenter="setHover(index, true)"
+                    @mouseleave="setHover(index, false)"
                 >
-                    <template #col_middle>
-                        <div class="tlp-selector">
-                            <div class="tlp-options">
-                                <button
-                                    v-for="tlp in tlpOptions"
-                                    :key="tlp"
-                                    type="button"
-                                    class="tlp-button"
-                                    :class="{ active: value.value === tlp }"
-                                    :style="getTLPStyle(tlp)"
-                                    :disabled="value.locked || !canModify"
-                                    @click="setTlpValue(index, tlp)"
-                                >
-                                    {{ tlp }}
-                                </button>
-                            </div>
-                            <div v-if="value.value" class="tlp-info">
-                                {{ getTLPDescription(value.value) }}
-                            </div>
+                    <div class="d-flex align-center ga-2">
+                        <!-- Invisible phantom so both flanking elements are always the same width,
+                             keeping the button group exactly centered regardless of delete visibility. -->
+                        <v-btn variant="text" size="small" style="visibility: hidden; pointer-events: none" tabindex="-1">
+                            <v-icon>{{ ICONS.CLOSE }}</v-icon>
+                        </v-btn>
+
+                        <!-- TLP button group - centered between the two equal-width flankers -->
+                        <div style="flex: 1" class="tlp-options d-flex ga-1">
+                            <button
+                                v-for="tlp in tlpOptions"
+                                :key="tlp"
+                                class="tlp-btn tlp-button"
+                                :style="getTLPButtonStyle(tlp, value.value)"
+                                :disabled="value.locked || !canModify"
+                                @click="setTlpValue(index, tlp)"
+                            >
+                                {{ tlp }}
+                            </button>
                         </div>
-                    </template>
-                </AttributeValueLayout>
+
+                        <!-- Delete button - always occupies the same space; only becomes visible on hover -->
+                        <v-btn
+                            variant="text"
+                            size="small"
+                            :style="{ visibility: canShowDelete(index) ? 'visible' : 'hidden' }"
+                            :title="t('report_item.tooltip.delete_value')"
+                            @click="del(index)"
+                        >
+                            <v-icon>{{ ICONS.CLOSE }}</v-icon>
+                        </v-btn>
+                    </div>
+
+                    <!-- Description centered under the button group -->
+                    <div v-if="value.value" class="text-caption text-medium-emphasis text-center mt-1">
+                        {{ getTLPDescription(value.value) }}
+                    </div>
+                </div>
             </div>
         </template>
     </AttributeItemLayout>
 </template>
 
 <script setup lang="ts">
-    import { onMounted, watch } from 'vue'
+    import { ref, onMounted, watch } from 'vue'
     import type { CSSProperties } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { ICONS } from '@/config/ui-constants'
     import AttributeItemLayout from './AttributeItemLayout.vue'
-    import AttributeValueLayout from './AttributeValueLayout.vue'
     import { useAttributes } from './useAttributes'
 
     type TlpLevel = 'CLEAR' | 'GREEN' | 'AMBER' | 'AMBER+STRICT' | 'RED'
@@ -88,57 +102,70 @@
     const { t } = useI18n()
     const { canModify, addButtonVisible, add, del, onEdit } = useAttributes(props)
 
+    const itemHovers = ref<Record<number, boolean>>({})
+
+    const setHover = (index: number, state: boolean): void => {
+        itemHovers.value[index] = state
+    }
+
+    const canShowDelete = (index: number): boolean => {
+        return !!(
+            itemHovers.value[index] &&
+            (props.attributeGroup.min_occurrence == null || props.attributeGroup.min_occurrence < props.values.length)
+        )
+    }
+
     onMounted(() => {
         if (props.values?.length === 0 && canModify.value && !props.readOnly) {
             add()
         }
     })
 
-    // Set CLEAR as default for new values
     watch(
         () => props.values,
         (newValues: AttributeValueItem[]) => {
             newValues.forEach((val: AttributeValueItem) => {
-                if (!val.value) {
-                    val.value = 'CLEAR'
-                }
+                if (!val.value) val.value = 'CLEAR'
             })
         },
         { immediate: true, deep: true }
     )
 
-    // TLP (Traffic Light Protocol) options in order
     const tlpOptions: TlpLevel[] = ['CLEAR', 'GREEN', 'AMBER', 'AMBER+STRICT', 'RED']
 
-    // TLP color definitions
     const tlpColors: Record<TlpLevel, { bg: string; text: string }> = {
-        CLEAR: { bg: '#ffffff', text: '#000000' },
-        GREEN: { bg: '#33FF00', text: '#000000' },
-        AMBER: { bg: '#FFC000', text: '#000000' },
+        'CLEAR': { bg: '#ffffff', text: '#000000' },
+        'GREEN': { bg: '#33FF00', text: '#000000' },
+        'AMBER': { bg: '#FFC000', text: '#000000' },
         'AMBER+STRICT': { bg: '#FFC000', text: '#000000' },
-        RED: { bg: '#FF2B2B', text: '#ffffff' }
+        'RED': { bg: '#FF2B2B', text: '#ffffff' }
     }
 
-    // TLP descriptions
     const tlpDescriptions: Record<TlpLevel, string> = {
-        CLEAR: 'Unrestricted - Information may be distributed without restriction',
-        GREEN: 'Community - Information may be shared within communities',
-        AMBER: 'Limited Sharing - Information should not be publicly disclosed',
+        'CLEAR': 'Unrestricted - Information may be distributed without restriction',
+        'GREEN': 'Community - Information may be shared within communities',
+        'AMBER': 'Limited Sharing - Information should not be publicly disclosed',
         'AMBER+STRICT': 'Strictly Limited Sharing - Information should not be shared outside the organization',
-        RED: 'Not for Sharing - Information may not be shared with anyone'
+        'RED': 'Not for Sharing - Information may not be shared with anyone'
     }
 
     const getTLPStyle = (tlp: string | null | undefined): CSSProperties => {
         const config = tlp ? tlpColors[tlp as TlpLevel] : undefined
-        if (!config) {
-            return {
-                backgroundColor: '#666666',
-                color: '#ffffff'
-            }
-        }
+        if (!config) return { backgroundColor: '#666666', color: '#ffffff' }
+        return { backgroundColor: config.bg, color: config.text }
+    }
+
+    const getTLPButtonStyle = (tlp: TlpLevel, selectedValue: string): CSSProperties => {
+        const config = tlpColors[tlp]
+        const isActive = tlp === selectedValue
+        // Ring contrasts with the button background. Always set boxShadow even when inactive
+        // so the CSS property value changes but the property itself never appears/disappears,
+        // preventing any layout recalculation that would change button size.
+        const ringColor = config.text === '#ffffff' ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.75)'
         return {
             backgroundColor: config.bg,
-            color: config.text
+            color: config.text,
+            boxShadow: isActive ? `inset 0 0 0 3px ${ringColor}` : 'none'
         }
     }
 
@@ -148,85 +175,30 @@
 
     const setTlpValue = (index: number, tlp: TlpLevel): void => {
         const item = props.values[index]
-        if (!item) {
-            return
-        }
+        if (!item) return
         item.value = tlp
         onEdit(index)
     }
 </script>
 
 <style scoped>
-    .tlp-holder {
-        display: flex;
-        align-items: center;
-        width: 100%;
-        padding: 8px 0;
-    }
-
-    .tlp-display {
-        display: flex;
-        align-items: center;
-        gap: 12px;
-    }
-
-    .tlp-badge {
-        padding: 6px 14px;
-        border-radius: 4px;
-        font-weight: 600;
-        font-size: 0.875rem;
-        min-width: 80px;
-        text-align: center;
-    }
-
-    .tlp-description {
-        font-size: 0.875rem;
-        color: rgba(255, 255, 255, 0.7);
-    }
-
-    .tlp-selector {
-        display: flex;
-        flex-direction: column;
-        gap: 8px;
-        width: 100%;
-    }
-
-    .tlp-options {
-        display: flex;
-        gap: 4px;
-        width: 100%;
-        flex-wrap: nowrap;
-    }
-
-    .tlp-button {
-        padding: 6px 6px;
-        border: 2px solid transparent;
-        border-radius: 4px;
-        font-weight: 600;
-        font-size: 0.65rem;
-        cursor: pointer;
-        transition: all 0.2s;
-        flex: 1;
+    .tlp-btn {
+        height: 36px;
+        /* Basis = label width, so every label always fits; extra space is shared.
+           Labels are static, so widths never change after layout. */
+        flex: 1 1 auto;
         white-space: nowrap;
+        border: none;
+        border-radius: 4px;
+        font-size: 0.75rem;
+        font-weight: 700;
+        cursor: pointer;
+        padding: 0 8px;
+        box-sizing: border-box;
     }
 
-    .tlp-button:not(:disabled):hover {
-        border-color: rgba(255, 255, 255, 0.3);
-    }
-
-    .tlp-button.active {
-        border-color: rgba(255, 255, 255, 0.8);
-        box-shadow: 0 0 8px rgba(255, 255, 255, 0.3);
-    }
-
-    .tlp-button:disabled {
+    .tlp-btn:disabled {
         opacity: 0.5;
         cursor: not-allowed;
-    }
-
-    .tlp-info {
-        font-size: 0.75rem;
-        color: rgba(255, 255, 255, 0.6);
-        padding: 4px 0;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeText.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeText.vue
@@ -21,6 +21,7 @@
                             v-model="value.value"
                             density="compact"
                             variant="outlined"
+                            hide-details="auto"
                             :label="$t('attribute.value')"
                             rows="3"
                             :disabled="value.locked || !canModify"
@@ -92,6 +93,6 @@
 
     .value-holder {
         width: 100%;
-        margin-bottom: 4px;
+        margin-bottom: 2px;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeTime.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeTime.vue
@@ -12,16 +12,18 @@
                 <AttributeValueLayout
                     v-if="!readOnly && canModify && !value.remote"
                     :del-button="true"
+                    embed-delete
                     :occurrence="attributeGroup.min_occurrence"
                     :values="values"
                     :val-index="index"
                     @del-value="del(index)"
                 >
-                    <template #col_middle>
+                    <template #col_middle="{ delVisible, onDelete }">
                         <v-text-field
                             v-model="value.value"
                             density="compact"
                             variant="outlined"
+                            hide-details="auto"
                             type="time"
                             :label="$t('attribute.value')"
                             :class="getLockedStyle(index)"
@@ -29,7 +31,11 @@
                             @focus="onFocus(index)"
                             @blur="onBlur(index)"
                             @keyup="onKeyUp(index)"
-                        />
+                        >
+                            <template #append-inner>
+                                <AttributeFieldDeleteButton :visible="delVisible" @delete="onDelete" />
+                            </template>
+                        </v-text-field>
                     </template>
                 </AttributeValueLayout>
             </div>
@@ -40,6 +46,7 @@
 <script setup lang="ts">
     import AttributeItemLayout from './AttributeItemLayout.vue'
     import AttributeValueLayout from './AttributeValueLayout.vue'
+    import AttributeFieldDeleteButton from '@/components/common/buttons/AttributeFieldDeleteButton.vue'
     import { useAttributes } from './useAttributes'
 
     type AttributeValueItem = {
@@ -91,6 +98,6 @@
 
     .value-holder {
         width: 100%;
-        margin-bottom: 4px;
+        margin-bottom: 2px;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeValueLayout.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeValueLayout.vue
@@ -1,12 +1,14 @@
 <template>
-    <v-row justify="center" class="attribute-value-layout pt-2" @mouseenter="itemHover = true" @mouseleave="itemHover = false">
-        <div class="col-left" style="position: relative">
+    <v-row align="start" no-gutters class="ga-2 pt-1" @mouseenter="itemHover = true" @mouseleave="itemHover = false">
+        <v-col v-if="$slots['col_left']" cols="auto">
             <slot name="col_left" />
-        </div>
-        <div class="col-middle">
-            <slot name="col_middle" />
-        </div>
-        <div class="col-right">
+        </v-col>
+        <v-col style="min-width: 200px">
+            <!-- del-visible / on-delete let an attribute embed the delete button inside its
+                 input (e.g. a text field's append-inner slot) instead of the col_right column. -->
+            <slot name="col_middle" :del-visible="delButtonVisible" :on-delete="handleDelete" />
+        </v-col>
+        <v-col v-if="!embedDelete" cols="auto">
             <slot name="col_right">
                 <v-btn
                     v-if="delButtonVisible"
@@ -18,7 +20,7 @@
                     <v-icon>{{ ICONS.CLOSE }}</v-icon>
                 </v-btn>
             </slot>
-        </div>
+        </v-col>
     </v-row>
 </template>
 
@@ -30,12 +32,14 @@
     const props = withDefaults(
         defineProps<{
             delButton?: boolean
+            embedDelete?: boolean
             valIndex: number
             occurrence?: number | null | undefined
             values: Array<Record<string, unknown>>
         }>(),
         {
             delButton: false,
+            embedDelete: false,
             occurrence: null
         }
     )
@@ -48,34 +52,13 @@
     const itemHover = ref(false)
 
     const delButtonVisible = computed(() => {
-        return itemHover.value && (props.occurrence == null || props.occurrence < props.values.length)
+        // Never allow deleting the last value: the effective minimum is at least 1,
+        // but a higher min_occurrence from the attribute group is still respected.
+        const minRequired = Math.max(props.occurrence ?? 0, 1)
+        return itemHover.value && minRequired < props.values.length
     })
 
     const handleDelete = (): void => {
         emit('del-value')
     }
 </script>
-
-<style scoped>
-    .attribute-value-layout {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        width: 100%;
-    }
-
-    .col-left {
-        flex-shrink: 0;
-        width: auto;
-    }
-
-    .col-middle {
-        flex: 1;
-        min-width: 200px;
-    }
-
-    .col-right {
-        flex-shrink: 0;
-        width: auto;
-    }
-</style>

--- a/src/gui-v3/src/components/common/buttons/AttributeFieldDeleteButton.vue
+++ b/src/gui-v3/src/components/common/buttons/AttributeFieldDeleteButton.vue
@@ -1,0 +1,27 @@
+<template>
+    <!-- Delete button intended for a field's append-inner slot.
+         tabindex -1 keeps it out of the tab order. mousedown.stop.prevent stops the host field
+         from reacting (e.g. a v-select opening its menu / a text field focusing) before the
+         click fires; click.stop then keeps the click from bubbling to the field. -->
+    <v-btn
+        v-if="visible"
+        icon
+        variant="text"
+        density="compact"
+        tabindex="-1"
+        :title="t('report_item.tooltip.delete_value')"
+        @mousedown.stop.prevent
+        @click.stop="emit('delete')"
+    >
+        <v-icon>{{ ICONS.CLOSE }}</v-icon>
+    </v-btn>
+</template>
+
+<script setup lang="ts">
+    import { useI18n } from 'vue-i18n'
+    import { ICONS } from '@/config/ui-constants'
+
+    defineProps<{ visible?: boolean }>()
+    const emit = defineEmits<{ (e: 'delete'): void }>()
+    const { t } = useI18n()
+</script>

--- a/src/gui-v3/src/components/common/cvss-utils.ts
+++ b/src/gui-v3/src/components/common/cvss-utils.ts
@@ -22,10 +22,20 @@ export interface CvssScores {
     [key: string]: number | undefined
 }
 
+export const SEVERITY_COLORS = {
+    none: '#53aa33',
+    low: '#ffcb0d',
+    medium: '#f9a009',
+    high: '#df3d03',
+    critical: '#cc0500',
+    na: '#9e9e9e'
+} as const
+
 export interface ScoreItem {
     name: string
     label: string
     score: string
+    color: string
     severityClass: string
     severityLabel: string
 }
@@ -146,6 +156,7 @@ function makeScoreItem(name: string, label: string, score: number | undefined, t
         name,
         label,
         score: scoreNum,
+        color: SEVERITY_COLORS[severity.name as keyof typeof SEVERITY_COLORS] ?? SEVERITY_COLORS.na,
         severityClass: `severity-${severity.name}`,
         severityLabel: te(`cvss_calculator.${severity.name}`) ? t(`cvss_calculator.${severity.name}`) : severity.label
     }
@@ -156,6 +167,7 @@ function makeNAScoreItem(name: string, label: string): ScoreItem {
         name,
         label,
         score: 'N/A',
+        color: SEVERITY_COLORS.na,
         severityClass: 'severity-na',
         severityLabel: ''
     }

--- a/src/gui-v3/src/components/publish/ReportItemSelector.vue
+++ b/src/gui-v3/src/components/publish/ReportItemSelector.vue
@@ -42,8 +42,7 @@
         <NewReportItem ref="reportItemDialog" :show-button="false" :read-only="readOnlySelector" />
 
         <!-- Selected Items Display -->
-        <div v-if="!selectorOpen" class="selected-items-container">
-            <v-spacer style="height: 8px" />
+        <div v-if="!selectorOpen" class="selected-items-container pt-2">
             <CardAnalyze
                 v-for="item in value"
                 :key="item.id"

--- a/src/gui-v3/src/i18n/cs.json
+++ b/src/gui-v3/src/i18n/cs.json
@@ -734,6 +734,7 @@
         "author": "Autor",
         "add_news_item": "Přidat novinku",
         "attached_news_items": "Přiložené novinky",
+        "read_news_item": "Kliknutím zobrazíte",
         "aggregate_detail": "Detail sloučené novinky",
         "aggregate_info": "Info",
         "aggregate_title": "Název",

--- a/src/gui-v3/src/i18n/en.json
+++ b/src/gui-v3/src/i18n/en.json
@@ -895,6 +895,7 @@
         "author": "Author",
         "add_news_item": "Add News Items",
         "attached_news_items": "Attached News Items",
+        "read_news_item": "Click to read",
         "aggregate_detail": "Aggregate Detail",
         "aggregate_info": "Info",
         "aggregate_title": "Title",

--- a/src/gui-v3/src/i18n/sk.json
+++ b/src/gui-v3/src/i18n/sk.json
@@ -870,6 +870,7 @@
         "published": "Publikované",
         "author": "Autor",
         "add_news_item": "Pridať novinku",
+        "read_news_item": "Kliknutím zobrazíte",
         "select_news_item": "Vybrať novinku",
         "aggregate_detail": "Detail zlúčenej novinky",
         "aggregate_info": "Info",

--- a/src/gui-v3/src/styles/colors.css
+++ b/src/gui-v3/src/styles/colors.css
@@ -62,6 +62,23 @@
     --color-dark-drawer-divider: rgba(255, 255, 255, 0.2);
 }
 
+/* Signal color-scheme to browsers and Dark Reader.
+   Fallback follows OS preference (covers login page, which uses prefers-color-scheme for styling).
+   Explicit classes override after login when the user's saved preference is known. */
+@media (prefers-color-scheme: dark) {
+    html {
+        color-scheme: dark;
+    }
+}
+
+html.light-mode {
+    color-scheme: light;
+}
+
+html.dark-mode {
+    color-scheme: dark;
+}
+
 /* Light theme */
 [data-theme='light'] {
     --color-drawer-bg: var(--color-light-drawer-bg);


### PR DESCRIPTION
- Move delete button inside attribute input fields (text, CVE, CWE, CPE, Date/Time, Enum, CVSS); add reusable AttributeFieldDeleteButton
- Always keep at least one attribute value — the last field can no longer be deleted (enforced centrally in AttributeValueLayout)
- Make attributes more vertically compact (hide empty validation lines, tighter spacing)
- Display Date, CWE and CVE attributes at half width so two fit per row
- Move the CVSS calculator icon inside the vector input; keep score boxes a fixed size
- Redesign TLP attribute (buttons centered, stable size, clearer selected state)
- Report dialog: keep the top toolbar fixed in both normal and side-by-side views; remove phantom empty scroll
- Side-by-side: click an attached news item to read it in the right pane; expand aggregates to show child items (like Assess)
- Attached News Items sidebar now lists the real OSINT source groups instead of a stubbed All/Unread
- Show the last-change author inline with the attribute name; fix "sort by newest" to use the actual timestamp; enlarge sort buttons
- Improve Dark Reader detection (color-scheme signalling)
- Fix CVSS 4.0 score display; restore unit tests (368 passing); make `test:coverage` actually report coverage