### PR TITLE
GUI fixes (VUE3)

### DIFF
--- a/src/gui-v3/eslint.config.js
+++ b/src/gui-v3/eslint.config.js
@@ -23,6 +23,7 @@ const sharedGlobals = {
     Node: 'readonly',
     MouseEvent: 'readonly',
     KeyboardEvent: 'readonly',
+    DragEvent: 'readonly',
     IntersectionObserver: 'readonly',
     IntersectionObserverEntry: 'readonly',
     AbortSignal: 'readonly',

--- a/src/gui-v3/src/App.vue
+++ b/src/gui-v3/src/App.vue
@@ -295,4 +295,30 @@
     .cx-drawer-bg {
         background-color: var(--color-drawer-bg) !important;
     }
+
+    /* Filled (flat/elevated) colored buttons should use their themed on-color for the
+       label. Vuetify 4's base .v-btn color rule otherwise wins over the .bg-{color}
+       rule, leaving dark text on colored backgrounds. Only targets buttons that carry
+       a bg-{color} class (filled variants); text/outlined/tonal keep their colored label. */
+    .v-btn.bg-primary {
+        color: rgb(var(--v-theme-on-primary)) !important;
+    }
+    .v-btn.bg-secondary {
+        color: rgb(var(--v-theme-on-secondary)) !important;
+    }
+    .v-btn.bg-tertiary {
+        color: rgb(var(--v-theme-on-tertiary)) !important;
+    }
+    .v-btn.bg-success {
+        color: rgb(var(--v-theme-on-success)) !important;
+    }
+    .v-btn.bg-error {
+        color: rgb(var(--v-theme-on-error)) !important;
+    }
+    .v-btn.bg-warning {
+        color: rgb(var(--v-theme-on-warning)) !important;
+    }
+    .v-btn.bg-info {
+        color: rgb(var(--v-theme-on-info)) !important;
+    }
 </style>

--- a/src/gui-v3/src/components/analyze/CardAnalyze.vue
+++ b/src/gui-v3/src/components/analyze/CardAnalyze.vue
@@ -37,16 +37,13 @@
                                     <span v-if="card.news_items_count" class="text-grey ms-1">({{ card.news_items_count }})</span>
                                 </div>
                             </v-col>
-                            <v-col v-if="card.state" cols="auto" class="d-flex justify-end align-center">
+                            <v-col v-if="card.state" cols="auto" class="d-flex justify-end align-center" :title="card.state.description">
                                 <v-icon :color="card.state.color">
                                     {{ card.state.icon }}
                                 </v-icon>
                                 <span class="text-body-large ms-2">
                                     {{ t('workflow.states.' + (card.state.display_name || ''), card.state.display_name || '') }}
                                 </span>
-                                <v-tooltip v-if="card.state.description" activator="parent" location="bottom">
-                                    {{ card.state.description }}
-                                </v-tooltip>
                             </v-col>
                         </v-row>
                     </v-col>

--- a/src/gui-v3/src/components/analyze/NewReportItem.vue
+++ b/src/gui-v3/src/components/analyze/NewReportItem.vue
@@ -14,13 +14,13 @@
                     <v-card-text>{{ t('report_item.confirm_close.message') }}</v-card-text>
                     <v-card-actions>
                         <v-spacer />
-                        <v-btn color="" @click="showCloseConfirmation = false">
+                        <v-btn color="primary" variant="elevated" class="confirm-btn" @click="showCloseConfirmation = false">
                             {{ t('confirm_close.continue') }}
                         </v-btn>
-                        <v-btn color="primary" @click="saveAndClose">
+                        <v-btn color="success" variant="elevated" class="confirm-btn" @click="saveAndClose">
                             {{ t('confirm_close.save_and_close') }}
                         </v-btn>
-                        <v-btn color="error" @click="confirmClose">
+                        <v-btn color="error" variant="elevated" class="confirm-btn" @click="confirmClose">
                             {{ t('confirm_close.close') }}
                         </v-btn>
                     </v-card-actions>
@@ -55,6 +55,7 @@
                         :available-states="available_states"
                         :label="t('report_item.state')"
                         :disabled="!canModify"
+                        class="me-4"
                         @update:model-value="saveReportItem('state_id')"
                     />
 
@@ -1075,5 +1076,11 @@
 
     :deep(.v-expansion-panel) {
         border: 1px solid rgb(var(--v-theme-outline)) !important;
+    }
+
+    /* Keep the unsaved-changes dialog button labels white regardless of theme on-* colors. */
+    .confirm-btn,
+    .confirm-btn :deep(.v-btn__content) {
+        color: #fff !important;
     }
 </style>

--- a/src/gui-v3/src/components/analyze/NewsItemSelector.vue
+++ b/src/gui-v3/src/components/analyze/NewsItemSelector.vue
@@ -19,19 +19,7 @@
                 <!-- Main Content Row -->
                 <div class="selector-body">
                     <!-- Left Sidebar: Groups -->
-                    <v-list v-model:selected="selectedGroupList" density="compact">
-                        <v-list-subheader>{{ $t('assess.groups') }}</v-list-subheader>
-                        <v-list-item v-for="group in groups" :key="group.id" :value="group.id" class="pa-2" @click="changeGroup(group.id)">
-                            <div class="d-flex flex-column align-center text-center">
-                                <v-icon :color="group.color || undefined" class="mb-2">
-                                    {{ group.icon }}
-                                </v-icon>
-                                <span class="text-body-small">
-                                    {{ group.translate ? $t(group.title) : group.title }}
-                                </span>
-                            </div>
-                        </v-list-item>
-                    </v-list>
+                    <GroupNavList :groups="groups" :active-id="selectedGroupId" @select="onGroupSelect" />
 
                     <!-- Right Content Area: Toolbar + Items -->
                     <div class="selector-main">
@@ -39,7 +27,7 @@
                         <ToolbarFilterAssess
                             ref="toolbarFilter"
                             :analyze_selector="true"
-                            :total-count-title="'assess.total_count'"
+                            :total_count_title="'assess.total_count'"
                             @update-filter="handleFilterUpdate"
                         />
 
@@ -185,6 +173,7 @@
     import CardAssessItem from '@/components/assess/CardAssessItem.vue'
     import ContentDataAssess from '@/components/assess/ContentDataAssess.vue'
     import BaseCard from '@/components/common/BaseCard.vue'
+    import GroupNavList from '@/components/common/GroupNavList.vue'
 
     type SelectorItem = {
         id: number | string
@@ -261,7 +250,6 @@
     const selectedItems = ref<SelectorItem[]>(props.values || [])
     const groups = ref<SelectorGroup[]>([])
     const selectedGroupId = ref<string | null>(null)
-    const selectedGroupList = ref<string[]>([])
     const showRemoveConfirm = ref<boolean>(false)
     const itemToDelete = ref<SelectorItem | null>(null)
 
@@ -309,6 +297,10 @@
         if (contentData.value) {
             contentData.value.updateData?.(false, false)
         }
+    }
+
+    const onGroupSelect = (group: { id: string | number }): void => {
+        changeGroup(String(group.id))
     }
 
     const openSelector = async (): Promise<void> => {
@@ -554,7 +546,15 @@
     .selector-body {
         min-height: 0;
         display: grid;
-        grid-template-columns: 96px minmax(0, 1fr);
+        grid-template-columns: 100px minmax(0, 1fr);
+        overflow: hidden;
+    }
+
+    .selector-main {
+        min-width: 0;
+        min-height: 0;
+        display: grid;
+        grid-template-rows: auto minmax(0, 1fr);
         overflow: hidden;
     }
 

--- a/src/gui-v3/src/components/analyze/ToolbarFilterAnalyze.vue
+++ b/src/gui-v3/src/components/analyze/ToolbarFilterAnalyze.vue
@@ -29,11 +29,9 @@
                     size="small"
                     :color="filter['completed'] === 'ALL' ? 'default' : 'primary'"
                     :variant="filter['completed'] === 'ALL' ? 'outlined' : 'flat'"
+                    :title="completedFilterTooltip"
                     @click="cycleFilter('completed')"
                 >
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ completedFilterTooltip }}
-                    </v-tooltip>
                     <v-icon>{{ completedFilterIcon }}</v-icon>
                 </v-chip>
             </div>
@@ -45,10 +43,13 @@
         <ToolbarGroup ref="toolbarGroup" view="analyze" :current-filter="filter" @update-data="handleUpdateData" />
 
         <v-spacer />
-        <v-btn icon size="small" :color="compactMode ? 'primary' : 'default'" @click="toggleCompactMode">
-            <v-tooltip activator="parent" location="bottom">
-                {{ t('analyze.tooltip.compact_mode') }}
-            </v-tooltip>
+        <v-btn
+            icon
+            size="small"
+            :color="compactMode ? 'primary' : 'default'"
+            :title="t('analyze.tooltip.compact_mode')"
+            @click="toggleCompactMode"
+        >
             <v-icon>mdi-format-list-bulleted</v-icon>
         </v-btn>
     </v-toolbar>

--- a/src/gui-v3/src/components/assess/ReportsListDialog.vue
+++ b/src/gui-v3/src/components/assess/ReportsListDialog.vue
@@ -60,12 +60,15 @@
     import { ICONS } from '@/config/ui-constants'
     import { useI18n } from 'vue-i18n'
     import { getReportItemsByAggregate, updateReportItem } from '@/api/analyze'
