### PR TITLE
Docker files improvements

### DIFF
--- a/docker/Dockerfile.bots
+++ b/docker/Dockerfile.bots
@@ -23,25 +23,16 @@ RUN uv pip install --system --no-cache-dir ./custom_packages/taranis_ng_shared-*
 
 # install dependencies
 COPY ./src/bots/pyproject.toml /app/pyproject.toml
-RUN \
-    apk add --no-cache --virtual .build-deps \
-    gcc \
-    g++ \
-    make \
-    musl-dev \
-    python3-dev \
-    libffi-dev && \
-    uv pip install --system --no-cache-dir . && \
-    apk --purge del .build-deps
+RUN apk add --no-cache --virtual .build-deps \
+        build-base \
+        python3-dev \
+        libffi-dev \
+    && uv pip install --system --no-cache-dir . \
+    && apk del .build-deps
 
-COPY ./docker/start.sh /start.sh
-RUN chmod +x /start.sh
-
-COPY ./docker/prestart.sh /app/prestart.sh
-RUN chmod +x /app/prestart.sh
-
-COPY ./docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+COPY --chmod=755 ./docker/start.sh /start.sh
+COPY --chmod=755 ./docker/prestart.sh /app/prestart.sh
+COPY --chmod=755 ./docker/entrypoint.sh /entrypoint.sh
 
 COPY ./docker/gunicorn_conf.py /gunicorn_conf.py
 
@@ -50,10 +41,10 @@ COPY ./src/bots/. /app/
 EXPOSE 80
 
 # setup environment variables
-ENV PYTHONPATH=/app
-ENV MODULE_NAME run
-ENV VARIABLE_NAME app
-ENV GUNICORN_CMD_ARGS --timeout 120
+ENV PYTHONPATH="/app"
+ENV MODULE_NAME="run"
+ENV VARIABLE_NAME="app"
+ENV GUNICORN_CMD_ARGS="--timeout 120"
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/start.sh"]

--- a/docker/Dockerfile.collectors
+++ b/docker/Dockerfile.collectors
@@ -38,7 +38,7 @@ RUN \
     cd /usr/local/bin/ && \
     tar -xzf /tmp/geckodriver.tar.gz && \
     rm -f /tmp/geckodriver.tar.gz && \
-    apk --purge del .build-deps
+    apk del .build-deps
 
 # install "shared" package from build_shared stage
 # TODO: somehow squash the following two layers into one to conserve space
@@ -49,27 +49,18 @@ RUN uv pip install --system --no-cache-dir ./custom_packages/taranis_ng_shared-*
 # install dependencies
 
 COPY ./src/collectors/pyproject.toml /app/pyproject.toml
-RUN \
-    apk add --no-cache --virtual .build-deps \
-    gcc \
-    g++ \
-    make \
-    musl-dev \
-    python3-dev \
-    libxslt-dev \
-    libxml2-dev \
-    libffi-dev && \
-    uv pip install --system --no-cache-dir . && \
-    apk --purge del .build-deps
+RUN apk add --no-cache --virtual .build-deps \
+        build-base \
+        python3-dev \
+        libxslt-dev \
+        libxml2-dev \
+        libffi-dev \
+    && uv pip install --system --no-cache-dir . \
+    && apk del .build-deps
 
-COPY ./docker/start.sh /start.sh
-RUN chmod +x /start.sh
-
-COPY ./docker/prestart.sh /app/prestart.sh
-RUN chmod +x /app/prestart.sh
-
-COPY ./docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+COPY --chmod=755 ./docker/start.sh /start.sh
+COPY --chmod=755 ./docker/prestart.sh /app/prestart.sh
+COPY --chmod=755 ./docker/entrypoint.sh /entrypoint.sh
 
 COPY ./docker/gunicorn_conf.py /gunicorn_conf.py
 
@@ -78,11 +69,11 @@ COPY ./src/collectors/. /app/
 EXPOSE 80
 
 # setup environment variables
-ENV PYTHONPATH=/app
-ENV MODULE_NAME run
-ENV VARIABLE_NAME app
-ENV GUNICORN_CMD_ARGS --timeout 120
-ENV COLLECTOR_CONFIG_FILE /app/storage/id.txt
+ENV PYTHONPATH="/app"
+ENV MODULE_NAME="run"
+ENV VARIABLE_NAME="app"
+ENV GUNICORN_CMD_ARGS="--timeout 120"
+ENV COLLECTOR_CONFIG_FILE="/app/storage/id.txt"
 
 VOLUME ["/app/storage"]
 

--- a/docker/Dockerfile.core
+++ b/docker/Dockerfile.core
@@ -7,9 +7,7 @@ COPY ./src/shared/. .
 RUN python -m build
 
 RUN apk add --no-cache  \
-    gcc \
     build-base\
-    libc-dev\
     linux-headers
 
 COPY ./src/core/sse/forward.c .
@@ -41,50 +39,37 @@ RUN uv pip install --system --no-cache-dir ./custom_packages/taranis_ng_shared-*
 # install other dependencies
 
 COPY ./src/core/pyproject.toml /app/pyproject.toml
-RUN \
-    apk add --no-cache --virtual .build-deps \
-    gcc \
-    g++ \
-    git \
-    build-base\
-    libc-dev\
-    zlib-dev \
-    linux-headers \
-    make \
-    glib-dev \
-    musl-dev \
-    python3-dev \
-    libffi-dev \
-    postgresql-dev && \
-    uv pip install --system --no-cache-dir . && \
-    apk --purge del .build-deps
-
+RUN apk add --no-cache --virtual .build-deps \
+        build-base \
+        python3-dev \
+        libffi-dev \
+        openssl-dev \
+        zlib-dev \
+        linux-headers \
+        postgresql-dev \
+        git \
+    && uv pip install --system --no-cache-dir . \
+    && apk del .build-deps
 
 COPY --from=build_shared /build_shared/forward /usr/local/bin/forward
 
