### PR TITLE
Fix: Unsaved-changes guard for GUI dialogs (Vue 3)

### DIFF
--- a/src/gui-v3/src/components/common/nodes/NodeDialog.vue
+++ b/src/gui-v3/src/components/common/nodes/NodeDialog.vue
@@ -4,6 +4,7 @@
         max-width="600"
         persistent
         scrollable
+        @keydown.esc="requestClose"
     >
         <template #activator="{ props: activatorProps }">
             <AddNewButton
@@ -16,14 +17,14 @@
             <DialogToolbar
                 :title="isEdit ? t(`${config.i18nPrefix}.edit`) : t(`${config.i18nPrefix}.add_new`)"
                 :saving="saving"
-                @cancel="handleCancel"
-                @save="handleSubmit"
+                @cancel="requestClose"
+                @save="saveAndClose"
             />
 
             <v-card-text>
                 <v-form
                     ref="formRef"
-                    @submit.prevent="handleSubmit"
+                    @submit.prevent="saveAndClose"
                 >
                     <v-text-field
                         v-model="localItem.name"
@@ -91,6 +92,13 @@
                 </v-alert>
             </v-card-text>
         </v-card>
+
+        <UnsavedChangesDialog
+            v-model="confirmVisible"
+            @continue="continueEditing"
+            @save="saveAndClose"
+            @discard="discardAndClose"
+        />
     </v-dialog>
 </template>
 
@@ -99,7 +107,9 @@
     import { useI18n } from 'vue-i18n'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
+    import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
     import { useAuth } from '@/composables/useAuth'
+    import { useUnsavedChanges } from '@/composables/useUnsavedChanges'
     import type { PermissionKey } from '@/types/permissions'
     import { NODE_TYPES, type NodeType } from './nodeTypes'
 
@@ -157,14 +167,16 @@
 
     const canCreate = computed(() => checkPermission(`${config.value.permissionPrefix}_CREATE` as PermissionKey))
 
-    async function handleSubmit(): Promise<void> {
+    // Persists the form. Returns true on success so the unsaved-changes guard can
+    // decide whether to close the dialog (it closes only on a successful save).
+    async function persist(): Promise<boolean> {
         showValidationError.value = false
         showError.value = false
 
-        const { valid } = (await formRef.value.validate()) as FormValidationResult
+        const { valid } = (await formRef.value?.validate()) as FormValidationResult
         if (!valid) {
             showValidationError.value = true
-            return
+            return false
         }
 
         saving.value = true
@@ -180,7 +192,7 @@
                 })
             )
             emit('saved')
-            handleCancel()
+            return true
         } catch (error) {
             window.dispatchEvent(
                 new CustomEvent('notification', {
@@ -188,6 +200,7 @@
                 })
             )
             showError.value = true
+            return false
         } finally {
             saving.value = false
         }
@@ -201,6 +214,16 @@
         localItem.value = { ...defaultItem }
         dialog.value = false
     }
+
+    // Unsaved-changes guard. capture() snapshots the freshly-loaded form as the clean
+    // baseline on open; requestClose() shows the prompt only when real edits exist.
+    // Without capture() the baseline stays null and isDirty() always returns false, so
+    // the prompt never shows — even after the user edits fields then clicks cancel.
+    const { confirmVisible, capture, requestClose, continueEditing, saveAndClose, discardAndClose } = useUnsavedChanges({
+        getState: () => localItem.value,
+        save: persist,
+        close: handleCancel
+    })
 
     watch(
         () => props.editItem,
@@ -223,6 +246,11 @@
                 showError.value = false
                 showApiKey.value = false
                 saving.value = false
+            } else {
+                // Snapshot the freshly-loaded form as the clean baseline for dirty-tracking.
+                // Without this capture(), baseline stays null and isDirty() always returns false,
+                // so the "Unsaved Changes" prompt never shows — even after real edits.
+                capture()
             }
         }
     )

--- a/src/gui-v3/src/components/config/access-management/NewACL.vue
+++ b/src/gui-v3/src/components/config/access-management/NewACL.vue
@@ -479,6 +479,11 @@
                 localItem.value = { ...defaultItem }
                 selectedUsers.value = []
                 selectedRoles.value = []