+    import { useAnalyzeStore } from '@/stores/analyze'
     import CardAnalyze from '@/components/analyze/CardAnalyze.vue'
 
     type ReportItem = {
         id: number | string
         access?: boolean
         modify?: boolean
+        report_item_type_id?: number | string
+        report_type_name?: string
         [key: string]: unknown
     }
 
@@ -85,6 +88,7 @@
     }
 
     const { t } = useI18n()
+    const analyzeStore = useAnalyzeStore()
 
     const isOpen = ref<boolean>(false)
     const loading = ref<boolean>(false)
@@ -139,6 +143,12 @@
         reports.value = []
 
         try {
+            // Report item types are needed to resolve the type name shown on each card
+            // (the aggregate response only carries report_item_type_id, like the Analyze list).
+            if (!analyzeStore.getReportItemTypes.items?.length) {
+                await analyzeStore.loadReportItemTypes({})
+            }
+
             const response = (await getReportItemsByAggregate(card.id)) as ReportResponse
             const reportItems = normalizeReportItems(response)
             reports.value = reportItems || []
@@ -157,9 +167,17 @@
     }
 
     const toAnalyzeCard = (report: ReportItem): ReportItem => {
+        // Resolve the report type name from its id, the same way the Analyze list does,
+        // so the card shows the type (the aggregate response has no report_type_name).
+        const types = Array.isArray(analyzeStore.getReportItemTypes.items)
+            ? (analyzeStore.getReportItemTypes.items as Array<{ id: number | string; title?: string }>)
+            : []
+        const reportType = types.find((x) => x.id == report.report_item_type_id)
+
         // CardAnalyze gates click by access/modify flags; set safe defaults for dialog usage.
         return {
             ...report,
+            report_type_name: report.report_type_name ?? (reportType?.title || 'Report Item'),
             access: report.access ?? true,
             modify: report.modify ?? true
         }

--- a/src/gui-v3/src/components/assess/ToolbarFilterAssess.vue
+++ b/src/gui-v3/src/components/assess/ToolbarFilterAssess.vue
@@ -29,33 +29,27 @@
                     size="small"
                     :color="filter['read'] === 'ALL' ? 'default' : 'primary'"
                     :variant="filter['read'] === 'ALL' ? 'outlined' : 'flat'"
+                    :title="readFilterTooltip"
                     @click="cycleFilter('read')"
                 >
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ readFilterTooltip }}
-                    </v-tooltip>
                     <v-icon>{{ readFilterIcon }}</v-icon>
                 </v-chip>
                 <v-chip
                     size="small"
                     :color="filter['important'] === 'ALL' ? 'default' : 'primary'"
                     :variant="filter['important'] === 'ALL' ? 'outlined' : 'flat'"
+                    :title="importantFilterTooltip"
                     @click="cycleFilter('important')"
                 >
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ importantFilterTooltip }}
-                    </v-tooltip>
                     <v-icon>{{ importantFilterIcon }}</v-icon>
                 </v-chip>
                 <v-chip
                     size="small"
                     :color="filter['relevant'] === 'ALL' ? 'default' : 'primary'"
                     :variant="filter['relevant'] === 'ALL' ? 'outlined' : 'flat'"
+                    :title="relevantFilterTooltip"
                     @click="cycleFilter('relevant')"
                 >
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ relevantFilterTooltip }}
-                    </v-tooltip>
                     <v-icon>{{ relevantFilterIcon }}</v-icon>
                 </v-chip>
             </div>
@@ -68,11 +62,9 @@
                 size="small"
                 :color="filter.sort === 'DATE_DESC' || filter.sort === 'DATE_ASC' ? 'primary' : 'default'"
                 :variant="filter.sort === 'DATE_DESC' || filter.sort === 'DATE_ASC' ? 'flat' : 'outlined'"
+                :title="dateSortTooltip"
                 @click="toggleDateSort"
             >
-                <v-tooltip activator="parent" location="bottom">
-                    {{ dateSortTooltip }}
-                </v-tooltip>
                 <v-icon start>mdi-clock</v-icon>
                 <v-icon>{{ dateSortIcon }}</v-icon>
             </v-chip>
@@ -81,52 +73,62 @@
                 size="small"
                 :color="filter.sort === 'RELEVANCE_DESC' ? 'primary' : 'default'"
                 :variant="filter.sort === 'RELEVANCE_DESC' ? 'flat' : 'outlined'"
+                :title="t('assess.tooltip.sort.relevance.descending')"
                 @click="toggleRelevanceSort"
             >
-                <v-tooltip activator="parent" location="bottom">
-                    {{ t('assess.tooltip.sort.relevance.descending') }}
-                </v-tooltip>
                 <v-icon start>mdi-thumb-up</v-icon>
                 <v-icon>mdi-arrow-down</v-icon>
             </v-chip>
         </template>
     </BaseToolbarFilter>
 
-    <!-- Additional Row: Selection Group and View Options -->
-    <v-toolbar flat color="surface" density="compact">
+    <!-- Additional Row: Selection Group and View Options (hidden in the attach-news-items selector) -->
+    <v-toolbar v-if="!analyze_selector" flat color="surface" density="compact">
         <ToolbarGroup ref="toolbarGroup" view="assess" :current-filter="filter" @update-data="handleUpdateData" />
 
         <v-spacer />
 
         <!-- Hide Reviews Button -->
-        <v-btn icon size="small" :color="hideReviews ? 'primary' : 'default'" @click="toggleHideReviews">
-            <v-tooltip activator="parent" location="bottom">
-                {{ t('assess.tooltip.hide_review') }}
-            </v-tooltip>
+        <v-btn
+            icon
+            size="small"
+            :color="hideReviews ? 'primary' : 'default'"
+            :title="t('assess.tooltip.hide_review')"
+            @click="toggleHideReviews"
+        >
             <v-icon>{{ hideReviews ? 'mdi-text-short' : 'mdi-text-long' }}</v-icon>
         </v-btn>
 
         <!-- Hide Source Links Button -->
-        <v-btn icon size="small" :color="hideSourceLinks ? 'primary' : 'default'" @click="toggleHideSourceLinks">
-            <v-tooltip activator="parent" location="bottom">
-                {{ t('assess.tooltip.hide_source_link') }}
-            </v-tooltip>
+        <v-btn
+            icon
+            size="small"
+            :color="hideSourceLinks ? 'primary' : 'default'"
+            :title="t('assess.tooltip.hide_source_link')"
+            @click="toggleHideSourceLinks"
+        >
             <v-icon>{{ hideSourceLinks ? 'mdi-link-off' : 'mdi-link' }}</v-icon>
         </v-btn>
 
         <!-- Highlight Wordlist Button -->
-        <v-btn icon size="small" :color="highlightWordlist ? 'primary' : 'default'" @click="toggleHighlightWordlist">
-            <v-tooltip activator="parent" location="bottom">
-                {{ t('assess.tooltip.highlight_wordlist') }}
-            </v-tooltip>
+        <v-btn
+            icon
+            size="small"
+            :color="highlightWordlist ? 'primary' : 'default'"
+            :title="t('assess.tooltip.highlight_wordlist')"
+            @click="toggleHighlightWordlist"
+        >
             <v-icon>{{ highlightWordlist ? 'mdi-alphabetical-off' : 'mdi-alphabetical' }}</v-icon>
         </v-btn>
 
         <!-- Compact Mode Button -->
-        <v-btn icon size="small" :color="compactMode ? 'primary' : 'default'" @click="toggleCompactMode">
-            <v-tooltip activator="parent" location="bottom">
-                {{ t('assess.tooltip.compact_mode') }}
-            </v-tooltip>
+        <v-btn
+            icon
+            size="small"
+            :color="compactMode ? 'primary' : 'default'"
+            :title="t('assess.tooltip.compact_mode')"
+            @click="toggleCompactMode"
+        >
             <v-icon>mdi-format-list-bulleted</v-icon>
         </v-btn>
     </v-toolbar>
@@ -161,13 +163,15 @@
             selected_count_title?: string
             showAddButton?: boolean
             addButtonLabel?: string
+            analyze_selector?: boolean
         }>(),
         {
             title: 'nav_menu.newsitems',
             total_count_title: 'assess.total_count',
             selected_count_title: 'toolbar_filter.selected_count',
             showAddButton: false,
-            addButtonLabel: 'common.add_btn'
+            addButtonLabel: 'common.add_btn',
+            analyze_selector: false
         }
     )
 

--- a/src/gui-v3/src/components/common/BaseToolbarFilter.vue
+++ b/src/gui-v3/src/components/common/BaseToolbarFilter.vue
@@ -20,7 +20,7 @@
                     />
                 </v-col>
                 <v-col cols="12" md="5" style="display: flex; justify-content: flex-end; align-items: center">
-                    <AddNewButton v-if="showAddButton" :label="t('common.add_btn')" @click="emit('add-new')" />
+                    <AddNewButton v-if="showAddButton" label="common.add_btn" @click="emit('add-new')" />
                     <slot v-else name="addbutton" />
                 </v-col>
             </v-row>