-COPY ./docker/start.sh /start.sh
-RUN chmod +x /start.sh
-
-COPY ./docker/prestart_core.sh /app/prestart.sh
-RUN chmod +x /app/prestart.sh
-
-COPY ./docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+COPY --chmod=755 ./docker/start.sh /start.sh
+COPY --chmod=755 ./docker/prestart_core.sh /app/prestart.sh
+COPY --chmod=755 ./docker/entrypoint.sh /entrypoint.sh
 
 COPY ./docker/gunicorn_conf.py /gunicorn_conf.py
 
 COPY ./src/core/. /app/
 
-RUN chmod +x /app/manage.py && \
-    chmod +x /app/db_migration.py
+RUN chmod +x /app/manage.py /app/db_migration.py
 
 EXPOSE 80
 
 # setup environment variables
-ENV PYTHONPATH=/app
-ENV MODULE_NAME run
-ENV VARIABLE_NAME app
-ENV GUNICORN_CMD_ARGS --timeout 120
+ENV PYTHONPATH="/app"
+ENV MODULE_NAME="run"
+ENV VARIABLE_NAME="app"
+ENV GUNICORN_CMD_ARGS="--timeout 120"
 
 VOLUME ["/data"]
 

--- a/docker/Dockerfile.gui
+++ b/docker/Dockerfile.gui
@@ -14,7 +14,7 @@ COPY ./src/gui/public /app/public
 COPY ./src/gui/src /app/src
 COPY ./src/gui/babel.config.js .
 
-ENV NODE_OPTIONS=--openssl-legacy-provider
+ENV NODE_OPTIONS="--openssl-legacy-provider"
 RUN npm run build
 
 # production stage

--- a/docker/Dockerfile.presenters
+++ b/docker/Dockerfile.presenters
@@ -63,16 +63,12 @@ RUN uv pip install --system --no-cache-dir ./custom_packages/taranis_ng_shared-*
 # install dependencies
 
 COPY ./src/presenters/pyproject.toml /app/pyproject.toml
-RUN \
-    apk add --no-cache --virtual .build-deps \
-    gcc \
-    g++ \
-    make \
-    musl-dev \
-    python3-dev \
-    libffi-dev && \
-    uv pip install --system --no-cache-dir . && \
-    apk --purge del .build-deps
+RUN apk add --no-cache --virtual .build-deps \
+        build-base \
+        python3-dev \
+        libffi-dev \
+    && uv pip install --system --no-cache-dir . \
+    && apk del .build-deps
 
 COPY ./docker/start.sh /start.sh
 RUN chmod +x /start.sh
@@ -90,10 +86,10 @@ COPY ./src/presenters/. /app/
 EXPOSE 80
 
 # setup environment variables
-ENV PYTHONPATH=/app
-ENV MODULE_NAME run
-ENV VARIABLE_NAME app
-ENV GUNICORN_CMD_ARGS --timeout 120
+ENV PYTHONPATH="/app"
+ENV MODULE_NAME="run"
+ENV VARIABLE_NAME="app"
+ENV GUNICORN_CMD_ARGS="--timeout 120"
 
 
 VOLUME ["/app/templates"]

--- a/docker/Dockerfile.publishers
+++ b/docker/Dockerfile.publishers
@@ -29,27 +29,18 @@ RUN apk add --no-cache \
     libmagic \
     gnupg
 
-RUN \
-    apk add --no-cache --virtual .build-deps build-base \
-    gcc \
-    g++ \
-    make \
-    musl-dev \
-    python3-dev \
-    libffi-dev \
-    openssl-dev \
-    rust && \
-    uv pip install --system --no-cache-dir . && \
-    apk --purge del .build-deps
+RUN apk add --no-cache --virtual .build-deps \
+        build-base \
+        python3-dev \
+        libffi-dev \
+        openssl-dev \
+        rust \
+    && uv pip install --system --no-cache-dir . \
+    && apk del .build-deps
 
-COPY ./docker/start.sh /start.sh
-RUN chmod +x /start.sh
-
-COPY ./docker/prestart.sh /app/prestart.sh
-RUN chmod +x /app/prestart.sh
-
-COPY ./docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+COPY --chmod=755 ./docker/start.sh /start.sh
+COPY --chmod=755 ./docker/prestart.sh /app/prestart.sh
+COPY --chmod=755 ./docker/entrypoint.sh /entrypoint.sh
 
 COPY ./docker/gunicorn_conf.py /gunicorn_conf.py
 
@@ -58,10 +49,10 @@ EXPOSE 80
 COPY ./src/publishers/. /app/
 
 # setup environment variables
-ENV PYTHONPATH=/app
-ENV MODULE_NAME run
-ENV VARIABLE_NAME app
-ENV GUNICORN_CMD_ARGS --timeout 120
+ENV PYTHONPATH="/app"
+ENV MODULE_NAME="run"
+ENV VARIABLE_NAME="app"
+ENV GUNICORN_CMD_ARGS="--timeout 120"
 
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src/core/sse/forward.c
+++ b/src/core/sse/forward.c
@@ -6,7 +6,7 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/types.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <getopt.h>
 
 #define PEER_POOL_INCREMENT 1024


### PR DESCRIPTION
- LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
- gcc, g++, make, musl-dev are already included in build-base (duplicity package)
- "COPY --chmod=755" in one step
-  #warning redirecting incorrect #include <sys/poll.h> to <poll.h>