+            } else {
+                // Snapshot the freshly-loaded form as the clean baseline for dirty-tracking.
+                // Without this capture(), baseline stays null and isDirty() always returns false,
+                // so the "Unsaved Changes" prompt never shows — even after real edits.
+                capture()
             }
             emit('update:modelValue', newVal)
         }

--- a/src/gui-v3/src/components/config/bots/NewBotPreset.vue
+++ b/src/gui-v3/src/components/config/bots/NewBotPreset.vue
@@ -10,6 +10,7 @@
             <AddNewButton
                 :show="canCreate"
                 v-bind="activatorProps"
+                @click="openCreateDialog"
             />
         </template>
 
@@ -298,6 +299,25 @@
     onMounted(async () => {
         await loadNodes()
     })
+
+    const openCreateDialog = (): void => {
+        localItem.value = { ...defaultItem }
+        showValidationError.value = false
+        showError.value = false
+
+        // Re-select the first node/bot on every open. resetForm() (called on close) nulls
+        // these, so without re-seeding here the second+ open shows ONLY the Bots Node field
+        // (the bot select / parameter fields are gated behind v-if="selectedNode/selectedBot").
+        selectedNode.value = nodes.value[0] ?? null
+        selectedBot.value = selectedNode.value?.bots?.[0] ?? null
+        // Initialize parameter values synchronously from the freshly-selected bot's defaults
+        // rather than in the deferred selectedBot watcher. The watcher is queued AFTER the
+        // dialog watcher (which calls capture() to snapshot the dirty-tracking baseline) because
+        // dialog=true is mutated first, so leaving this to the async watcher would snapshot
+        // params:[] while the live state becomes the bot's defaults — every subsequent
+        // create-open would spuriously report unsaved changes.
+        parameterValues.value = selectedBot.value?.parameters?.map((param) => String(param.default_value ?? '')) || []
+    }
 
     const loadNodes = async (): Promise<void> => {
         loadingNodes.value = true

--- a/src/gui-v3/src/components/config/collectors/NewOSINTSource.vue
+++ b/src/gui-v3/src/components/config/collectors/NewOSINTSource.vue
@@ -331,6 +331,13 @@
         if (collectorId === undefined || collectorId === null) {
             selectedNode.value = nodes.value[0] ?? null
             selectedCollector.value = selectedNode.value?.collectors?.[0] ?? null
+            // Initialize parameter values from the freshly-selected collector's defaults here, not
+            // in the selectedCollector watcher. The watcher is queued AFTER the dialog watcher
+            // (which calls capture() to snapshot the dirty-tracking baseline) because dialog=true
+            // is mutated first, so leaving this to the async watcher snapshots params:[] while the
+            // live state becomes the collector's defaults — every subsequent create-open would
+            // spuriously report unsaved changes. The edit path below already sets this synchronously.
+            parameterValues.value = selectedCollector.value?.parameters?.map((param) => String(param.default_value ?? '')) || []
             return
         }
 

--- a/src/gui-v3/src/components/config/presenters/NewProductType.vue
+++ b/src/gui-v3/src/components/config/presenters/NewProductType.vue
@@ -402,6 +402,13 @@
         if (presenterId === undefined || presenterId === null) {
             selectedNode.value = nodes.value[0] ?? null
             selectedPresenter.value = selectedNode.value?.presenters?.[0] ?? null
+            // Initialize parameter values from the freshly-selected presenter's defaults here, not
+            // in the selectedPresenter watcher. The watcher is queued AFTER the dialog watcher
+            // (which calls capture() to snapshot the dirty-tracking baseline) because dialog=true
+            // is mutated first, so leaving this to the async watcher snapshots params:[] while the
+            // live state becomes the presenter's defaults — every subsequent create-open would
+            // spuriously report unsaved changes. The edit path below already sets this synchronously.
+            parameterValues.value = selectedPresenter.value?.parameters?.map((param) => String(param.default_value ?? '')) || []
             return
         }
 

--- a/src/gui-v3/src/components/config/publishers/NewPublisherPreset.vue
+++ b/src/gui-v3/src/components/config/publishers/NewPublisherPreset.vue
@@ -10,6 +10,7 @@
             <AddNewButton
                 :show="canCreate"
                 v-bind="activatorProps"
+                @click="openCreateDialog"
             />
         </template>
 
@@ -310,6 +311,25 @@
     onMounted(async () => {
         await loadNodes()
     })
+
+    const openCreateDialog = (): void => {
+        localItem.value = { ...defaultItem }
+        showValidationError.value = false
+        showError.value = false
+
+        // Re-select the first node/publisher on every open. resetForm() (called on close) nulls
+        // these, so without re-seeding here the second+ open shows ONLY the Publishers Node field
+        // (the publisher select / parameter fields are gated behind v-if="selectedNode/selectedPublisher").
+        selectedNode.value = nodes.value[0] ?? null
+        selectedPublisher.value = selectedNode.value?.publishers?.[0] ?? null
+        // Initialize parameter values synchronously from the freshly-selected publisher's defaults
+        // rather than in the deferred selectedPublisher watcher. The watcher is queued AFTER the
+        // dialog watcher (which calls capture() to snapshot the dirty-tracking baseline) because
+        // dialog=true is mutated first, so leaving this to the async watcher would snapshot
+        // params:[] while the live state becomes the publisher's defaults — every subsequent
+        // create-open would spuriously report unsaved changes.
+        parameterValues.value = selectedPublisher.value?.parameters?.map((param) => String(param.default_value ?? '')) || []
+    }
 
     const loadNodes = async (): Promise<void> => {
         loadingNodes.value = true

--- a/src/gui-v3/src/components/config/workflow/StateWorkflowTab.vue
+++ b/src/gui-v3/src/components/config/workflow/StateWorkflowTab.vue
@@ -112,10 +112,16 @@
         />
 
         <!-- Edit Dialog - Simplified -->
+        <!-- `persistent`: blocks Vuetify's native close-on-Escape so Escape routes only
+             through @keydown.esc="requestClose" (the unsaved-changes guard). Without it,
+             Escape both opens the prompt AND closes this dialog — the prompt (rendered
+             inside this dialog) unmounts mid-click, so "Close without saving" detaches. -->
         <v-dialog
             v-model="dialogEdit"
             max-width="700"
+            persistent
             scrollable
+            @keydown.esc="requestClose"
         >
             <v-card>
                 <DialogToolbar
@@ -125,8 +131,9 @@
                             : t('workflow.state_workflow.edit_state_association')
                     "
                     :show-save="isEditable"
-                    @cancel="closeEdit"
-                    @save="saveRecord"
+                    :saving="saving"
+                    @cancel="requestClose"
+                    @save="saveAndClose"
                 />
                 <v-card-text>
                     <v-form ref="formRef">
@@ -183,6 +190,13 @@
                     </v-form>
                 </v-card-text>
             </v-card>
+
+            <UnsavedChangesDialog
+                v-model="confirmVisible"
+                @continue="continueEditing"
+                @save="saveAndClose"
+                @discard="discardAndClose"
+            />
         </v-dialog>
     </v-container>
 </template>
@@ -194,8 +208,10 @@
     import ActionButton from '@/components/common/buttons/ActionButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import ConfirmationDialog from '@/components/common/dialogs/ConfirmationDialog.vue'
+    import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
     import { useConfigStore } from '@/stores/config'
     import { useAuth } from '@/composables/useAuth'
+    import { useUnsavedChanges } from '@/composables/useUnsavedChanges'
     import { createNewStateEntityType, updateStateEntityType, deleteStateEntityType } from '@/api/config'
 
     type EntityType = 'product' | 'report_item' | string
@@ -245,6 +261,7 @@
     const dialogDelete = ref(false)
     const editedIndex = ref(-1)
     const formRef = ref<any>(null)
+    const saving = ref(false)
 
     const defaultItem: StateEntityTypeRecord = {
         id: -1,
@@ -361,10 +378,15 @@
         dialogDelete.value = false
     }
 
-    async function saveRecord(): Promise<void> {
-        const { valid } = (await formRef.value.validate()) as FormValidationResult
-        if (!valid) return
+    // Persists the form. Returns true on success so the unsaved-changes guard can
+    // decide whether to close the dialog (it closes only on a successful save).
+    async function persist(): Promise<boolean> {
+        const { valid } = (await formRef.value?.validate()) as FormValidationResult
+        if (!valid) {
+            return false
+        }
 
+        saving.value = true
         try {
             // Send only the persisted fields. The record also carries a nested `state`
             // object (and updated_by/at) which the backend schema feeds straight into the
@@ -383,15 +405,40 @@
                 await createNewStateEntityType(payload)
             }
             await fetchRecords()
-            closeEdit()
+            return true
         } catch (error) {
             window.dispatchEvent(
                 new CustomEvent('notification', {
                     detail: { type: 'error', loc: 'common.error_saving' }
                 })
             )
+            return false
+        } finally {
+            saving.value = false
         }
     }
+
+    // Unsaved-changes guard. capture() snapshots the freshly-loaded form as the clean
+    // baseline on open; requestClose() shows the prompt only when real edits exist.
+    // Without capture() the baseline stays null and isDirty() always returns false, so
+    // the prompt never shows — even after the user edits fields then clicks cancel.
+    const { confirmVisible, capture, requestClose, continueEditing, saveAndClose, discardAndClose } = useUnsavedChanges({
+        getState: () => editedItem.value,
+        save: persist,
+        close: closeEdit
+    })
+
+    watch(
+        () => dialogEdit.value,
+        (newVal: boolean) => {
+            if (!newVal) {
+                saving.value = false
+            } else {
+                // Snapshot the form as the clean baseline for dirty-tracking.
+                capture()
+            }
+        }
+    )
 
     async function deleteRecord(): Promise<void> {
         if (!editedItem.value.editable) {

--- a/src/gui-v3/src/components/config/workflow/StatesTab.vue
+++ b/src/gui-v3/src/components/config/workflow/StatesTab.vue
@@ -83,17 +83,24 @@
         />
 
         <!-- Edit Dialog - Simplified for now -->
+        <!-- `persistent`: blocks Vuetify's native close-on-Escape so Escape routes only
+             through @keydown.esc="requestClose" (the unsaved-changes guard). Without it,
+             Escape both opens the prompt AND closes this dialog — the prompt (rendered
+             inside this dialog) unmounts mid-click, so "Close without saving" detaches. -->
         <v-dialog
             v-model="dialogEdit"
             max-width="700"
+            persistent
             scrollable
+            @keydown.esc="requestClose"
         >
             <v-card>
                 <DialogToolbar
                     :title="editedIndex === -1 ? t('workflow.states.add_new') : t('workflow.states.edit')"
                     :show-save="isEditable"
-                    @cancel="closeEdit"
-                    @save="saveRecord"
+                    :saving="saving"
+                    @cancel="requestClose"
+                    @save="saveAndClose"
                 />
                 <v-card-text>
                     <v-form ref="formRef">
@@ -138,20 +145,29 @@
                     </v-form>
                 </v-card-text>
             </v-card>
+
+            <UnsavedChangesDialog
+                v-model="confirmVisible"
+                @continue="continueEditing"
+                @save="saveAndClose"
+                @discard="discardAndClose"
+            />
         </v-dialog>
     </v-container>
 </template>
 
 <script setup lang="ts">
-    import { ref, computed, onMounted } from 'vue'
+    import { ref, computed, onMounted, watch } from 'vue'
     import { useI18n } from 'vue-i18n'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import ActionButton from '@/components/common/buttons/ActionButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import ConfirmationDialog from '@/components/common/dialogs/ConfirmationDialog.vue'
+    import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
     import SearchField from '@/components/common/SearchField.vue'
     import { useConfigStore } from '@/stores/config'
     import { useAuth } from '@/composables/useAuth'
+    import { useUnsavedChanges } from '@/composables/useUnsavedChanges'
     import { createNewStateDefinition, updateStateDefinition, deleteStateDefinition } from '@/api/config'
 
     type StateDefinition = {
@@ -183,6 +199,7 @@
     const dialogDelete = ref(false)
     const editedIndex = ref(-1)
     const formRef = ref<any>(null)
+    const saving = ref(false)
 
     const defaultItem: StateDefinition = {
         id: -1,
@@ -252,10 +269,15 @@
         dialogDelete.value = false
     }
 
-    async function saveRecord(): Promise<void> {
-        const { valid } = (await formRef.value.validate()) as FormValidationResult
-        if (!valid) return
+    // Persists the form. Returns true on success so the unsaved-changes guard can
+    // decide whether to close the dialog (it closes only on a successful save).
+    async function persist(): Promise<boolean> {
+        const { valid } = (await formRef.value?.validate()) as FormValidationResult
+        if (!valid) {
+            return false
+        }
 
+        saving.value = true
         try {
             // Send only editable fields. On create, omit id entirely so the backend
             // assigns a real auto-increment id; sending id (e.g. -1) inserts a row with
@@ -273,15 +295,40 @@
                 await createNewStateDefinition(payload)
             }
             await configStore.loadStateDefinitions({ search: '' })
-            closeEdit()
+            return true
         } catch (error) {
             window.dispatchEvent(
                 new CustomEvent('notification', {
                     detail: { type: 'error', loc: 'common.error_saving' }
                 })
             )
+            return false
+        } finally {
+            saving.value = false
         }
     }
+
+    // Unsaved-changes guard. capture() snapshots the freshly-loaded form as the clean
+    // baseline on open; requestClose() shows the prompt only when real edits exist.
+    // Without capture() the baseline stays null and isDirty() always returns false, so
+    // the prompt never shows — even after the user edits fields then clicks cancel.
+    const { confirmVisible, capture, requestClose, continueEditing, saveAndClose, discardAndClose } = useUnsavedChanges({
+        getState: () => editedItem.value,
+        save: persist,
+        close: closeEdit
+    })
+
+    watch(
+        () => dialogEdit.value,
+        (newVal: boolean) => {
+            if (!newVal) {
+                saving.value = false
+            } else {
+                // Snapshot the form as the clean baseline for dirty-tracking.
+                capture()
+            }
+        }
+    )
 
     async function deleteRecord(): Promise<void> {
         if (!editedItem.value.editable) {

--- a/src/gui-v3/tests/e2e/collectors.spec.js
+++ b/src/gui-v3/tests/e2e/collectors.spec.js
@@ -61,4 +61,38 @@ test.describe('Collectors', () => {
         await expect(dialog.locator('.v-alert')).toBeVisible()
         await expect(dialog).toBeVisible()
     })
+
+    // ── Unsaved-changes guard ─────────────────────
+    // NodeDialog (the shared node create/edit dialog used by Collectors / Presenters /
+    // Publishers / Bots Nodes tabs). Cancel with edits must raise the prompt instead of
+    // closing silently. Covers the mode-2 fix (missing `capture()` ⇒ prompt never showed).
+    test('should prompt and discard unsaved changes when cancelling a new collectors node', async ({ page }) => {
+        await page.goto('/v2/config/collectors?tab=nodes')
+        await page.getByRole('button', { name: 'Add New' }).click()
+
+        const dialog = page.locator('.v-dialog:visible')
+        await expect(dialog).toBeVisible()
+        await dialog.locator('input').first().fill('Cancelled Collectors Node')
+
+        await dialog.getByRole('button', { name: 'Cancel' }).click()
+
+        const prompt = page.locator('.v-overlay--active').filter({ hasText: 'Unsaved Changes' })
+        await expect(prompt).toBeVisible()
+        await prompt.getByRole('button', { name: 'Close without saving' }).click()
+
+        await expect(page.locator('.v-overlay--active')).toHaveCount(0)
+    })
+
+    test('cancel without edits closes immediately (no false prompt) for a new collectors node', async ({ page }) => {
+        // Regression guard for failure mode 1: opening the create dialog and cancelling
+        // with NO edits must close right away, without a spurious prompt.
+        await page.goto('/v2/config/collectors?tab=nodes')
+        await page.getByRole('button', { name: 'Add New' }).click()
+
+        const dialog = page.locator('.v-dialog:visible')
+        await expect(dialog).toBeVisible()
+
+        await dialog.getByRole('button', { name: 'Cancel' }).click()
+        await expect(page.locator('.v-overlay--active')).toHaveCount(0)
+    })
 })

--- a/src/gui-v3/tests/e2e/organizations.spec.js
+++ b/src/gui-v3/tests/e2e/organizations.spec.js
@@ -39,7 +39,14 @@ test.describe('Organization Management', () => {
 
         // The list is paginated, so the new row may land on a later page. Filter by the
         // (unique) name to surface it regardless of which page it's on.
-        await page.getByRole('textbox', { name: 'Search' }).fill(orgName)
+        //
+        // Scope the search field to the *active* Access Management window item. The view
+        // (Users/Roles/ACL/Organizations tabs) renders a SearchField per tab; Vuetify's
+        // v-window-item transition leaves the previous tab's search input cloned in the
+        // DOM (hidden) on tab switch, so a page-wide `getByRole('textbox', { name: 'Search' })`
+        // is ambiguous (strict-mode violation: resolved to 2 elements).
+        const activePanel = page.locator('.v-window-item--active')
+        await activePanel.getByRole('textbox', { name: 'Search' }).fill(orgName)
         await expect(page.locator('tbody tr').filter({ hasText: orgName })).toBeVisible()
     })
 

--- a/src/gui-v3/tests/e2e/presenters.spec.js
+++ b/src/gui-v3/tests/e2e/presenters.spec.js
@@ -77,4 +77,38 @@ test.describe('Presenters', () => {
         await expect(dialog.locator('.v-alert')).toBeVisible()
         await expect(dialog).toBeVisible()
     })
+
+    // ── Unsaved-changes guard ─────────────────────
+    // NodeDialog (the shared node create/edit dialog used by Collectors / Presenters /
+    // Publishers / Bots Nodes tabs). Cancel with edits must raise the prompt instead of
+    // closing silently. Covers the mode-2 fix (missing `capture()` ⇒ prompt never showed).
+    test('should prompt and discard unsaved changes when cancelling a new presenters node', async ({ page }) => {
+        await page.goto('/v2/config/presenters?tab=nodes')
+        await page.getByRole('button', { name: 'Add New' }).click()
+
+        const dialog = page.locator('.v-dialog:visible')
+        await expect(dialog).toBeVisible()
+        await dialog.locator('input').first().fill('Cancelled Presenters Node')
+
+        await dialog.getByRole('button', { name: 'Cancel' }).click()
+
+        const prompt = page.locator('.v-overlay--active').filter({ hasText: 'Unsaved Changes' })
+        await expect(prompt).toBeVisible()
+        await prompt.getByRole('button', { name: 'Close without saving' }).click()
+
+        await expect(page.locator('.v-overlay--active')).toHaveCount(0)
+    })
+
+    test('cancel without edits closes immediately (no false prompt) for a new presenters node', async ({ page }) => {
+        // Regression guard for failure mode 1: opening the create dialog and cancelling
+        // with NO edits must close right away, without a spurious prompt.
+        await page.goto('/v2/config/presenters?tab=nodes')
+        await page.getByRole('button', { name: 'Add New' }).click()
+
+        const dialog = page.locator('.v-dialog:visible')
+        await expect(dialog).toBeVisible()
+
+        await dialog.getByRole('button', { name: 'Cancel' }).click()
+        await expect(page.locator('.v-overlay--active')).toHaveCount(0)
+    })
 })

--- a/src/gui-v3/tests/e2e/roles.spec.js
+++ b/src/gui-v3/tests/e2e/roles.spec.js
@@ -59,7 +59,14 @@ test.describe('Role Management', () => {
 
         // The list is paginated, so the new row may land on a later page. Filter by the
         // (unique) name to surface it regardless of which page it's on.
-        await page.getByRole('textbox', { name: 'Search' }).fill(roleName)
+        //
+        // Scope the search field to the *active* Access Management window item. The view
+        // (Users/Roles/ACL/Organizations tabs) renders a SearchField per tab; Vuetify's
+        // v-window-item transition leaves the previous tab's search input cloned in the
+        // DOM (hidden) on tab switch, so a page-wide `getByRole('textbox', { name: 'Search' })`
+        // is ambiguous (strict-mode violation: resolved to 2 elements).
+        const activePanel = page.locator('.v-window-item--active')
+        await activePanel.getByRole('textbox', { name: 'Search' }).fill(roleName)
         await expect(page.locator('tbody tr').filter({ hasText: roleName })).toBeVisible()
     })
 
@@ -123,17 +130,16 @@ test.describe('Role Management', () => {
     })
 
     test('should filter/search roles', async ({ page }) => {
-        // Look for search input (if implemented)
-        const searchInput = page.locator('input[aria-label*="search" i], input[placeholder*="search" i]').first()
-        const searchExists = await searchInput.isVisible().catch(() => false)
+        // Scope to the active Access Management window item — see the create test for why a
+        // page-wide search locator is ambiguous (Vuetify leaves a cloned input from the
+        // previous tab in the DOM).
+        const searchInput = page.locator('.v-window-item--active').getByRole('textbox', { name: 'Search' })
+        await expect(searchInput).toBeVisible()
 
-        if (searchExists) {
-            // Use search
-            await searchInput.fill('Admin')
+        await searchInput.fill('Admin')
 
-            // Should show only matching role
-            await expect(page.locator('tbody tr').filter({ hasText: 'Admin' })).toBeVisible()
-        }
+        // Should show only matching role
+        await expect(page.locator('tbody tr').filter({ hasText: 'Admin' })).toBeVisible()
     })
 
     test('should handle duplicate role names', async ({ page }) => {

--- a/src/gui-v3/tests/e2e/state-workflow.spec.js
+++ b/src/gui-v3/tests/e2e/state-workflow.spec.js
@@ -92,6 +92,57 @@ test.describe('Workflow - State Workflow', () => {
         await expect(dialog.locator('.v-input--error').first()).toBeVisible()
     })
 
+    // ── Unsaved-changes guard ─────────────────────
+    // Cancel with edits raises the prompt rather than closing silently. Covers the
+    // mode-2 fix (missing `capture()` ⇒ prompt never showed) for StateWorkflowTab.vue.
+    test('should prompt and discard unsaved changes on cancel', async ({ page }) => {
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible()
+
+        // Any field edit flips the form from its captured baseline to dirty. The sort
+        // order is a plain number input, so it needs no select menu interaction.
+        await dialog.locator('input[type="number"]').fill('9')
+
+        await dialog.getByRole('button', { name: 'Cancel' }).click()
+
+        const prompt = page.locator('.v-overlay--active').filter({ hasText: 'Unsaved Changes' })
+        await expect(prompt).toBeVisible()
+        await prompt.getByRole('button', { name: 'Close without saving' }).click()
+
+        await expect(page.locator('.v-overlay--active')).toHaveCount(0)
+    })
+
+    test('should keep editing when choosing "Continue editing" on the prompt', async ({ page }) => {
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await dialog.locator('input[type="number"]').fill('9')
+
+        await dialog.getByRole('button', { name: 'Cancel' }).click()
+
+        const prompt = page.locator('.v-overlay--active').filter({ hasText: 'Unsaved Changes' })
+        await expect(prompt).toBeVisible()
+
+        await prompt.getByRole('button', { name: 'Continue editing' }).click()
+        await expect(prompt).toHaveCount(0)
+
+        // The edit dialog stays open with the edit intact.
+        const editDialog = page.locator('.v-overlay--active')
+        await expect(editDialog).toBeVisible()
+        await expect(editDialog.locator('input[type="number"]')).toHaveValue('9')
+    })
+
+    test('cancel without edits closes immediately (no false prompt)', async ({ page }) => {
+        // Regression guard for failure mode 1: opening the create dialog and cancelling
+        // with NO edits must close right away, without a spurious prompt.
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible()
+
+        await dialog.getByRole('button', { name: 'Cancel' }).click()
+        await expect(page.locator('.v-overlay--active')).toHaveCount(0)
+    })
+
     test('should create, edit and delete a state association', async ({ page }) => {
         const stateName = generateTestName('E2E Assoc State')
 

--- a/src/gui-v3/tests/e2e/states.spec.js
+++ b/src/gui-v3/tests/e2e/states.spec.js
@@ -68,6 +68,71 @@ test.describe('Workflow - States', () => {
         await expect(dialog.locator('.v-input--error').first()).toBeVisible()
     })
 
+    // ── Unsaved-changes guard ─────────────────────
+    // Cancel with edits raises the prompt rather than closing silently. Covers the
+    // mode-2 fix (missing `capture()` ⇒ prompt never showed) for StatesTab.vue.
+    test('should prompt and discard unsaved changes on cancel', async ({ page }) => {
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible()
+        await dialog.locator('input').first().fill('Cancelled State')
+
+        await dialog.getByRole('button', { name: 'Cancel' }).click()
+
+        // The prompt appears instead of closing immediately.
+        const prompt = page.locator('.v-overlay--active').filter({ hasText: 'Unsaved Changes' })
+        await expect(prompt).toBeVisible()
+
+        await prompt.getByRole('button', { name: 'Close without saving' }).click()
+
+        await expect(page.locator('.v-overlay--active')).toHaveCount(0)
+        await expect(page.locator('tbody tr').filter({ hasText: 'Cancelled State' })).toHaveCount(0)
+    })
+
+    test('should keep editing when choosing "Continue editing" on the prompt', async ({ page }) => {
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await dialog.locator('input').first().fill('Kept State')
+
+        await dialog.getByRole('button', { name: 'Cancel' }).click()
+
+        const prompt = page.locator('.v-overlay--active').filter({ hasText: 'Unsaved Changes' })
+        await expect(prompt).toBeVisible()
+
+        // Continue editing dismisses the prompt and leaves the edit dialog open with data intact.
+        await prompt.getByRole('button', { name: 'Continue editing' }).click()
+        await expect(prompt).toHaveCount(0)
+
+        const editDialog = page.locator('.v-overlay--active')
+        await expect(editDialog).toBeVisible()
+        await expect(editDialog.locator('input').first()).toHaveValue('Kept State')
+    })
+
+    test('should prompt when pressing Escape with unsaved changes', async ({ page }) => {
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await dialog.locator('input').first().fill('Escaped State')
+
+        await page.keyboard.press('Escape')
+
+        const prompt = page.locator('.v-overlay--active').filter({ hasText: 'Unsaved Changes' })
+        await expect(prompt).toBeVisible()
+        // Discard via the prompt.
+        await prompt.getByRole('button', { name: 'Close without saving' }).click()
+        await expect(page.locator('.v-overlay--active')).toHaveCount(0)
+    })
+
+    test('cancel without edits closes immediately (no false prompt)', async ({ page }) => {
+        // Regression guard for failure mode 1: opening the create dialog and cancelling
+        // with NO edits must close right away, without a spurious prompt.
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible()
+
+        await dialog.getByRole('button', { name: 'Cancel' }).click()
+        await expect(page.locator('.v-overlay--active')).toHaveCount(0)
+    })
+
     test('should create a new state and remove it again', async ({ page }) => {
         const stateName = generateTestName('E2E State')
 

--- a/src/gui-v3/tests/unit/useUnsavedChanges.spec.js
+++ b/src/gui-v3/tests/unit/useUnsavedChanges.spec.js
@@ -65,6 +65,19 @@ describe('useUnsavedChanges', () => {
             expect(close).not.toHaveBeenCalled()
             expect(guard.confirmVisible.value).toBe(true)
         })
+
+        // Regression guard for "mode 2": a dialog that never calls capture() (the bug
+        // fixed in StatesTab / StateWorkflowTab / NodeDialog / NewACL) must close
+        // silently on requestClose() — its baseline stays null so isDirty() is always
+        // false, hence the prompt never shows even after real edits.
+        it('closes immediately (never prompts) when capture() was never called', () => {
+            const { guard, close, state } = setup()
+            // Simulate a dialog that omitted `else { capture() }`: edit the form without a baseline.
+            state.name = 'edited-but-never-captured'
+            guard.requestClose()
+            expect(close).toHaveBeenCalledTimes(1)
+            expect(guard.confirmVisible.value).toBe(false)
+        })
     })
 
     // ── Prompt actions ────────────────────────────


### PR DESCRIPTION
### Fixes

- Wire up useUnsavedChanges guard in StatesTab.vue, StateWorkflowTab.vue, and NodeDialog.vue — the "Unsaved Changes" prompt was never showing on cancel (missing capture() on open left the dirty-tracking baseline null, so isDirty() always returned false).
- Make workflow edit dialogs persistent (StatesTab.vue, StateWorkflowTab.vue) — blocks Vuetify's native Escape close so the prompt stays mounted instead of detaching mid-click.
- Convert save handlers to boolean-returning persist() so the guard closes the dialog only on a successful save.

### Tests

- **Unit**: added regression test for the mode-2 invariant (no capture() ⇒ never prompts) in useUnsavedChanges.spec.js.
- **E2E**: added unsaved-changes prompt coverage (cancel-with-discard, continue-editing, Escape, no-false-prompt) to states/state-workflow/collectors/presenters specs.
- **E2E fixes**: scoped page-wide getByRole('textbox', { name: 'Search' }) locators to .v-window-item--active in roles/organizations specs to resolve Vuetify v-window transition-clone strict-mode violations.