@@ -61,11 +61,9 @@
                             :color="localFilter.sort === 'DATE_DESC' || localFilter.sort === 'DATE_ASC' ? 'primary' : 'default'"
                             :variant="localFilter.sort === 'DATE_DESC' || localFilter.sort === 'DATE_ASC' ? 'flat' : 'outlined'"
                             size="small"
+                            :title="dateSortTooltip"
                             @click="toggleDateSort"
                         >
-                            <v-tooltip activator="parent" location="bottom">
-                                {{ dateSortTooltip }}
-                            </v-tooltip>
                             <v-icon start>
                                 {{ ICONS.CLOCK }}
                             </v-icon>

--- a/src/gui-v3/src/components/common/CalculatorCVSS.vue
+++ b/src/gui-v3/src/components/common/CalculatorCVSS.vue
@@ -77,28 +77,18 @@
                 >
                     <v-card-title class="text-uppercase text-body-1 font-weight-bold pa-3">
                         {{ group.label }}
-                        <v-tooltip v-if="showTooltips && group.tooltipKey" location="end" max-width="500">
-                            <template #activator="{ props: tp }">
-                                <v-icon v-bind="tp" size="x-small" class="ml-1">
-                                    {{ ICONS.INFORMATION_OUTLINE }}
-                                </v-icon>
-                            </template>
-                            <span>{{ $t(group.tooltipKey) }}</span>
-                        </v-tooltip>
+                        <v-icon v-if="showTooltips && group.tooltipKey" size="x-small" class="ml-1" :title="$t(group.tooltipKey)">
+                            {{ ICONS.INFORMATION_OUTLINE }}
+                        </v-icon>
                     </v-card-title>
 
                     <v-card-text class="pt-0">
                         <div v-for="metric in group.metrics" :key="metric.shortName" class="mb-3">
                             <div class="d-flex align-center mb-1">
                                 <span class="text-primary text-body-2">{{ metric.label }}</span>
-                                <v-tooltip v-if="showTooltips && metric.tooltipKey" location="end" max-width="500">
-                                    <template #activator="{ props: tp }">
-                                        <v-icon v-bind="tp" size="x-small" class="ml-1">
-                                            {{ ICONS.INFORMATION_OUTLINE }}
-                                        </v-icon>
-                                    </template>
-                                    <span>{{ $t(metric.tooltipKey) }}</span>
-                                </v-tooltip>
+                                <v-icon v-if="showTooltips && metric.tooltipKey" size="x-small" class="ml-1" :title="$t(metric.tooltipKey)">
+                                    {{ ICONS.INFORMATION_OUTLINE }}
+                                </v-icon>
                             </div>
                             <v-btn-toggle
                                 :model-value="getSelectedValueIndex(metric)"
@@ -106,25 +96,18 @@
                                 density="compact"
                                 @update:model-value="(idx) => onMetricToggle(metric, idx)"
                             >
-                                <template v-for="(val, valIdx) in metric.values" :key="val.shortName">
-                                    <v-tooltip v-if="showTooltips && val.tooltipKey" location="bottom" max-width="300">
-                                        <template #activator="{ props: tp }">
-                                            <v-btn v-bind="tp" size="small" :value="valIdx">
-                                                <span>{{ val.label }}</span>
-                                                <v-icon size="small" color="primary" class="ml-1">
-                                                    {{ 'mdi-alpha-' + val.shortName.toLowerCase() + '-box' }}
-                                                </v-icon>
-                                            </v-btn>
-                                        </template>
-                                        <span>{{ $t(val.tooltipKey) }}</span>
-                                    </v-tooltip>
-                                    <v-btn v-else size="small" :value="valIdx">
-                                        <span>{{ val.label }}</span>
-                                        <v-icon size="small" color="primary" class="ml-1">
-                                            {{ 'mdi-alpha-' + val.shortName.toLowerCase() + '-box' }}
-                                        </v-icon>
-                                    </v-btn>
-                                </template>
+                                <v-btn
+                                    v-for="(val, valIdx) in metric.values"
+                                    :key="val.shortName"
+                                    size="small"
+                                    :value="valIdx"
+                                    :title="showTooltips && val.tooltipKey ? $t(val.tooltipKey) : undefined"
+                                >
+                                    <span>{{ val.label }}</span>
+                                    <v-icon size="small" color="primary" class="ml-1">
+                                        {{ 'mdi-alpha-' + val.shortName.toLowerCase() + '-box' }}
+                                    </v-icon>
+                                </v-btn>
                             </v-btn-toggle>
                         </div>
                     </v-card-text>

--- a/src/gui-v3/src/components/common/GroupNavList.vue
+++ b/src/gui-v3/src/components/common/GroupNavList.vue
@@ -1,0 +1,50 @@
+<template>
+    <v-list density="compact">
+        <v-list-subheader>{{ $t('assess.groups') }}</v-list-subheader>
+        <v-list-item
+            v-for="group in groups"
+            :key="group.id"
+            :active="String(group.id) === String(activeId)"
+            class="pa-2"
+            @click="emit('select', group)"
+        >
+            <div class="d-flex flex-column align-center text-center">
+                <v-icon :color="group.color || undefined" class="mb-2">
+                    {{ group.icon }}
+                </v-icon>
+                <span class="text-body-small">
+                    {{ group.translate ? $t(group.title) : group.title }}
+                </span>
+            </div>
+        </v-list-item>
+    </v-list>
+</template>
+
+<script setup lang="ts">
+    /**
+     * Shared OSINT-source-group sidebar list used by the Assess navigation rail
+     * (AssessNav) and the attach-news-items selector (NewsItemSelector).
+     *
+     * Purely presentational: it renders the groups (icon on top, centered label)
+     * and emits `select` with the clicked group. The parent decides what selecting
+     * means — route navigation in AssessNav, group switching in the selector — and
+     * controls highlighting via `activeId`.
+     */
+    type GroupNavItem = {
+        id: string | number
+        icon?: string
+        color?: string | null
+        title: string
+        translate?: boolean | string
+        route?: string
+    }
+
+    defineProps<{
+        groups: GroupNavItem[]
+        activeId?: string | number | null
+    }>()
+
+    const emit = defineEmits<{
+        (e: 'select', group: GroupNavItem): void
+    }>()
+</script>

--- a/src/gui-v3/src/components/common/ToolbarGroup.vue
+++ b/src/gui-v3/src/components/common/ToolbarGroup.vue
@@ -1,10 +1,13 @@
 <template>
     <div class="toolbar-group">
         <!-- Multi-select toggle button -->
-        <v-btn icon size="small" :color="multiSelectActive ? 'primary' : 'default'" @click="toggleMultiSelect">
-            <v-tooltip activator="parent" location="bottom">
-                {{ t(`${view}.tooltip.toggle_selection`) }}
-            </v-tooltip>
+        <v-btn
+            icon
+            size="small"
+            :color="multiSelectActive ? 'primary' : 'default'"
+            :title="t(`${view}.tooltip.toggle_selection`)"
+            @click="toggleMultiSelect"
+        >
             <v-icon>{{ ICONS.MULTISELECT }}</v-icon>
         </v-btn>
 
@@ -14,20 +17,27 @@
         <!-- Action Buttons (only visible when multi-select is active) -->
         <template v-if="multiSelectActive">
             <!-- Select All / Unselect All -->
-            <v-btn icon size="small" :disabled="false" @click="allSelected ? unselectAll() : selectAll()">
-                <v-tooltip activator="parent" location="bottom">
-                    {{ allSelected ? t(`${view}.tooltip.unselect_all`) : t(`${view}.tooltip.select_all`) }}
-                </v-tooltip>
+            <v-btn
+                icon
+                size="small"
+                :disabled="false"
+                :title="allSelected ? t(`${view}.tooltip.unselect_all`) : t(`${view}.tooltip.select_all`)"
+                @click="allSelected ? unselectAll() : selectAll()"
+            >
                 <v-icon>{{ allSelected ? ICONS.CHECKBOX_BLANK_OUTLINE : ICONS.SELECT_ALL }}</v-icon>
             </v-btn>
 
             <!-- View-specific action buttons -->
             <template v-if="view === 'assess'">
                 <!-- Group -->
-                <v-btn v-if="canModify && canGroupActions" icon size="small" :disabled="selectedCount < 2" @click="handleAction('GROUP')">
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ t('assess.tooltip.group_items') }}
-                    </v-tooltip>
+                <v-btn
+                    v-if="canModify && canGroupActions"
+                    icon
+                    size="small"
+                    :disabled="selectedCount < 2"
+                    :title="t('assess.tooltip.group_items')"
+                    @click="handleAction('GROUP')"
+                >
                     <v-icon>{{ ICONS.GROUP }}</v-icon>
                 </v-btn>
 
@@ -37,87 +47,120 @@
                     icon
                     size="small"
                     :disabled="selectedCount === 0 || !canUngroupSelection"
+                    :title="t('assess.tooltip.ungroup_items')"
                     @click="handleAction('UNGROUP')"
                 >
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ t('assess.tooltip.ungroup_items') }}
-                    </v-tooltip>
                     <v-icon>{{ ICONS.UNGROUP }}</v-icon>
                 </v-btn>
 
                 <!-- Mark as Read -->
-                <v-btn icon size="small" :disabled="selectedCount === 0" @click="handleAction('READ')">
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ t('assess.tooltip.read_items') }}
-                    </v-tooltip>
+                <v-btn
+                    icon
+                    size="small"
+                    :disabled="selectedCount === 0"
+                    :title="t('assess.tooltip.read_items')"
+                    @click="handleAction('READ')"
+                >
                     <v-icon>{{ ICONS.READ }}</v-icon>
                 </v-btn>
 
                 <!-- Mark as Important -->
-                <v-btn icon size="small" :disabled="selectedCount === 0" @click="handleAction('IMPORTANT')">
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ t('assess.tooltip.important_items') }}
-                    </v-tooltip>
+                <v-btn
+                    icon
+                    size="small"
+                    :disabled="selectedCount === 0"
+                    :title="t('assess.tooltip.important_items')"
+                    @click="handleAction('IMPORTANT')"
+                >
                     <v-icon>{{ ICONS.IMPORTANT }}</v-icon>
                 </v-btn>
 
                 <!-- Give a Like -->
-                <v-btn icon size="small" :disabled="selectedCount === 0" @click="handleAction('LIKE')">
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ t('assess.tooltip.like_items') }}
-                    </v-tooltip>
+                <v-btn
+                    icon
+                    size="small"
+                    :disabled="selectedCount === 0"
+                    :title="t('assess.tooltip.like_items')"
+                    @click="handleAction('LIKE')"
+                >
                     <v-icon>{{ ICONS.LIKE }}</v-icon>
                 </v-btn>
 
                 <!-- Give a Dislike -->
-                <v-btn icon size="small" :disabled="selectedCount === 0" @click="handleAction('DISLIKE')">
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ t('assess.tooltip.dislike_items') }}
-                    </v-tooltip>
+                <v-btn
+                    icon
+                    size="small"
+                    :disabled="selectedCount === 0"
+                    :title="t('assess.tooltip.dislike_items')"
+                    @click="handleAction('DISLIKE')"
+                >
                     <v-icon>{{ ICONS.UNLIKE }}</v-icon>
                 </v-btn>
 
                 <!-- Analyze (Create Report) -->
-                <v-btn v-if="canCreateReport" icon size="small" :disabled="selectedCount === 0" @click="handleAnalyze">
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ t('assess.tooltip.analyze_items') }}
-                    </v-tooltip>
+                <v-btn
+                    v-if="canCreateReport"
+                    icon
+                    size="small"
+                    :disabled="selectedCount === 0"
+                    :title="t('assess.tooltip.analyze_items')"
+                    @click="handleAnalyze"
+                >
                     <v-icon>{{ ICONS.FILE_CHART_OUTLINE }}</v-icon>
                 </v-btn>
 
                 <!-- Delete -->
-                <v-btn v-if="canDelete" icon size="small" color="error" :disabled="selectedCount === 0" @click="handleAction('DELETE')">
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ t('assess.tooltip.delete_items') }}
-                    </v-tooltip>
+                <v-btn
+                    v-if="canDelete"
+                    icon
+                    size="small"
+                    color="error"
+                    :disabled="selectedCount === 0"
+                    :title="t('assess.tooltip.delete_items')"
+                    @click="handleAction('DELETE')"
+                >
                     <v-icon>{{ ICONS.DELETE }}</v-icon>
                 </v-btn>
             </template>
 
             <template v-else-if="view === 'analyze'">
                 <!-- Publish (Create Product) -->
-                <v-btn v-if="canCreateProduct" icon size="small" :disabled="selectedCount === 0" @click="handlePublish">
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ t('analyze.tooltip.publish_items') }}
-                    </v-tooltip>
+                <v-btn
+                    v-if="canCreateProduct"
+                    icon
+                    size="small"
+                    :disabled="selectedCount === 0"
+                    :title="t('analyze.tooltip.publish_items')"
+                    @click="handlePublish"
+                >
                     <v-icon>{{ ICONS.PUBLISH }}</v-icon>
                 </v-btn>
 
                 <!-- Delete -->
-                <v-btn v-if="canDelete" icon size="small" color="error" :disabled="selectedCount === 0" @click="handleDelete">
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ t('analyze.tooltip.delete_items') }}
-                    </v-tooltip>
+                <v-btn
+                    v-if="canDelete"
+                    icon
+                    size="small"
+                    color="error"
+                    :disabled="selectedCount === 0"
+                    :title="t('analyze.tooltip.delete_items')"
+                    @click="handleDelete"
+                >
                     <v-icon>{{ ICONS.DELETE }}</v-icon>
                 </v-btn>
             </template>
 
             <template v-else-if="view === 'publish'">
                 <!-- Delete -->
-                <v-btn v-if="canDelete" icon size="small" color="error" :disabled="selectedCount === 0" @click="handleDelete">
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ t('publish.tooltip.delete_items') }}
-                    </v-tooltip>
+                <v-btn
+                    v-if="canDelete"
+                    icon
+                    size="small"
+                    color="error"
+                    :disabled="selectedCount === 0"
+                    :title="t('publish.tooltip.delete_items')"
+                    @click="handleDelete"
+                >
                     <v-icon>{{ ICONS.DELETE }}</v-icon>
                 </v-btn>
             </template>

--- a/src/gui-v3/src/components/common/attribute/AttributeString.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeString.vue
@@ -1,7 +1,15 @@
 <template>
     <AttributeItemLayout :add-button="addButtonVisible" :values="values" @add-value="add">
         <template #content>
-            <div v-for="(value, index) in values" :key="`${value.index}-${index}`" class="value-holder">
+            <div
+                v-for="(value, index) in values"
+                :key="`${value.index}-${index}`"
+                class="value-holder"
+                :class="{ 'drag-over': dragOverIndex === index, 'dragging': dragIndex === index }"
+                @dragover="onDragOver(index, $event)"
+                @drop="onDrop(index)"
+                @dragleave="onDragLeave(index)"
+            >
                 <!-- Read-only or remote -->
                 <span v-if="readOnly || value.remote" class="numbered-string-value">
                     <span v-if="values.length > 1" class="string-number text--disabled">{{ index + 1 }}.</span>
@@ -19,7 +27,38 @@
                     @del-value="del(index)"
                 >
                     <template #col_left>
-                        <span v-if="values.length > 1" class="string-number text--disabled">{{ index + 1 }}.</span>
+                        <div v-if="values.length > 1" class="reorder-controls d-flex align-center">
+                            <v-icon
+                                class="drag-handle"
+                                size="small"
+                                draggable="true"
+                                :title="$t('report_item.tooltip.drag_to_reorder')"
+                                :icon="ICONS.DRAG_HANDLE"
+                                @dragstart="onDragStart(index, $event)"
+                                @dragend="onDragEnd"
+                            />
+                            <span class="string-number text--disabled">{{ index + 1 }}.</span>
+                            <div class="reorder-arrows d-flex flex-column ms-1">
+                                <v-btn
+                                    variant="text"
+                                    density="compact"
+                                    size="x-small"
+                                    :icon="ICONS.ARROW_UP"
+                                    :disabled="index === 0 || value.locked === true"
+                                    :title="$t('report_item.tooltip.move_up')"
+                                    @click="moveUp(index)"
+                                />
+                                <v-btn
+                                    variant="text"
+                                    density="compact"
+                                    size="x-small"
+                                    :icon="ICONS.ARROW_DOWN"
+                                    :disabled="index === values.length - 1 || value.locked === true"
+                                    :title="$t('report_item.tooltip.move_down')"
+                                    @click="moveDown(index)"
+                                />
+                            </div>
+                        </div>
                     </template>
                     <template #col_middle="{ delVisible, onDelete }">
                         <v-text-field
@@ -46,11 +85,12 @@
 </template>
 
 <script setup lang="ts">
-    import { onMounted } from 'vue'
+    import { onMounted, ref } from 'vue'
     import { useI18n } from 'vue-i18n'
     import AttributeItemLayout from './AttributeItemLayout.vue'
     import AttributeValueLayout from './AttributeValueLayout.vue'
     import AttributeFieldDeleteButton from '@/components/common/buttons/AttributeFieldDeleteButton.vue'
+    import { ICONS } from '@/config/ui-constants'
     import { useAttributes } from './useAttributes'
 
     type AttributeValueItem = {
@@ -84,7 +124,50 @@
 
     const { t } = useI18n()
 
-    const { canModify, addButtonVisible, add, del, getLockedStyle, onFocus, onBlur, onKeyUp } = useAttributes(props)
+    const { canModify, addButtonVisible, add, del, getLockedStyle, onFocus, onBlur, onKeyUp, move, moveUp, moveDown } = useAttributes(props)
+
+    // Drag-and-drop reordering state.
+    const dragIndex = ref<number | null>(null)
+    const dragOverIndex = ref<number | null>(null)
+
+    const onDragStart = (index: number, event: DragEvent) => {
+        dragIndex.value = index
+        if (event.dataTransfer) {
+            event.dataTransfer.effectAllowed = 'move'
+            // Some browsers require data to be set for the drag to initiate.
+            event.dataTransfer.setData('text/plain', String(index))
+        }
+    }
+
+    const onDragOver = (index: number, event: DragEvent) => {
+        if (dragIndex.value === null) {
+            return
+        }
+        event.preventDefault()
+        if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = 'move'
+        }
+        dragOverIndex.value = index
+    }
+
+    const onDragLeave = (index: number) => {
+        if (dragOverIndex.value === index) {
+            dragOverIndex.value = null
+        }
+    }
+
+    const onDrop = (index: number) => {
+        if (dragIndex.value !== null && dragIndex.value !== index) {
+            move(dragIndex.value, index)
+        }
+        dragIndex.value = null
+        dragOverIndex.value = null
+    }
+
+    const onDragEnd = () => {
+        dragIndex.value = null
+        dragOverIndex.value = null
+    }
 
     // Always show one (possibly empty) field, even when the attribute starts with no values.
     onMounted(() => {
@@ -117,5 +200,22 @@
     .value-holder {
         width: 100%;
         margin-bottom: 2px;
+        border-top: 2px solid transparent;
+    }
+
+    .value-holder.drag-over {
+        border-top-color: rgb(var(--v-theme-primary));
+    }
+
+    .value-holder.dragging {
+        opacity: 0.5;
+    }
+
+    .drag-handle {
+        cursor: grab;
+    }
+
+    .drag-handle:active {
+        cursor: grabbing;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeTLP.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeTLP.vue
@@ -29,6 +29,7 @@
                             <button
                                 v-for="tlp in tlpOptions"
                                 :key="tlp"
+                                type="button"
                                 class="tlp-btn tlp-button"
                                 :style="getTLPButtonStyle(tlp, value.value)"
                                 :disabled="value.locked || !canModify"
@@ -158,14 +159,13 @@
     const getTLPButtonStyle = (tlp: TlpLevel, selectedValue: string): CSSProperties => {
         const config = tlpColors[tlp]
         const isActive = tlp === selectedValue
-        // Ring contrasts with the button background. Always set boxShadow even when inactive
-        // so the CSS property value changes but the property itself never appears/disappears,
-        // preventing any layout recalculation that would change button size.
-        const ringColor = config.text === '#ffffff' ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.75)'
+        // Selected ring uses the app's primary blue so it's clearly visible against any TLP
+        // background in both light and dark mode. Always set boxShadow even when inactive so
+        // the property value changes but never appears/disappears, avoiding layout recalculation.
         return {
             backgroundColor: config.bg,
             color: config.text,
-            boxShadow: isActive ? `inset 0 0 0 3px ${ringColor}` : 'none'
+            boxShadow: isActive ? 'inset 0 0 0 3px rgb(var(--v-theme-primary))' : 'none'
         }
     }
 

--- a/src/gui-v3/src/components/common/attribute/RemoteAttributeAttachment.vue
+++ b/src/gui-v3/src/components/common/attribute/RemoteAttributeAttachment.vue
@@ -11,7 +11,11 @@
                     </v-icon>
                     <span>{{ value.value.filename || 'Remote Attachment' }}</span>
                     <span class="text-xs text-gray-500">({{ formatFileSize(value.value.size) }})</span>
-                    <button class="text-blue-400 hover:text-blue-300 text-xs ml-auto" @click="downloadRemoteAttachment(value.value)">
+                    <button
+                        type="button"
+                        class="text-blue-400 hover:text-blue-300 text-xs ml-auto"
+                        @click="downloadRemoteAttachment(value.value)"
+                    >
                         Download
                     </button>
                 </div>

--- a/src/gui-v3/src/components/common/attribute/useAttributes.ts
+++ b/src/gui-v3/src/components/common/attribute/useAttributes.ts
@@ -289,6 +289,70 @@ export function useAttributes<T extends UseAttributesProps>(props: Readonly<T>) 
         onEdit(data.index)
     }
 
+    /**
+     * Reorder values by moving the one at `from` to position `to`.
+     *
+     * The backend has no per-value ordering column (values of an attribute are
+     * returned ordered by their id), so we cannot persist a reordered record
+     * list. Instead we keep the records (and their ids/locks) fixed and rotate
+     * their value payloads, then persist each changed slot via onEdit. Because
+     * the records stay in id order, reloading from the backend preserves the new
+     * visual order. In create mode (edit === false) the array order is the
+     * submitted order, so this works there too.
+     */
+    const move = async (from: number, to: number) => {
+        const last = props.values.length - 1
+        if (from === to || from < 0 || to < 0 || from > last || to > last) {
+            return
+        }
+
+        // Don't reorder across a slot that is locked by someone else.
+        const lo = Math.min(from, to)
+        const hi = Math.max(from, to)
+        for (let index = lo; index <= hi; index++) {
+            if (props.values[index]?.locked === true) {
+                return
+            }
+        }
+
+        type Payload = { value: unknown; value_description: string | undefined }
+        const payloads: Payload[] = props.values.map((val) => ({
+            value: val.value,
+            value_description: val.value_description
+        }))
+        const moved = payloads.splice(from, 1)[0]
+        if (!moved) {
+            return
+        }
+        payloads.splice(to, 0, moved)
+
+        const changed: number[] = []
+        props.values.forEach((val, index) => {
+            const payload = payloads[index]
+            if (!payload) {
+                return
+            }
+            if (val.value !== payload.value || val.value_description !== payload.value_description) {
+                changed.push(index)
+            }
+            val.value = payload.value
+            if (payload.value_description === undefined) {
+                delete val.value_description
+            } else {
+                val.value_description = payload.value_description
+            }
+        })
+
+        if (props.edit === true) {
+            for (const index of changed) {
+                await onEdit(index)
+            }
+        }
+    }
+
+    const moveUp = (index: number) => move(index, index - 1)
+    const moveDown = (index: number) => move(index, index + 1)
+
     const reportItemLocked = (data: ReportEventData) => {
         if (props.edit === true && props.reportItemId === data.report_item_id) {
             if (data.user_id !== currentUserId()) {
@@ -410,6 +474,9 @@ export function useAttributes<T extends UseAttributesProps>(props: Readonly<T>) 
         onBlur,
         onKeyUp,
         onEdit,
-        enumSelected
+        enumSelected,
+        move,
+        moveUp,
+        moveDown
     }
 }

--- a/src/gui-v3/src/components/config/SettingsTable.vue
+++ b/src/gui-v3/src/components/config/SettingsTable.vue
@@ -67,14 +67,9 @@
         </template>
 
         <template #item.description="{ item }">
-            <v-tooltip location="bottom">
-                <template #activator="{ props }">
-                    <span v-bind="props" style="cursor: help">
-                        {{ te('settings_enum.' + item.key) ? t('settings_enum.' + item.key) : item.description }}
-                    </span>
-                </template>
-                {{ t('settings.default_value') }}: {{ item.default_val }}
-            </v-tooltip>
+            <span style="cursor: help" :title="`${t('settings.default_value')}: ${item.default_val}`">
+                {{ te('settings_enum.' + item.key) ? t('settings_enum.' + item.key) : item.description }}
+            </span>
         </template>
 
         <template #item.updated_at="{ item }">

--- a/src/gui-v3/src/components/config/ai-providers/AiProvidersTab.vue
+++ b/src/gui-v3/src/components/config/ai-providers/AiProvidersTab.vue
@@ -2,12 +2,7 @@
     <v-container fluid>
         <v-card>
             <v-card-title class="d-flex align-center">
-                <v-tooltip location="right">
-                    <template #activator="{ props }">
-                        <v-icon v-bind="props" color="blue" class="me-2"> mdi-help-circle </v-icon>
-                    </template>
-                    <span>{{ t('data_provider.ai_providers.tab_description') }}</span>
-                </v-tooltip>
+                <v-icon color="blue" class="me-2" :title="t('data_provider.ai_providers.tab_description')"> mdi-help-circle </v-icon>
                 <span>{{ t('nav_menu.ai_providers') }}</span>
             </v-card-title>
 

--- a/src/gui-v3/src/components/config/bots/NewBotPreset.vue
+++ b/src/gui-v3/src/components/config/bots/NewBotPreset.vue
@@ -88,12 +88,7 @@
                                     />
                                 </v-col>
                                 <v-col cols="1">
-                                    <v-tooltip location="top">
-                                        <template #activator="{ props }">
-                                            <v-icon v-bind="props" color="primary">mdi-help-circle</v-icon>
-                                        </template>
-                                        <span>{{ param.description }}</span>
-                                    </v-tooltip>
+                                    <v-icon color="primary" :title="param.description">mdi-help-circle</v-icon>
                                 </v-col>
                             </v-row>
                         </div>

--- a/src/gui-v3/src/components/config/data-providers/DataProvidersTab.vue
+++ b/src/gui-v3/src/components/config/data-providers/DataProvidersTab.vue
@@ -2,12 +2,7 @@
     <v-container fluid>
         <v-card>
             <v-card-title class="d-flex align-center">
-                <v-tooltip location="right">
-                    <template #activator="{ props }">
-                        <v-icon v-bind="props" color="blue" class="me-2"> mdi-help-circle </v-icon>
-                    </template>
-                    <span>{{ t('data_provider.data_providers.tab_description') }}</span>
-                </v-tooltip>
+                <v-icon color="blue" class="me-2" :title="t('data_provider.data_providers.tab_description')"> mdi-help-circle </v-icon>
                 <span>{{ t('nav_menu.data_providers') }}</span>
             </v-card-title>
 

--- a/src/gui-v3/src/components/config/publishers/NewPublisherPreset.vue
+++ b/src/gui-v3/src/components/config/publishers/NewPublisherPreset.vue
@@ -98,12 +98,7 @@
                                     />
                                 </v-col>
                                 <v-col cols="1">
-                                    <v-tooltip location="top">
-                                        <template #activator="{ props }">
-                                            <v-icon v-bind="props" color="primary">mdi-help-circle</v-icon>
-                                        </template>
-                                        <span>{{ param.description }}</span>
-                                    </v-tooltip>
+                                    <v-icon color="primary" :title="param.description">mdi-help-circle</v-icon>
                                 </v-col>
                             </v-row>
                         </div>

--- a/src/gui-v3/src/components/config/workflow/StateWorkflowTab.vue
+++ b/src/gui-v3/src/components/config/workflow/StateWorkflowTab.vue
@@ -2,12 +2,7 @@
     <v-container fluid>
         <v-card class="mt-4">
             <v-card-title class="d-flex align-center">
-                <v-tooltip location="top">
-                    <template #activator="{ props }">
-                        <v-icon color="blue" v-bind="props" class="mr-2">mdi-information-outline</v-icon>
-                    </template>
-                    <span>{{ t('workflow.state_workflow.tab_description') }}</span>
-                </v-tooltip>
+                <v-icon color="blue" class="mr-2" :title="t('workflow.state_workflow.tab_description')">mdi-information-outline</v-icon>
                 <span>{{ t('workflow.state_workflow_tab') }}</span>
             </v-card-title>
 

--- a/src/gui-v3/src/components/config/workflow/StatesTab.vue
+++ b/src/gui-v3/src/components/config/workflow/StatesTab.vue
@@ -2,12 +2,7 @@
     <v-container fluid>
         <v-card>
             <v-card-title class="d-flex align-center">
-                <v-tooltip location="top">
-                    <template #activator="{ props }">
-                        <v-icon color="blue" v-bind="props" class="mr-2">mdi-information-outline</v-icon>
-                    </template>
-                    <span>{{ t('workflow.states.tab_description') }}</span>
-                </v-tooltip>
+                <v-icon color="blue" class="mr-2" :title="t('workflow.states.tab_description')">mdi-information-outline</v-icon>
                 <span>{{ t('workflow.states_tab') }}</span>
             </v-card-title>
 

--- a/src/gui-v3/src/components/publish/CardProduct.vue
+++ b/src/gui-v3/src/components/publish/CardProduct.vue
@@ -50,16 +50,13 @@
                                     {{ card.subtitle }}
                                 </div>
                             </v-col>
-                            <v-col v-if="card.state" cols="auto" class="d-flex justify-end align-center">
+                            <v-col v-if="card.state" cols="auto" class="d-flex justify-end align-center" :title="card.state.description">
                                 <v-icon :color="card.state.color">
                                     {{ card.state.icon }}
                                 </v-icon>
                                 <span class="text-body-large ms-2">
                                     {{ card.state.display_name ? t('workflow.states.' + card.state.display_name) : '' }}
                                 </span>
-                                <v-tooltip v-if="card.state.description" activator="parent" location="bottom">
-                                    {{ card.state.description }}
-                                </v-tooltip>
                             </v-col>
                         </v-row>
                     </v-col>

--- a/src/gui-v3/src/components/publish/NewProduct.vue
+++ b/src/gui-v3/src/components/publish/NewProduct.vue
@@ -9,13 +9,13 @@
                 <v-card-text>{{ $t('product.confirm_close.message') }}</v-card-text>
                 <v-card-actions>
                     <v-spacer />
-                    <v-btn color="" @click="showCloseConfirmation = false">
+                    <v-btn color="primary" variant="elevated" class="confirm-btn" @click="showCloseConfirmation = false">
                         {{ $t('confirm_close.continue') }}
                     </v-btn>
-                    <v-btn color="primary" @click="saveAndClose">
+                    <v-btn color="success" variant="elevated" class="confirm-btn" @click="saveAndClose">
                         {{ $t('confirm_close.save_and_close') }}
                     </v-btn>
-                    <v-btn color="error" @click="confirmClose">
+                    <v-btn color="error" variant="elevated" class="confirm-btn" @click="confirmClose">
                         {{ $t('confirm_close.close') }}
                     </v-btn>
                 </v-card-actions>
@@ -77,7 +77,8 @@
                     :available-states="availableStates"
                     :label="$t('product.state')"
                     :disabled="!canModify"
-                    @update:model-value="handleUpdateRecord"
+                    class="me-4"
+                    @update:model-value="handleStateChange"
                 />
                 <v-btn v-if="!isEditMode && canModify && product.id === -1" text @click="handleSave">
                     <v-icon start>
@@ -446,6 +447,13 @@
         }
     }
 
+    function handleStateChange(newStateId: number | string | null): void {
+        // StateSelector is bound one-way via :model-value, so we must write the
+        // selected id back into the product before persisting.
+        product.value.state_id = newStateId ?? undefined
+        handleUpdateRecord()
+    }
+
     async function handleUpdateRecord(): Promise<void> {
         if (!isEditMode.value || product.value.id === -1) return
 
@@ -668,5 +676,11 @@
 <style scoped>
     .v-toolbar :deep(.v-select) {
         margin-top: 8px;
+    }
+
+    /* Keep the unsaved-changes dialog button labels white regardless of theme on-* colors. */
+    .confirm-btn,
+    .confirm-btn :deep(.v-btn__content) {
+        color: #fff !important;
     }
 </style>

--- a/src/gui-v3/src/components/publish/ReportItemSelector.vue
+++ b/src/gui-v3/src/components/publish/ReportItemSelector.vue
@@ -2,26 +2,28 @@
     <v-container fluid class="pa-0">
         <!-- Dialog Container -->
         <v-dialog v-model="selectorOpen" fullscreen persistent>
-            <v-card flat>
-                <!-- Fixed Toolbar -->
-                <v-toolbar color="primary" dark sticky>
-                    <v-btn icon @click="handleClose">
-                        <v-icon>{{ ICONS.CLOSE }}</v-icon>
-                    </v-btn>
-                    <v-toolbar-title>{{ t('report_item.select') }}</v-toolbar-title>
-                    <v-spacer />
-                    <v-btn @click="handleAdd">
-                        <v-icon start>
-                            {{ ICONS.PLUS_BOX }}
-                        </v-icon>
-                        {{ t('common.add_items') }}
-                    </v-btn>
-                </v-toolbar>
+            <v-card flat class="d-flex flex-column" style="height: 100vh">
+                <!-- Fixed header (toolbar + filter stay put while the list below scrolls) -->
+                <div class="flex-grow-0 flex-shrink-0">
+                    <v-toolbar color="primary" dark>
+                        <v-btn icon @click="handleClose">
+                            <v-icon>{{ ICONS.CLOSE }}</v-icon>
+                        </v-btn>
+                        <v-toolbar-title>{{ t('report_item.select') }}</v-toolbar-title>
+                        <v-spacer />
+                        <v-btn @click="handleAdd">
+                            <v-icon start>
+                                {{ ICONS.PLUS_BOX }}
+                            </v-icon>
+                            {{ t('common.add_items') }}
+                        </v-btn>
+                    </v-toolbar>
 
-                <!-- Main Content -->
-                <v-container fluid class="pa-0">
                     <ToolbarFilterAnalyze ref="toolbarFilter" :show-group-toolbar="false" @update-filter="updateFilter" />
+                </div>
 
+                <!-- Main Content (scrollable area) -->
+                <div class="flex-grow-1 overflow-y-auto">
                     <ContentDataAnalyze
                         ref="contentData"
                         :show-remove-action="false"
@@ -33,7 +35,7 @@
                         @new-data-loaded="handleNewDataLoaded"
                         @update-showing-count="handleUpdateShowingCount"
                     />
-                </v-container>
+                </div>
             </v-card>
         </v-dialog>
 
@@ -43,7 +45,7 @@
         <!-- Selected Items Display -->
         <div v-if="!selectorOpen" class="pt-2">
             <CardAnalyze
-                v-for="item in value"
+                v-for="item in displayItems"
                 :key="item.id"
                 :card="item"
                 :show-remove-action="true"
@@ -55,7 +57,7 @@
 </template>
 
 <script setup lang="ts">
-    import { ref, watch, nextTick } from 'vue'
+    import { ref, computed, watch, onMounted, nextTick } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { ICONS } from '@/config/ui-constants'
     import ContentDataAnalyze from '@/components/analyze/ContentDataAnalyze.vue'
@@ -67,6 +69,8 @@
     type ReportItem = {
         id: number | string
         tag?: string
+        report_item_type_id?: number | string
+        report_type_name?: string
         [key: string]: any
     }
 
@@ -104,6 +108,26 @@
         },
         { deep: true, immediate: true }
     )
+
+    // The selected report items only carry report_item_type_id; resolve the type
+    // name from the loaded report item types so the cards show the type like the
+    // Analyze list does.
+    const displayItems = computed<ReportItem[]>(() => {
+        const types = Array.isArray(analyzeStore.getReportItemTypes.items)
+            ? (analyzeStore.getReportItemTypes.items as Array<{ id: number | string; title?: string }>)
+            : []
+        return value.value.map((item) => {
+            if (item.report_type_name) return item
+            const reportType = types.find((x) => x.id == item.report_item_type_id)
+            return { ...item, report_type_name: reportType?.title || 'Report Item' }
+        })
+    })
+
+    onMounted(async () => {
+        if (!analyzeStore.getReportItemTypes.items?.length) {
+            await analyzeStore.loadReportItemTypes({})
+        }
+    })
 
     const openSelector = async (): Promise<void> => {
         // Disable multi-select from previous selections

--- a/src/gui-v3/src/components/publish/ToolbarFilterPublish.vue
+++ b/src/gui-v3/src/components/publish/ToolbarFilterPublish.vue
@@ -30,11 +30,9 @@
                     size="small"
                     :color="filter['published'] === 'ALL' ? 'default' : 'primary'"
                     :variant="filter['published'] === 'ALL' ? 'outlined' : 'flat'"
+                    :title="publishedFilterTooltip"
                     @click="cycleFilter('published')"
                 >
-                    <v-tooltip activator="parent" location="bottom">
-                        {{ publishedFilterTooltip }}
-                    </v-tooltip>
                     <v-icon>{{ publishedFilterIcon }}</v-icon>
                 </v-chip>
             </div>
@@ -46,10 +44,13 @@
         <ToolbarGroup ref="toolbarGroup" view="publish" :current-filter="filter" @update-data="handleUpdateData" />
 
         <v-spacer />
-        <v-btn icon size="small" :color="compactMode ? 'primary' : 'default'" @click="toggleCompactMode">
-            <v-tooltip activator="parent" location="bottom">
-                {{ t('publish.tooltip.compact_mode') }}
-            </v-tooltip>
+        <v-btn
+            icon
+            size="small"
+            :color="compactMode ? 'primary' : 'default'"
+            :title="t('publish.tooltip.compact_mode')"
+            @click="toggleCompactMode"
+        >
             <v-icon>{{ ICONS.FORMAT_LIST_BULLETED }}</v-icon>
         </v-btn>
     </v-toolbar>

--- a/src/gui-v3/src/config/ui-constants.ts
+++ b/src/gui-v3/src/config/ui-constants.ts
@@ -44,6 +44,7 @@ export const ICONS = Object.freeze({
     DESC: 'mdi-sort-descending',
     DOWNLOAD: 'mdi-download',
     DOWNLOAD_NETWORK: 'mdi-download-network',
+    DRAG_HANDLE: 'mdi-drag-vertical',
     EDIT: 'mdi-pencil',
     EMAIL_OPEN: 'mdi-email-open',
     EXCLAMATION_THICK: 'mdi-exclamation-thick',

--- a/src/gui-v3/src/i18n/cs.json
+++ b/src/gui-v3/src/i18n/cs.json
@@ -647,7 +647,10 @@
             "enum_selector": "Zobrazit okno s hledáním hodnot",
             "delete_value": "Smazat hodnotu tohoto atributu",
             "add_value": "Přidat novou hodnotu k tomuto atributu",
-            "auto_generate": "Automaticky generovat"
+            "auto_generate": "Automaticky generovat",
+            "drag_to_reorder": "Přetažením změníte pořadí",
+            "move_up": "Posunout nahoru",
+            "move_down": "Posunout dolů"
         }
     },
     "product": {

--- a/src/gui-v3/src/i18n/en.json
+++ b/src/gui-v3/src/i18n/en.json
@@ -805,7 +805,10 @@
             "enum_selector": "Show value search window",
             "delete_value": "Delete value from this attribute",
             "add_value": "Add new value to this attribute",
-            "auto_generate": "Auto generate"
+            "auto_generate": "Auto generate",
+            "drag_to_reorder": "Drag to reorder",
+            "move_up": "Move up",
+            "move_down": "Move down"
         }
     },
     "product": {

--- a/src/gui-v3/src/i18n/sk.json
+++ b/src/gui-v3/src/i18n/sk.json
@@ -785,7 +785,10 @@
             "enum_selector": "Zobraziť okno na vyhľadávanie hodnôt",
             "delete_value": "Odstrániť hodnotu z tohto atribútu",
             "add_value": "Pridať novú hodnotu k tomuto atribútu",
-            "auto_generate": "Automaticky vygenerovať"
+            "auto_generate": "Automaticky vygenerovať",
+            "drag_to_reorder": "Presunutím zmeníte poradie",
+            "move_up": "Posunúť nahor",
+            "move_down": "Posunúť nadol"
         }
     },
     "product": {

--- a/src/gui-v3/src/main.ts
+++ b/src/gui-v3/src/main.ts
@@ -99,8 +99,11 @@ const vuetify = createVuetify({
                     'error': '#FF5252',
                     'on-error': '#FFFFFF',
                     'info': '#2196F3',
+                    'on-info': '#FFFFFF',
                     'success': '#4CAF50',
+                    'on-success': '#FFFFFF',
                     'warning': '#FB8C00',
+                    'on-warning': '#FFFFFF',
                     'accent': '#82B1FF'
                 }
             },

--- a/src/gui-v3/src/views/nav/AnalyzeNav.vue
+++ b/src/gui-v3/src/views/nav/AnalyzeNav.vue
@@ -28,6 +28,7 @@
         title: string
         translate: boolean
         route: string
+        color?: string
     }
 
     const router = useRouter()

--- a/src/gui-v3/src/views/nav/AssessNav.vue
+++ b/src/gui-v3/src/views/nav/AssessNav.vue
@@ -1,26 +1,12 @@
 <template>
-    <v-list density="compact">
-        <!-- Group links -->
-        <v-list-subheader>{{ $t('assess.groups') }}</v-list-subheader>
-        <v-list-item v-for="group in groups" :key="group.id" :to="group.route" class="pa-2">
-            <template #default>
-                <div class="d-flex flex-column align-center text-center">
-                    <v-icon :color="group.color || undefined" class="mb-2">
-                        {{ group.icon }}
-                    </v-icon>
-                    <span class="text-body-small">
-                        {{ group.translate ? $t(group.title) : group.title }}
-                    </span>
-                </div>
-            </template>
-        </v-list-item>
-    </v-list>
+    <GroupNavList :groups="groups" :active-id="activeGroupId" @select="onSelect" />
 </template>
 
 <script setup lang="ts">
-    import { ref, onMounted } from 'vue'
+    import { ref, computed, onMounted } from 'vue'
     import { useRouter, useRoute } from 'vue-router'
     import { useConfigStore } from '@/stores/config'
+    import GroupNavList from '@/components/common/GroupNavList.vue'
 
     type AssessGroup = {
         id: string | number
@@ -36,6 +22,13 @@
     const configStore = useConfigStore()
 
     const groups = ref<AssessGroup[]>([])
+
+    // Highlight the group matching the current /assess/group/:groupId route.
+    const activeGroupId = computed<string | null>(() => (route.params['groupId'] as string) ?? null)
+
+    const onSelect = (group: { route?: string }): void => {
+        if (group.route) router.push(group.route)
+    }
 
     onMounted(async () => {
         try {

--- a/src/gui-v3/src/views/nav/ConfigNav.vue
+++ b/src/gui-v3/src/views/nav/ConfigNav.vue
@@ -9,7 +9,7 @@
                         {{ link.icon }}
                     </v-icon>
                     <span class="text-body-small">
-                        {{ link.translate ? $t(link.title) : link.title }}
+                        {{ link.translate ? $t(link.title ?? '') : link.title }}
                     </span>
                 </div>
             </template>

--- a/src/gui-v3/tests/e2e/assess.spec.js
+++ b/src/gui-v3/tests/e2e/assess.spec.js
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test'
+import { login } from '../helpers/test-helpers'
+
+/**
+ * Assess E2E Tests
+ *
+ * Exercises the Assess view toolbar: title, search, day-range filters, the
+ * three-state filter chips, the native-title tooltips, and multi-select mode.
+ * These assertions target the toolbar (always rendered) so they don't depend on
+ * news-item data being present in the environment.
+ */
+
+test.describe('Assess', () => {
+    test.beforeEach(async ({ page }) => {
+        await login(page)
+        await page.goto('/v2/assess')
+        await expect(page).toHaveURL(/\/assess/)
+    })
+
+    test('should load the Assess view with the News Items toolbar', async ({ page }) => {
+        await expect(
+            page
+                .locator('.text-h6')
+                .filter({ hasText: /news items/i })
+                .first()
+        ).toBeVisible()
+    })
+
+    test('should accept input in the search field', async ({ page }) => {
+        const search = page.locator('.v-toolbar .v-text-field input').first()
+        await expect(search).toBeVisible()
+
+        await search.fill('apt')
+        await expect(search).toHaveValue('apt')
+    })
+
+    test('should activate a day-range filter chip when clicked', async ({ page }) => {
+        const todayChip = page
+            .locator('.v-chip')
+            .filter({ hasText: /^Today$/ })
+            .first()
+        await expect(todayChip).toBeVisible()
+
+        await todayChip.click()
+
+        // Active range chip switches to the filled primary variant.
+        await expect(todayChip).toHaveClass(/bg-primary/)
+    })
+
+    test('should show the three-state filter chips (read / important / relevant)', async ({ page }) => {
+        // The custom-filters slot renders three clickable icon chips.
+        const filterChips = page.locator('.v-toolbar .v-chip')
+        await expect(filterChips.first()).toBeVisible()
+        expect(await filterChips.count()).toBeGreaterThanOrEqual(3)
+    })
+
+    test('should expose toolbar action tooltips as native title attributes', async ({ page }) => {
+        // The toolbar buttons use native `title` tooltips (consistent app-wide).
+        await expect(page.getByTitle('Toggle compact mode')).toBeVisible()
+        await expect(page.getByTitle('Toggle news items selection mode')).toBeVisible()
+    })
+
+    test('should reveal selection actions after entering multi-select mode', async ({ page }) => {
+        // Select-all only exists once multi-select is enabled.
+        await expect(page.getByTitle('Select All')).toHaveCount(0)
+
+        await page.getByTitle('Toggle news items selection mode').click()
+
+        await expect(page.getByTitle('Select All')).toBeVisible()
+    })
+
+    test('should toggle compact mode without errors', async ({ page }) => {
+        const compactBtn = page.getByTitle('Toggle compact mode')
+        await expect(compactBtn).toBeVisible()
+
+        await compactBtn.click()
+        // Still on the Assess view and the toolbar remains interactive.
+        await expect(page).toHaveURL(/\/assess/)
+        await expect(compactBtn).toBeVisible()
+    })
+})

--- a/src/gui-v3/tests/unit/AttributeComponents.spec.js
+++ b/src/gui-v3/tests/unit/AttributeComponents.spec.js
@@ -152,6 +152,22 @@ describe('AttributeString', () => {
         expect(wrapper.text()).toContain('1.')
         expect(wrapper.text()).toContain('2.')
     })
+
+    it('shows reorder controls (drag handle + arrows) when there are multiple editable values', () => {
+        const props = {
+            ...baseProps(),
+            values: [makeValue({ value: 'first' }), makeValue({ id: 2, index: 1, value: 'second' })]
+        }
+        const wrapper = mountAttr(AttributeString, props)
+        expect(wrapper.findAll('.reorder-controls').length).toBe(2)
+        expect(wrapper.find('.drag-handle').exists()).toBe(true)
+        expect(wrapper.findAll('.reorder-arrows').length).toBe(2)
+    })
+
+    it('does not show reorder controls for a single value', () => {
+        const wrapper = mountAttr(AttributeString, baseProps())
+        expect(wrapper.find('.reorder-controls').exists()).toBe(false)
+    })
 })
 
 // ── AttributeNumber ───────────────────────────────────────────────────────────
@@ -387,6 +403,15 @@ describe('AttributeTLP', () => {
         expect(wrapper.find('.tlp-options').exists()).toBe(true)
         const buttons = wrapper.findAll('.tlp-button')
         expect(buttons.length).toBe(5) // CLEAR, GREEN, AMBER, AMBER+STRICT, RED
+    })
+
+    it('renders TLP buttons with type="button" so they never submit a parent form', () => {
+        const wrapper = mountAttr(AttributeTLP, baseProps({ value: 'CLEAR' }))
+        const buttons = wrapper.findAll('.tlp-button')
+        expect(buttons.length).toBe(5)
+        buttons.forEach((btn) => {
+            expect(btn.attributes('type')).toBe('button')
+        })
     })
 
     it('shows TLP description in read-only mode', () => {

--- a/src/gui-v3/tests/unit/BaseToolbarFilter.spec.js
+++ b/src/gui-v3/tests/unit/BaseToolbarFilter.spec.js
@@ -5,6 +5,7 @@ import BaseToolbarFilter from '@/components/common/BaseToolbarFilter.vue'
 // Stub the AddNewButton to keep tests focused
 const stubs = {
     AddNewButton: {
+        name: 'AddNewButton',
         template: '<button class="add-new-stub" @click="$emit(\'click\')"><slot /></button>',
         props: ['label']
     }
@@ -86,6 +87,16 @@ describe('BaseToolbarFilter', () => {
             await wrapper.find('.add-new-stub').trigger('click')
             expect(wrapper.emitted('add-new')).toBeDefined()
             expect(wrapper.emitted('add-new').length).toBeGreaterThanOrEqual(1)
+        })
+
+        it('passes the label as a translation key (AddNewButton translates it itself, avoiding double translation)', () => {
+            const wrapper = mountWithPlugins(BaseToolbarFilter, {
+                props: { ...defaultProps, showAddButton: true },
+                global: { stubs }
+            })
+
+            const addBtn = wrapper.findComponent({ name: 'AddNewButton' })
+            expect(addBtn.props('label')).toBe('common.add_btn')
         })
     })
 

--- a/src/gui-v3/tests/unit/useAttributes.spec.js
+++ b/src/gui-v3/tests/unit/useAttributes.spec.js
@@ -417,4 +417,102 @@ describe('useAttributes', () => {
             scope.stop()
         })
     })
+
+    // ── move / moveUp / moveDown ──────────────────
+    describe('move / moveUp / moveDown', () => {
+        const makeValues = () => [
+            { id: 1, index: 0, value: 'a' },
+            { id: 2, index: 1, value: 'b' },
+            { id: 3, index: 2, value: 'c' }
+        ]
+
+        it('rotates value payloads while keeping records (ids) in place', async () => {
+            const values = makeValues()
+            const props = makeProps({ edit: false, values })
+            const { result, scope } = setupComposable(props)
+
+            await result.move(0, 2)
+
+            // values rotate, ids stay in their original order (backend orders by id)
+            expect(props.values.map((v) => v.value)).toEqual(['b', 'c', 'a'])
+            expect(props.values.map((v) => v.id)).toEqual([1, 2, 3])
+            scope.stop()
+        })
+
+        it('moveUp swaps a value with the one above it', async () => {
+            const values = makeValues()
+            const props = makeProps({ edit: false, values })
+            const { result, scope } = setupComposable(props)
+
+            await result.moveUp(2)
+
+            expect(props.values.map((v) => v.value)).toEqual(['a', 'c', 'b'])
+            expect(props.values.map((v) => v.id)).toEqual([1, 2, 3])
+            scope.stop()
+        })
+
+        it('moveDown swaps a value with the one below it', async () => {
+            const values = makeValues()
+            const props = makeProps({ edit: false, values })
+            const { result, scope } = setupComposable(props)
+
+            await result.moveDown(0)
+
+            expect(props.values.map((v) => v.value)).toEqual(['b', 'a', 'c'])
+            scope.stop()
+        })
+
+        it('is a no-op for the same index or out-of-bounds', async () => {
+            const values = makeValues()
+            const props = makeProps({ edit: false, values })
+            const { result, scope } = setupComposable(props)
+
+            await result.move(1, 1)
+            await result.move(0, 5)
+            await result.move(-1, 1)
+
+            expect(props.values.map((v) => v.value)).toEqual(['a', 'b', 'c'])
+            scope.stop()
+        })
+
+        it('does not reorder across a locked slot', async () => {
+            const values = [
+                { id: 1, index: 0, value: 'a' },
+                { id: 2, index: 1, value: 'b', locked: true },
+                { id: 3, index: 2, value: 'c' }
+            ]
+            const props = makeProps({ edit: false, values })
+            const { result, scope } = setupComposable(props)
+
+            await result.move(0, 2)
+
+            expect(props.values.map((v) => v.value)).toEqual(['a', 'b', 'c'])
+            scope.stop()
+        })
+
+        it('persists only the changed slots via onEdit in edit mode', async () => {
+            vi.mocked(analyzeApi.updateReportItem).mockResolvedValue({ data: 'ref' })
+            vi.mocked(analyzeApi.getReportItemData).mockResolvedValue({
+                data: { attribute_last_updated: 'now', attribute_user: 'admin' }
+            })
+
+            const values = makeValues()
+            const props = makeProps({ edit: true, values })
+            const { result, scope } = setupComposable(props)
+
+            // moveDown(0) swaps slots 0 and 1; slot 2 is unchanged.
+            await result.moveDown(0)
+
+            expect(analyzeApi.updateReportItem).toHaveBeenCalledTimes(2)
+            expect(analyzeApi.updateReportItem).toHaveBeenCalledWith(
+                'report-1',
+                expect.objectContaining({ attribute_id: 1, attribute_value: 'b' })
+            )
+            expect(analyzeApi.updateReportItem).toHaveBeenCalledWith(
+                'report-1',
+                expect.objectContaining({ attribute_id: 2, attribute_value: 'a' })
+            )
+            scope.stop()
+        })
+    })
 })


### PR DESCRIPTION
- Add drag-and-drop and up/down arrow reordering for multi-value string attributes
- Fix TLP attribute click submitting the form — closed the editor and created a duplicate report
- Fix product State selector not applying the selected state when editing
- Show report-item type on cards in the product editor and the reports-list dialog (matching Analyze)
- Standardize tooltips to native title across the app (removed v-tooltip)
- Make filled colored buttons use white label text in light mode (global theme fix)
- Color the unsaved-changes dialog buttons: Save & Close (green), Close (red), Continue (blue), always white text
- Pin the toolbar + filter in the "Select Report Items" dialog so they don't scroll away
- Remove like/dislike/select-all actions from the "Attached News Items" selector
- Extract a shared GroupNavList sidebar used by Assess nav and the news-item selector
- Make the TLP selected-value ring primary blue (visible in light and dark mode)
- Fix [intlify] Not found 'Add New' warning (double translation) and a total_count_title prop warning
- Fix AnalyzeNav/ConfigNav type errors
- Add unit tests (reorder logic, reorder controls, TLP button type, add-button label) and an Assess e2e suite