### PR TITLE
Fixes and updates (VUE 3), backend optimizations, news item badges

### DIFF
--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -4,3 +4,15 @@ services:
       traefik.enable: "false"
     ports:
       - "127.0.0.1:8082:80"
+
+  collectors:
+    ports:
+      - "127.0.0.1:5001:80"
+
+  presenters:
+    ports:
+      - "127.0.0.1:5002:80"
+
+  publishers:
+    ports:
+      - "127.0.0.1:5003:80"

--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -13,7 +13,7 @@ echo "Starting Taranis-NG backend services for E2E tests..."
 # Start core, postgres, redis with localhost port exposure for the frontend dev server.
 # Build the core image from the current workspace so new backend routes are available in E2E runs.
 cd "$COMPOSE_DIR"
-docker compose --env-file "$E2E_ENV_FILE" -f docker-compose.yml -f docker-compose.e2e.yml -p taranis-e2e up -d --build postgres redis core
+docker compose --env-file "$E2E_ENV_FILE" -f docker-compose.yml -f docker-compose.e2e.yml -p taranis-e2e up -d --build postgres redis core collectors presenters publishers
 
 echo "Waiting for services to be ready..."
 
@@ -55,6 +55,23 @@ for i in {1..30}; do
     exit 1
   fi
   sleep 1
+done
+
+# Wait for collectors, presenters, and publishers containers to be running.
+# The core container needs to reach these via Docker DNS when the test adds nodes.
+for service in collectors presenters publishers; do
+  for i in {1..30}; do
+    status=$(docker compose --env-file "$E2E_ENV_FILE" -f docker-compose.yml -f docker-compose.e2e.yml -p taranis-e2e ps --format json "$service" 2>/dev/null | tr -d '\n')
+    if echo "$status" | grep -q '"running":true'; then
+      echo "✓ $service container is running"
+      break
+    fi
+    if [ $i -eq 30 ]; then
+      echo "✗ $service container failed to start"
+      exit 1
+    fi
+    sleep 1
+  done
 done
 
 echo "✓ All services ready"

--- a/src/core/model/news_item.py
+++ b/src/core/model/news_item.py
@@ -874,6 +874,12 @@ class NewsItemAggregate(db.Model):
             dict: News item aggregates JSON
         """
         news_item_aggregates, count = cls.get_by_group(group_id, filters, offset, limit, user)
+
+        # Batch-compute report counts for all aggregates on the page in two
+        # grouped queries instead of N+1 per-aggregate count() calls.
+        aggregate_ids = [nia.id for nia in news_item_aggregates]
+        report_counts = ReportItemNewsItemAggregate.counts_for_aggregates(aggregate_ids)
+
         for news_item_aggregate in news_item_aggregates:
             news_item_aggregate.me_like = False
             news_item_aggregate.me_dislike = False
@@ -896,7 +902,9 @@ class NewsItemAggregate(db.Model):
                 if news_item.me_dislike is True:
                     news_item_aggregate.me_dislike = True
 
-            news_item_aggregate.in_reports_count = ReportItemNewsItemAggregate.count(news_item_aggregate.id)
+            total_reports, completed_reports = report_counts.get(news_item_aggregate.id, (0, 0))
+            news_item_aggregate.in_reports_count = total_reports
+            news_item_aggregate.completed_reports_count = completed_reports
 
         news_item_aggregate_schema = NewsItemAggregateSchema(many=True)
         items = news_item_aggregate_schema.dump(news_item_aggregates)
@@ -1590,3 +1598,66 @@ class ReportItemNewsItemAggregate(db.Model):
             int: Count
         """
         return cls.query.filter_by(news_item_aggregate_id=aggregate_id).count()
+
+    @classmethod
+    def counts_for_aggregates(cls, aggregate_ids: list[int]) -> dict[int, tuple[int, int]]:
+        """Batch-compute (total_reports, completed_reports) per aggregate.
+
+        Replaces the previous N+1 pattern of calling ``count()`` once per
+        aggregate by issuing a single grouped query over the association
+        table joined to ``ReportItem``. The COMPLETED state is resolved once
+        via ``StateDefinition`` (matching the semantics used elsewhere, e.g.
+        ``ReportItem.get_by_filter``).
+
+        Args:
+            aggregate_ids: Aggregate IDs to compute counts for.
+
+        Returns:
+            dict mapping aggregate_id -> (total_reports, completed_reports).
+            Aggregates with no report items are absent from the dict; callers
+            should default missing keys to (0, 0).
+        """
+        if not aggregate_ids:
+            return {}
+
+        # Late import to avoid circular dependency (report_item imports news_item).
+        from model.report_item import ReportItem  # noqa: PLC0415
+        from model.state import StateDefinition, StateEnum  # noqa: PLC0415
+
+        completed_state = StateDefinition.get_by_name(StateEnum.COMPLETED.value)
+        completed_state_id = completed_state.id if completed_state else None
+
+        # Total reports per aggregate (one grouped query).
+        total_rows = (
+            db.session.query(ReportItemNewsItemAggregate.news_item_aggregate_id, db.func.count(ReportItemNewsItemAggregate.report_item_id))
+            .filter(ReportItemNewsItemAggregate.news_item_aggregate_id.in_(aggregate_ids))
+            .group_by(ReportItemNewsItemAggregate.news_item_aggregate_id)
+            .all()
+        )
+
+        result: dict[int, tuple[int, int]] = {}
+        for agg_id, total in total_rows:
+            result[agg_id] = (total, 0)
+
+        # Completed reports per aggregate (one grouped query on a joined query).
+        # Only run when a COMPLETED state exists; otherwise completed stays 0 for all.
+        if completed_state_id is not None:
+            completed_rows = (
+                db.session.query(
+                    ReportItemNewsItemAggregate.news_item_aggregate_id,
+                    db.func.count(ReportItemNewsItemAggregate.report_item_id),
+                )
+                .join(ReportItem, ReportItemNewsItemAggregate.report_item_id == ReportItem.id)
+                .filter(
+                    ReportItemNewsItemAggregate.news_item_aggregate_id.in_(aggregate_ids),
+                    ReportItem.state_id == completed_state_id,
+                )
+                .group_by(ReportItemNewsItemAggregate.news_item_aggregate_id)
+                .all()
+            )
+            for agg_id, completed in completed_rows:
+                if agg_id in result:
+                    total_existing = result[agg_id][0]
+                    result[agg_id] = (total_existing, completed)
+
+        return result

--- a/src/core/model/product.py
+++ b/src/core/model/product.py
@@ -334,6 +334,60 @@ class Product(db.Model):
             logger.exception(f"Failed to auto-complete reports on product publish: {error}")
 
     @classmethod
+    def _auto_complete_added_reports(
+        cls,
+        product_state_id: int,
+        user: User,
+        added_report_item_ids: set[int],
+    ) -> None:
+        """Auto-complete newly-added non-FINAL reports when the product is already FINAL.
+
+        This closes the gap left by ``_auto_complete_reports_on_publish``, which only
+        fires on a product *state change*. When a report is added to a product that
+        is *already* in a FINAL state (e.g. already published), the product's state
+        does not change, so the existing cascade is skipped. This method completes
+        only the newly-added non-FINAL reports, mirroring the publish cascade for
+        the add-to-published-product path.
+
+        Args:
+            product_id: The product ID being updated
+            product_state_id: The current state ID of the product
+            user: The user performing the update
+            added_report_item_ids: IDs of report items newly attached in this update
+
+        Returns:
+            None
+        """
+        try:
+            # Check if cascade states feature is enabled
+            if not StateManager.is_cascade_states_enabled(user):
+                return
+
+            # Only act when the product is already in a FINAL state.
+            if not StateManager.is_final_state(product_state_id, StateEntityTypeEnum.PRODUCT.value):
+                return
+
+            if not added_report_item_ids:
+                return
+
+            # Get the FINAL state for REPORT_ITEM
+            final_state = StateDefinition.get_final_state(StateEntityTypeEnum.REPORT_ITEM.value)
+            if not final_state:
+                return
+
+            # Auto-complete only newly-added non-FINAL reports.
+            for report_item_id in added_report_item_ids:
+                report_item = ReportItem.find(report_item_id)
+                if not report_item:
+                    continue
+                if not StateManager.is_final_state(report_item.state_id, StateEntityTypeEnum.REPORT_ITEM.value):
+                    update_data = {"update": True, "state_id": final_state.id}
+                    ReportItem.update_report_item(report_item.id, update_data, user)
+
+        except Exception as error:
+            logger.exception(f"Failed to auto-complete newly-added reports on product update: {error}")
+
+    @classmethod
     def add_product(cls, product_data: dict, user: User) -> Product:
         """Add a product.
 
@@ -367,6 +421,10 @@ class Product(db.Model):
 
         original_product = Product.find(product_id)
         old_state_id = original_product.state_id
+        # Capture existing report-item ids before reassignment so the cascade
+        # can target only newly-added reports (Option B: a report added to an
+        # already-published product should be auto-completed too).
+        existing_report_item_ids = {ri.id for ri in original_product.report_items} if original_product.report_items else set()
         original_product.title = product.title
         original_product.description = product.description
         original_product.product_type_id = product.product_type_id
@@ -378,7 +436,13 @@ class Product(db.Model):
 
         db.session.commit()
 
-        # Handle cascade state changes for reports if product is published
+        # Handle cascade state changes for reports:
+        #  - When the product's state changed toward FINAL, complete all non-FINAL reports.
+        #  - When the product is already in a FINAL state and new reports were added,
+        #    complete only those newly-added non-FINAL reports.
+        added_report_item_ids = {ri.id for ri in product.report_items} - existing_report_item_ids if product.report_items else set()
+        if user and added_report_item_ids:
+            cls._auto_complete_added_reports(product.state_id, user, added_report_item_ids)
         if user and old_state_id != product.state_id:
             cls._auto_complete_reports_on_publish(product_id, product.state_id, user)
 

--- a/src/gui-v3/playwright.config.js
+++ b/src/gui-v3/playwright.config.js
@@ -43,18 +43,29 @@ export default defineConfig({
 
     /* Configure projects for major browsers */
     projects: [
+        // Setup project: seeds the E2E environment (collectors/presenters/publishers nodes,
+        // manual OSINT source, product type, publisher preset) before any other test runs.
+        {
+            name: 'setup',
+            testMatch: /00-config-seed\.spec\.js/,
+            use: { ...devices['Desktop Chrome'] }
+        },
+
         {
             name: 'chromium',
+            dependencies: ['setup'],
             use: { ...devices['Desktop Chrome'] }
         },
 
         {
             name: 'firefox',
+            dependencies: ['setup'],
             use: { ...devices['Desktop Firefox'] }
         },
 
         {
             name: 'webkit',
+            dependencies: ['setup'],
             use: { ...devices['Desktop Safari'] }
         }
 

--- a/src/gui-v3/src/components/analyze/ContentDataAnalyze.vue
+++ b/src/gui-v3/src/components/analyze/ContentDataAnalyze.vue
@@ -30,7 +30,7 @@
             style="min-height: 100px; display: flex; align-items: center; justify-content: center"
         >
             <div
-                v-if="!dataLoaded"
+                v-if="!dataLoaded && collections.length > 0"
                 class="text-center text-grey"
             >
                 <v-progress-circular
@@ -42,12 +42,35 @@
                 </p>
             </div>
             <div
-                v-else
+                v-else-if="collections.length > 0"
                 class="text-caption text-grey"
             >
                 {{ t('common.end_of_list') }}
             </div>
         </div>
+
+        <!-- Empty State -->
+        <v-row
+            v-if="dataLoaded && collections.length === 0"
+            justify="center"
+            class="my-8"
+        >
+            <v-col
+                cols="12"
+                md="6"
+                class="text-center"
+            >
+                <v-icon
+                    size="64"
+                    color="grey"
+                >
+                    {{ ICONS.FILE_TABLE_OUTLINE }}
+                </v-icon>
+                <p class="text-h6 text-grey mt-4">
+                    {{ t('analyze.no_items') }}
+                </p>
+            </v-col>
+        </v-row>
     </v-container>
 </template>
 
@@ -55,6 +78,7 @@
     import { ref, watch, onMounted, onUnmounted, computed } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useRoute } from 'vue-router'
+    import { ICONS } from '@/config/ui-constants'
     import { useAnalyzeStore } from '@/stores/analyze'
     import CardAnalyze from './CardAnalyze.vue'
     import CardCompact from '@/components/common/CardCompact.vue'
@@ -98,7 +122,7 @@
     const analyzeStore = useAnalyzeStore()
 
     const collections = ref<ReportItem[]>([])
-    const dataLoaded = ref(false)
+    const dataLoaded = ref(true)
     const filter = ref<FilterState>({
         search: '',
         range: 'ALL',
@@ -133,6 +157,10 @@
 
     const infiniteScrolling = (isIntersecting: boolean): void => {
         const totalCount = analyzeStore.getReportItems.total_count || 0
+        // Don't attempt to load more when there are no items to load
+        if (totalCount === 0) {
+            return
+        }
         if (dataLoaded.value && isIntersecting && collections.value.length < totalCount) {
             updateData(true, false)
         }
@@ -175,14 +203,17 @@
         }
 
         try {
-            await analyzeStore.loadReportItems({
-                group: group,
-                filter: filter.value,
-                offset: offset,
-                limit: limit
-            })
-
-            await analyzeStore.loadReportItemTypes({})
+            // Load the report items list and the report-item-type catalog in
+            // parallel, since the type enrichment below only needs both results.
+            await Promise.all([
+                analyzeStore.loadReportItems({
+                    group: group,
+                    filter: filter.value,
+                    offset: offset,
+                    limit: limit
+                }),
+                analyzeStore.loadReportItemTypes({})
+            ])
 
             const reportTypes = Array.isArray(analyzeStore.getReportItemTypes.items)
                 ? (analyzeStore.getReportItemTypes.items as ReportItem[])
@@ -214,12 +245,9 @@
             const totalCount = analyzeStore.getReportItems.total_count || 0
             emit('new-data-loaded', totalCount)
             emit('update-showing-count', collections.value.length)
-
-            setTimeout(() => {
-                dataLoaded.value = true
-            }, 1000)
         } catch (error) {
             console.error('Error loading report items:', error)
+        } finally {
             dataLoaded.value = true
         }
     }

--- a/src/gui-v3/src/components/assess/CardAssess.vue
+++ b/src/gui-v3/src/components/assess/CardAssess.vue
@@ -82,18 +82,33 @@
                         </v-chip>
 
                         <v-chip
-                            v-if="inReportsCount > 0"
+                            v-if="inProgressReportsCount > 0"
                             size="small"
                             color="orange"
                             variant="outlined"
                             class="mr-2"
                             :disabled="analyzeSelector"
                             :style="analyzeSelector ? '' : 'cursor: pointer'"
-                            @click.stop="!analyzeSelector && showInReports()"
+                            @click.stop="!analyzeSelector && showInReports('in_progress')"
                         >
                             <v-icon start> mdi-file-document </v-icon>
                             {{ t('card_item.in_analyze') }}
-                            <span v-if="inReportsCount > 1">&nbsp;({{ inReportsCount }})</span>
+                            <span v-if="inProgressReportsCount > 1">&nbsp;({{ inProgressReportsCount }})</span>
+                        </v-chip>
+
+                        <v-chip
+                            v-if="completedReportsCount > 0"
+                            size="small"
+                            color="green"
+                            variant="outlined"
+                            class="mr-2"
+                            :disabled="analyzeSelector"
+                            :style="analyzeSelector ? '' : 'cursor: pointer'"
+                            @click.stop="!analyzeSelector && showInReports('completed')"
+                        >
+                            <v-icon start>{{ ICONS.CHECK_CIRCLE }}</v-icon>
+                            {{ t('card_item.analyzed') }}
+                            <span v-if="completedReportsCount > 1">&nbsp;({{ completedReportsCount }})</span>
                         </v-chip>
 
                         <v-icon
@@ -194,6 +209,7 @@
         modify?: boolean
         access?: boolean
         in_reports_count?: number
+        completed_reports_count?: number
         news_items?: NewsItemEntry[]
         [key: string]: any
     }
@@ -222,7 +238,7 @@
         (e: 'show-detail', card: AssessCard): void
         (e: 'update-item', card: AssessCard, action: string): void
         (e: 'delete-item', card: AssessCard): void
-        (e: 'show-reports-for-item', card: AssessCard): void
+        (e: 'show-reports-for-item', card: AssessCard, mode: 'all' | 'completed' | 'in_progress'): void
     }>()
 
     const { t } = useI18n()
@@ -233,6 +249,8 @@
     const firstNewsItem = computed(() => props.card.news_items?.[0])
     const newsItemsCount = computed(() => props.card.news_items?.length ?? 0)
     const inReportsCount = computed(() => props.card.in_reports_count ?? 0)
+    const completedReportsCount = computed(() => props.card.completed_reports_count ?? 0)
+    const inProgressReportsCount = computed(() => Math.max(0, inReportsCount.value - completedReportsCount.value))
     const isAggregate = computed(() => newsItemsCount.value > 1)
     const childNewsItems = computed(() => props.card.news_items ?? [])
 
@@ -264,8 +282,8 @@
         emit('show-detail', item)
     }
 
-    const showInReports = (): void => {
-        emit('show-reports-for-item', props.card)
+    const showInReports = (mode: 'all' | 'completed' | 'in_progress' = 'all'): void => {
+        emit('show-reports-for-item', props.card, mode)
     }
 
     const toggleOpen = (): void => {

--- a/src/gui-v3/src/components/assess/ContentDataAssess.vue
+++ b/src/gui-v3/src/components/assess/ContentDataAssess.vue
@@ -47,7 +47,7 @@
                 </p>
             </div>
             <div
-                v-else
+                v-else-if="news_items_data.length > 0"
                 class="text-caption text-grey"
             >
                 {{ t('common.end_of_list') }}
@@ -312,9 +312,9 @@
         return null
     }
 
-    const showReportsForItem = (card: NewsItem): void => {
+    const showReportsForItem = (card: NewsItem, mode: 'all' | 'completed' | 'in_progress'): void => {
         if (reportsListDialogRef.value) {
-            reportsListDialogRef.value.open(card)
+            reportsListDialogRef.value.open(card, mode)
         }
     }
 

--- a/src/gui-v3/src/components/assess/ReportsListDialog.vue
+++ b/src/gui-v3/src/components/assess/ReportsListDialog.vue
@@ -59,7 +59,7 @@
                         {{ ICONS.INFORMATION_OUTLINE }}
                     </v-icon>
                     <p class="mt-2">
-                        {{ t('assess.reports_dialog.no_reports') }}
+                        {{ emptyMessage }}
                     </p>
                 </div>
 
@@ -89,7 +89,7 @@
 </template>
 
 <script setup lang="ts">
-    import { ref } from 'vue'
+    import { ref, computed } from 'vue'
     import { ICONS } from '@/config/ui-constants'
     import { useI18n } from 'vue-i18n'
     import { getReportItemsByAggregate, updateReportItem } from '@/api/analyze'
@@ -128,6 +128,7 @@
     const error = ref<string | null>(null)
     const reports = ref<ReportItem[]>([])
     const currentCard = ref<AggregateCard | null>(null)
+    const filterMode = ref<'all' | 'completed' | 'in_progress'>('all')
 
     const emit = defineEmits<{
         (e: 'view-report-detail', report: ReportItem): void
@@ -144,36 +145,34 @@
         return []
     }
 
-    const open = async (card: AggregateCard): Promise<void> => {
-        currentCard.value = card
-
-        // If only one report, open it directly without dialog
-        if (card.in_reports_count === 1) {
-            try {
-                const response = (await getReportItemsByAggregate(card.id)) as ReportResponse
-                const reportItems = normalizeReportItems(response)
-
-                if (reportItems && reportItems.length === 1) {
-                    const firstReportItem = reportItems[0]
-                    if (firstReportItem) {
-                        emit('view-report-detail', firstReportItem)
-                    }
-                    return
-                }
-            } catch (err) {
-                console.error('Error fetching report:', err)
-            }
-        }
-
-        // Show dialog for multiple or fallback cases
-        showDialog(card)
+    const isReportCompleted = (report: ReportItem): boolean => {
+        const state = report['state'] as { display_name?: string } | undefined | null
+        return state?.display_name === 'completed'
     }
 
-    const showDialog = async (card: AggregateCard): Promise<void> => {
-        isOpen.value = true
-        loading.value = true
-        error.value = null
-        reports.value = []
+    const applyFilter = (items: ReportItem[]): ReportItem[] => {
+        if (filterMode.value === 'completed') {
+            return items.filter(isReportCompleted)
+        }
+        if (filterMode.value === 'in_progress') {
+            return items.filter((r) => !isReportCompleted(r))
+        }
+        return items
+    }
+
+    const emptyMessage = computed(() => {
+        if (filterMode.value === 'completed') {
+            return t('assess.reports_dialog.no_completed_reports')
+        }
+        if (filterMode.value === 'in_progress') {
+            return t('assess.reports_dialog.no_in_progress_reports')
+        }
+        return t('assess.reports_dialog.no_reports')
+    })
+
+    const open = async (card: AggregateCard, mode: 'all' | 'completed' | 'in_progress' = 'all'): Promise<void> => {
+        currentCard.value = card
+        filterMode.value = mode
 
         try {
             // Report item types are needed to resolve the type name shown on each card
@@ -184,11 +183,28 @@
 
             const response = (await getReportItemsByAggregate(card.id)) as ReportResponse
             const reportItems = normalizeReportItems(response)
-            reports.value = reportItems || []
+            const filtered = applyFilter(reportItems)
+
+            // If exactly one report matches the filter (or all), open it directly without the dialog.
+            // This covers: single total report, single completed report, or single in-progress report
+            // (the latter derived by subtraction: in_reports_count - completed_reports_count === 1).
+            if (filtered.length === 1) {
+                const singleReport = filtered[0]
+                if (singleReport) {
+                    emit('view-report-detail', singleReport)
+                }
+                return
+            }
+
+            // Show dialog for multiple or zero matches
+            reports.value = filtered
+            isOpen.value = true
             loading.value = false
         } catch (err) {
             console.error('Error fetching reports:', err)
             error.value = t('assess.reports_dialog.error_loading')
+            reports.value = []
+            isOpen.value = true
             loading.value = false
         }
     }
@@ -221,6 +237,7 @@
         reports.value = []
         currentCard.value = null
         error.value = null
+        filterMode.value = 'all'
     }
 
     const removeReport = async (report: ReportItem): Promise<void> => {

--- a/src/gui-v3/src/components/common/dialogs/ConfirmationDialog.vue
+++ b/src/gui-v3/src/components/common/dialogs/ConfirmationDialog.vue
@@ -12,7 +12,7 @@
                     color="error"
                     class="mr-2"
                 >
-                    {{ ICONS.ALERT_CIRCLE }}
+                    {{ icon }}
                 </v-icon>
                 {{ t(titleKey) }}
             </v-card-title>
@@ -51,13 +51,15 @@
             titleKey?: string
             confirmLabelKey?: string
             maxWidth?: string
+            icon?: string
         }>(),
         {
             modelValue: false,
             message: '',
             titleKey: 'common.messagebox.delete',
             confirmLabelKey: 'common.delete',
-            maxWidth: '600px'
+            maxWidth: '600px',
+            icon: ICONS.ALERT_CIRCLE
         }
     )
 

--- a/src/gui-v3/src/components/publish/ContentDataPublish.vue
+++ b/src/gui-v3/src/components/publish/ContentDataPublish.vue
@@ -25,7 +25,7 @@
             style="min-height: 100px; display: flex; align-items: center; justify-content: center"
         >
             <div
-                v-if="!dataLoaded"
+                v-if="!dataLoaded && collections.length > 0"
                 class="text-center text-grey"
             >
                 <v-progress-circular
@@ -37,18 +37,42 @@
                 </p>
             </div>
             <div
-                v-else
+                v-else-if="collections.length > 0"
                 class="text-caption text-grey"
             >
                 {{ t('common.end_of_list') }}
             </div>
         </div>
+
+        <!-- Empty State -->
+        <v-row
+            v-if="dataLoaded && collections.length === 0"
+            justify="center"
+            class="my-8"
+        >
+            <v-col
+                cols="12"
+                md="6"
+                class="text-center"
+            >
+                <v-icon
+                    size="64"
+                    color="grey"
+                >
+                    {{ ICONS.SEND_OUTLINE }}
+                </v-icon>
+                <p class="text-h6 text-grey mt-4">
+                    {{ t('publish.no_items') }}
+                </p>
+            </v-col>
+        </v-row>
     </v-container>
 </template>
 
 <script setup lang="ts">
     import { ref, onMounted, onUnmounted, computed } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { ICONS } from '@/config/ui-constants'
     import { usePublishStore } from '@/stores/publish'
     import { getAllProductTypes } from '@/api/config'
     import CardProduct from './CardProduct.vue'
@@ -90,7 +114,7 @@
     const publishStore = usePublishStore()
 
     const collections = ref<ProductItem[]>([])
-    const dataLoaded = ref(false)
+    const dataLoaded = ref(true)
     const filter = ref<FilterState>({
         search: '',
         range: 'ALL',
@@ -115,6 +139,10 @@
                   : entries?.isIntersecting === true
 
         const totalCount = publishStore.getProducts.total_count || 0
+        // Don't attempt to load more when there are no items to load
+        if (totalCount === 0) {
+            return
+        }
 
         if (dataLoaded.value && isIntersecting && collections.value.length < totalCount) {
             updateData(true, false)
@@ -142,14 +170,17 @@
         }
 
         try {
-            await publishStore.loadProducts({
-                filter: filter.value,
-                offset: offset,
-                limit: limit
-            })
+            // Load the list and the product-type catalog in parallel, since the
+            // type enrichment below only needs both results to be available.
+            const [, productTypesResponse] = await Promise.all([
+                publishStore.loadProducts({
+                    filter: filter.value,
+                    offset: offset,
+                    limit: limit
+                }),
+                getAllProductTypes({ search: '' })
+            ])
 
-            // Load product types
-            const productTypesResponse = await getAllProductTypes({ search: '' })
             const productTypes = Array.isArray(productTypesResponse?.data?.items) ? (productTypesResponse.data.items as ProductType[]) : []
 
             const newItems = Array.isArray(publishStore.getProducts.items) ? (publishStore.getProducts.items as ProductItem[]) : []
@@ -177,12 +208,9 @@
             }
 
             emit('update-showing-count', collections.value.length)
-
-            setTimeout(() => {
-                dataLoaded.value = true
-            }, 1000)
         } catch (error) {
             console.error('Error loading products:', error)
+        } finally {
             dataLoaded.value = true
         }
     }

--- a/src/gui-v3/src/components/publish/NewProduct.vue
+++ b/src/gui-v3/src/components/publish/NewProduct.vue
@@ -46,30 +46,36 @@
             </v-card>
         </v-dialog>
 
-        <v-dialog
+        <ConfirmationDialog
             v-model="showPublishConfirmation"
+            title-key="product.publish_confirmation"
+            confirm-label-key="common.yes"
             max-width="500px"
-            persistent
+            @confirm="handlePublish"
         >
-            <v-card>
-                <v-card-title class="text-h5">
-                    {{ $t('product.publish_confirmation') }}
-                </v-card-title>
-                <v-card-text>{{ product.title }}</v-card-text>
-                <v-card-actions>
-                    <v-spacer />
-                    <v-btn @click="showPublishConfirmation = false">
-                        {{ $t('common.cancel') }}
-                    </v-btn>
-                    <v-btn
-                        color="primary"
-                        @click="handlePublish"
-                    >
-                        {{ $t('common.yes') }}
-                    </v-btn>
-                </v-card-actions>
-            </v-card>
-        </v-dialog>
+            <div class="text-body-1 font-weight-bold mb-2">
+                {{ product.title }}
+            </div>
+            <div class="mb-1">
+                <span class="font-weight-medium">{{ $t('product.report_type') }}:</span>
+                {{ selectedType?.title || $t('product.no_type') }}
+            </div>
+            <div class="mb-1">
+                <span class="font-weight-medium">{{ $t('product.publisher_presets') }}:</span>
+                <span v-if="selectedPublisherPresetNames.length > 0">
+                    {{ selectedPublisherPresetNames.join(', ') }}
+                </span>
+                <span
+                    v-else
+                    class="text-grey"
+                >
+                    {{ $t('product.no_publisher_in_dialog') }}
+                </span>
+            </div>
+            <div class="text-body-2 text-grey mt-3">
+                {{ $t('product.publish_confirmation_message') }}
+            </div>
+        </ConfirmationDialog>
 
         <v-dialog
             v-model="showPublishUnsavedConfirmation"
@@ -202,6 +208,7 @@
                                 :values="reportItems"
                                 :modify="canModify"
                                 :edit="isEditMode"
+                                :product-state-is-final="productStateIsFinal"
                                 @items-changed="handleReportItemsChanged"
                             />
                         </v-col>
@@ -291,6 +298,7 @@
     import { getEntityTypeStates } from '@/api/state'
     import { useAuth } from '@/composables/useAuth'
     import StateSelector from '@/components/common/StateSelector.vue'
+    import ConfirmationDialog from '@/components/common/dialogs/ConfirmationDialog.vue'
     import ReportItemSelector from '@/components/publish/ReportItemSelector.vue'
 
     type ProductModel = {
@@ -323,6 +331,7 @@
         id: number | string
         title?: string
         is_default?: boolean
+        state_type?: string
         [key: string]: unknown
     }
 
@@ -390,6 +399,18 @@
         if (!isEditMode.value) return true
         return checkPermission('PUBLISH_PRODUCT') && canAccessFlag.value
     })
+
+    // True when the product's current state is a FINAL state (e.g. published),
+    // so newly-added non-final reports will be auto-completed by the backend cascade.
+    const productStateIsFinal = computed(() => {
+        if (product.value.state_id === undefined || product.value.state_id === null) return false
+        return availableStates.value.some((s) => s.id === product.value.state_id && s.state_type === 'final')
+    })
+
+    // The full names of the selected publisher presets, used in the publish dialog.
+    const selectedPublisherPresetNames = computed<string[]>(() =>
+        publisherPresets.value.filter((preset) => preset.selected).map((preset) => preset.name)
+    )
 
     // Methods
     function resetForm() {

--- a/src/gui-v3/src/components/publish/ReportItemSelector.vue
+++ b/src/gui-v3/src/components/publish/ReportItemSelector.vue
@@ -67,6 +67,59 @@
             :read-only="readOnlySelector"
         />
 
+        <!-- Confirm adding non-final reports to a final/published product -->
+        <v-dialog
+            v-model="showCompletionConfirm"
+            max-width="500px"
+            persistent
+        >
+            <v-card>
+                <v-card-title class="text-h5">
+                    {{ t('product.add_incomplete_reports.title') }}
+                </v-card-title>
+                <v-card-text>
+                    <p class="mb-2">{{ confirmMessage }}</p>
+                    <v-list
+                        v-if="incompleteReportTitles.length > 0"
+                        density="compact"
+                        class="mb-2"
+                        style="max-height: 200px; overflow-y: auto"
+                    >
+                        <v-list-item
+                            v-for="(title, index) in incompleteReportTitles"
+                            :key="index"
+                            class="px-0"
+                        >
+                            <template #prepend>
+                                <v-icon
+                                    color="orange"
+                                    size="small"
+                                >
+                                    {{ ICONS.FILE_DOCUMENT }}
+                                </v-icon>
+                            </template>
+                            <v-list-item-title class="text-body-2">
+                                {{ title }}
+                            </v-list-item-title>
+                        </v-list-item>
+                    </v-list>
+                </v-card-text>
+                <v-card-actions>
+                    <v-spacer />
+                    <v-btn @click="cancelAddReports">
+                        {{ t('common.cancel') }}
+                    </v-btn>
+                    <v-btn
+                        color="primary"
+                        variant="elevated"
+                        @click="confirmAddReports"
+                    >
+                        {{ confirmButton }}
+                    </v-btn>
+                </v-card-actions>
+            </v-card>
+        </v-dialog>
+
         <!-- Selected Items Display -->
         <div
             v-if="!selectorOpen"
@@ -93,28 +146,41 @@
     import CardAnalyze from '@/components/analyze/CardAnalyze.vue'
     import NewReportItem from '@/components/analyze/NewReportItem.vue'
     import { useAnalyzeStore } from '@/stores/analyze'
+    import { useSettingsStore } from '@/stores/settings'
+    import { getEntityTypeStates } from '@/api/state'
 
     type ReportItem = {
         id: number | string
+        title?: string
         tag?: string
         report_item_type_id?: number | string
         report_type_name?: string
+        state?: {
+            name?: string
+            display_name?: string
+            color?: string
+            icon?: string
+            description?: string
+        } | null
         [key: string]: any
     }
 
     const { t } = useI18n()
     const analyzeStore = useAnalyzeStore()
+    const settingsStore = useSettingsStore()
 
     const props = withDefaults(
         defineProps<{
             values?: ReportItem[]
             modify?: boolean
             edit?: boolean
+            productStateIsFinal?: boolean
         }>(),
         {
             values: () => [],
             modify: false,
-            edit: false
+            edit: false,
+            productStateIsFinal: false
         }
     )
 
@@ -128,6 +194,13 @@
     const toolbarFilter = ref<any>(null)
     const contentData = ref<any>(null)
     const reportItemDialog = ref<any>(null)
+    // Display names of report-item states marked as FINAL (state_type === 'final').
+    // Loaded once from /state/entity-types/report_item/states so we can detect
+    // non-final reports when adding them to an already-published product.
+    const finalReportStateNames = ref<Set<string>>(new Set())
+    // Pending selection awaiting confirmation when adding non-final reports to a final product.
+    const pendingSelection = ref<ReportItem[] | null>(null)
+    const showCompletionConfirm = ref<boolean>(false)
 
     watch(
         () => props.values,
@@ -151,9 +224,41 @@
         })
     })
 
+    const isReportFinal = (item: ReportItem): boolean => {
+        const displayName = item.state?.display_name
+        if (!displayName) return false
+        return finalReportStateNames.value.has(displayName)
+    }
+
+    // Whether the backend "Automatic cascade state changes" (CASCADE_STATES_ENABLED)
+    // app setting is on. The completion-confirmation dialog only makes sense when
+    // the backend would actually auto-complete newly-added non-final reports.
+    const cascadeStatesEnabled = computed(() => {
+        const setting = settingsStore.getSetting('CASCADE_STATES_ENABLED')
+        return setting?.value === 'true'
+    })
+
+    const loadReportItemStates = async (): Promise<void> => {
+        try {
+            const response = await getEntityTypeStates('report_item')
+            const states = Array.isArray(response?.data?.states) ? response.data.states : []
+            finalReportStateNames.value = new Set(
+                states
+                    .filter((s: { state_type?: string; display_name?: string }) => s.state_type === 'final')
+                    .map((s: { display_name?: string }) => s.display_name)
+                    .filter((name?: string): name is string => Boolean(name))
+            )
+        } catch (error: unknown) {
+            console.error('Failed to load report item states:', error)
+        }
+    }
+
     onMounted(async () => {
         if (!analyzeStore.getReportItemTypes.items?.length) {
             await analyzeStore.loadReportItemTypes({})
+        }
+        if (finalReportStateNames.value.size === 0) {
+            await loadReportItemStates()
         }
     })
 
@@ -172,7 +277,7 @@
         }
     }
 
-    const handleAdd = (): void => {
+    const collectNewItems = (): ReportItem[] => {
         const rawSelection = analyzeStore.getSelectionReport
         const selection: Array<{ item: ReportItem }> = Array.isArray(rawSelection)
             ? rawSelection
@@ -186,16 +291,71 @@
                   })
                   .filter((entry): entry is { item: ReportItem } => entry !== null)
             : []
+        const newItems: ReportItem[] = []
         selection.forEach((selectedItem: { item: ReportItem }) => {
             const found = value.value.some((item) => item.id === selectedItem.item.id)
             if (!found) {
                 selectedItem.item.tag = ICONS.FILE_TABLE_OUTLINE
-                value.value.push(selectedItem.item)
+                newItems.push(selectedItem.item)
             }
         })
+        return newItems
+    }
 
+    const handleAdd = (): void => {
+        const newItems = collectNewItems()
+
+        // Confirm whenever any non-completed report is being added, but only when
+        // the backend "Automatic cascade state changes" setting is enabled —
+        // otherwise adding incomplete reports has no cascade side effect.
+        if (cascadeStatesEnabled.value && newItems.some((item) => !isReportFinal(item))) {
+            pendingSelection.value = newItems
+            showCompletionConfirm.value = true
+            return
+        }
+
+        applySelection(newItems)
+    }
+
+    const confirmMessage = computed(() => {
+        if (props.productStateIsFinal) {
+            return t('product.add_incomplete_reports.message_published')
+        }
+        return t('product.add_incomplete_reports.message')
+    })
+
+    // Display titles of the non-final reports pending confirmation.
+    const incompleteReportTitles = computed<string[]>(() => {
+        if (!pendingSelection.value) return []
+        return pendingSelection.value
+            .filter((item) => !isReportFinal(item))
+            .map((item) => item.title || item.report_type_name || t('product.add_incomplete_reports.untitled'))
+    })
+
+    const confirmButton = computed(() => {
+        if (props.productStateIsFinal) {
+            return t('product.add_incomplete_reports.confirm_published')
+        }
+        return t('product.add_incomplete_reports.confirm')
+    })
+
+    const applySelection = (newItems: ReportItem[]): void => {
+        value.value.push(...newItems)
         handleClose()
         emit('items-changed', value.value)
+    }
+
+    const confirmAddReports = (): void => {
+        showCompletionConfirm.value = false
+        if (pendingSelection.value) {
+            applySelection(pendingSelection.value)
+            pendingSelection.value = null
+        }
+    }
+
+    const cancelAddReports = (): void => {
+        showCompletionConfirm.value = false
+        pendingSelection.value = null
     }
 
     const handleClose = (): void => {

--- a/src/gui-v3/src/i18n/cs.json
+++ b/src/gui-v3/src/i18n/cs.json
@@ -225,6 +225,7 @@
         "node": "Instance",
         "description": "Popis",
         "in_analyze": "Probíhá analýza",
+        "analyzed": "Analyzováno",
         "url": "URL",
         "name": "Jméno",
         "username": "Uživatelské jméno",
@@ -497,6 +498,9 @@
         "preview": "Zobrazit náhled publikace",
         "publish": "Zveřejnit publikaci",
         "publish_confirmation": "Opravdu chcete zveřejnit tuto publikaci?",
+        "publish_confirmation_message": "Opravdu chcete tuto publikaci zveřejnit?",
+        "no_type": "Není vybrán typ",
+        "no_publisher_in_dialog": "Žádné",
         "publish_successful": "Publikace byla úspěšně zveřejněna",
         "publish_failed": "Nepodařilo se zveřejnit publikaci",
         "publish_error": "Při zveřejňování publikace došlo k chybě",
@@ -511,6 +515,14 @@
             "close": "Zavřít",
             "save_and_publish": "Uložit a zveřejnit",
             "publish_only": "Zveřejnit bez uložení"
+        },
+        "add_incomplete_reports": {
+            "title": "Přidat nedokončené reporty",
+            "message": "Přidáváte reporty, které ještě nejsou dokončené. Dokončení publikace později tyto reporty automaticky označí jako dokončené. Chcete pokračovat?",
+            "message_published": "Tato publikace je již zveřejněna. Přidání nedokončených reportů je automaticky označí jako dokončené. Chcete pokračovat?",
+            "confirm": "Přidat reporty",
+            "confirm_published": "Přidat a dokončit",
+            "untitled": "Report bez názvu"
         }
     },
     "analyze": {
@@ -518,6 +530,7 @@
         "from": "Od",
         "to": "Do",
         "total_count": "Počet analýz: ",
+        "no_items": "Nebyly nalezeny žádné analýzy",
         "tooltip": {
             "filter_all": "Aktuálně zobrazeno: vše",
             "filter_completed": "Aktuálně zobrazeno: hotové",
@@ -630,7 +643,10 @@
         "reports_dialog": {
             "title": "Reporty obsahující tuto položku",
             "no_reports": "Tato položka není v žádných reportech",
-            "error_loading": "Chyba při načítání reportů"
+            "no_completed_reports": "Tato položka není v žádných dokončených reportech",
+            "no_in_progress_reports": "Tato položka není v žádných rozpracovaných reportech",
+            "error_loading": "Chyba při načítání reportů",
+            "error_removing": "Chyba při odebírání reportu z agregátu"
         },
         "select_all_success": "Vybráno {count} novinek",
         "groups": "SKUPINY"
@@ -659,7 +675,8 @@
             "unselect_all": "Zrušit výběr všeho",
             "delete_item": "Smazat report"
         },
-        "select_all_success": "Vybráno {count} produktů"
+        "select_all_success": "Vybráno {count} produktů",
+        "no_items": "Nebyly nalezeny žádné produkty"
     },
     "toolbar_filter": {
         "search": "Hledání",
@@ -863,6 +880,7 @@
             "delete_confirm_item": "Opravdu chcete smazat tuto položku?",
             "remove": "Jste si jisti, že chcete odstranit tuto položku?"
         },
+        "required": "Toto pole je povinné",
         "coming_soon": "Již brzy..."
     },
     "collectors": {

--- a/src/gui-v3/src/i18n/en.json
+++ b/src/gui-v3/src/i18n/en.json
@@ -225,6 +225,7 @@
         "node": "Node",
         "description": "Description",
         "in_analyze": "Analysis in progress",
+        "analyzed": "Analyzed",
         "url": "URL",
         "name": "Name",
         "username": "Username",
@@ -636,6 +637,9 @@
         "preview": "Show product preview",
         "publish": "Publish product",
         "publish_confirmation": "Are you sure you want to publish following product?",
+        "publish_confirmation_message": "Do you really want to publish this product?",
+        "no_type": "No type selected",
+        "no_publisher_in_dialog": "None",
         "publish_successful": "Product was successfully published",
         "publish_failed": "Failed to publish product",
         "publish_error": "An error occurred while publishing the product",
@@ -650,6 +654,14 @@
             "close": "Close",
             "save_and_publish": "Save and Publish",
             "publish_only": "Publish without Saving"
+        },
+        "add_incomplete_reports": {
+            "title": "Add Incomplete Reports",
+            "message": "You are adding reports that are not yet completed. Completing the product later will automatically mark these reports as completed. Do you want to proceed?",
+            "message_published": "This product is already published. Adding incomplete reports will automatically mark them as completed. Do you want to proceed?",
+            "confirm": "Add Reports",
+            "confirm_published": "Add and Complete",
+            "untitled": "Untitled report"
         }
     },
     "analyze": {
@@ -657,6 +669,7 @@
         "from": "From",
         "to": "To",
         "total_count": "Report item count",
+        "no_items": "No report items found",
         "tooltip": {
             "filter_all": "Currently showing: all",
             "filter_completed": "Currently showing: completed",
@@ -780,7 +793,10 @@
         "reports_dialog": {
             "title": "Reports Containing This Item",
             "no_reports": "This item is not in any reports",
-            "error_loading": "Error loading reports"
+            "no_completed_reports": "This item is not in any completed reports",
+            "no_in_progress_reports": "This item is not in any in-progress reports",
+            "error_loading": "Error loading reports",
+            "error_removing": "Error removing report from aggregate"
         },
         "select_all_success": "Selected {count} news item(s)",
         "groups": "GROUPS"
@@ -811,7 +827,8 @@
             "delete_items": "Delete products",
             "delete_item": "Delete product"
         },
-        "select_all_success": "Selected {count} product(s)"
+        "select_all_success": "Selected {count} product(s)",
+        "no_items": "No products found"
     },
     "toolbar_filter": {
         "search": "Search",
@@ -1027,6 +1044,7 @@
             "delete_confirm_item": "Are you sure you want to delete this item?",
             "remove": "Are you sure you want to remove following item?"
         },
+        "required": "This field is required",
         "coming_soon": "Coming soon..."
     },
     "collectors": {

--- a/src/gui-v3/src/i18n/sk.json
+++ b/src/gui-v3/src/i18n/sk.json
@@ -225,6 +225,7 @@
         "node": "Inštancia",
         "description": "Popis",
         "in_analyze": "Analýza prebieha",
+        "analyzed": "Analyzované",
         "url": "URL",
         "name": "Názov",
         "username": "Meno používateľa",
@@ -636,6 +637,9 @@
         "preview": "Náhľad",
         "publish": "Zverejniť",
         "publish_confirmation": "Ste si istý, že chcete zverejniť túto publikáciu?",
+        "publish_confirmation_message": "Naozaj chcete túto publikáciu zverejniť?",
+        "no_type": "Nie je vybraný typ",
+        "no_publisher_in_dialog": "Žiadne",
         "publish_successful": "Publikácia bola úspešne zverejnená",
         "publish_failed": "Nepodarilo sa zverejniť publikáciu",
         "publish_error": "Pri zverejňovaní nastala chyba",
@@ -650,6 +654,14 @@
             "close": "Zavrieť",
             "save_and_publish": "Uložiť a zverejniť",
             "publish_only": "Zverejniť bez uloženia"
+        },
+        "add_incomplete_reports": {
+            "title": "Pridať nedokončené analýzy",
+            "message": "Pridávate analýzy, ktoré ešte nie sú dokončené. Dokončenie publikácie neskôr tieto analýzy automaticky označí ako dokončené. Chcete pokračovať?",
+            "message_published": "Táto publikácia je už zverejnená. Pridanie nedokončených analýz ich automaticky označí ako dokončené. Chcete pokračovať?",
+            "confirm": "Pridať analýzy",
+            "confirm_published": "Pridať a dokončiť",
+            "untitled": "Analýza bez názvu"
         }
     },
     "analyze": {
@@ -657,6 +669,7 @@
         "from": "Od",
         "to": "Do",
         "total_count": "Počet analýz: ",
+        "no_items": "Neboli nájdené žiadne analýzy",
         "tooltip": {
             "filter_all": "Aktuálne zobrazené: všetko",
             "filter_completed": "Aktuálne zobrazené: hotové",
@@ -780,7 +793,10 @@
         "reports_dialog": {
             "title": "Analýzy obsahujúce túto položku",
             "no_reports": "Táto položka nie je v žiadnych analýzach",
-            "error_loading": "Načítavanie analýz zlyhalo"
+            "no_completed_reports": "Táto položka nie je v žiadnych dokončených analýzach",
+            "no_in_progress_reports": "Táto položka nie je v žiadnych rozpracovaných analýzach",
+            "error_loading": "Načítavanie analýz zlyhalo",
+            "error_removing": "Chyba pri odoberaní analýzy z agregátu"
         },
         "select_all_success": "{count} položiek vybraných",
         "groups": "SKUPINY"
@@ -811,7 +827,8 @@
             "delete_items": "Odstrániť publikácie",
             "delete_item": "Odstrániť publikáciu"
         },
-        "select_all_success": "Označených {count} publikácií"
+        "select_all_success": "Označených {count} publikácií",
+        "no_items": "Neboli nájdené žiadne publikácie"
     },
     "toolbar_filter": {
         "search": "Hľadanie",
@@ -1027,6 +1044,7 @@
             "delete_confirm_item": "Naozaj chcete zmazať túto položku?",
             "remove": "Ste si istý, že chcete odstrániť túto položku?"
         },
+        "required": "Toto pole je povinné",
         "coming_soon": "Už čoskoro..."
     },
     "collectors": {

--- a/src/gui-v3/tests/e2e/00-config-seed.spec.js
+++ b/src/gui-v3/tests/e2e/00-config-seed.spec.js
@@ -1,0 +1,212 @@
+import { test, expect } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { login, generateTestName } from '../helpers/test-helpers'
+import { createApiContext } from '../helpers/api-seed'
+
+/**
+ * E2E Environment Setup: Presenters/Publishers Nodes + Product Type + Publisher Preset
+ *
+ * This spec exercises the GUI to add a presenters node and a publishers node,
+ * then creates a product type and publisher preset via the GUI. This both
+ * tests the configuration UI and seeds data for the publish-confirm spec.
+ *
+ * Prerequisites: the presenters and publishers Docker services must be running
+ * (started by test-setup.sh). The presenters service is reachable at
+ * http://presenters:80 (Docker DNS) from the core container, and at
+ * http://127.0.0.1:5002 from the host.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const PRESENTERS_URL = 'http://presenters'
+const PUBLISHERS_URL = 'http://publishers'
+const COLLECTORS_URL = 'http://collectors'
+const API_KEY = readFileSync(resolve(__dirname, '../../../../docker/secrets/api_key.txt'), 'utf-8').trim()
+
+test.describe('Configure environment: nodes + product type + publisher preset', () => {
+    // Nodes, product types, and publisher presets are created via the GUI and
+    // intentionally left in the E2E environment for downstream specs. They are
+    // not cleaned up per-run — the environment is ephemeral (rebuilt by test-setup.sh).
+
+    test('should add a presenters node via the GUI', async ({ page }) => {
+        await login(page)
+        await page.goto('/v2/config/presenters?tab=nodes')
+        await page.getByRole('tab', { name: 'Presenters Nodes' }).waitFor({ state: 'visible', timeout: 10000 })
+
+        // Click the "Add New" button inside the Presenters Nodes tab.
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible({ timeout: 5000 })
+
+        // Fill in the node form.
+        await dialog.locator('input').nth(0).fill('E2E Presenters Node')
+        await dialog.locator('input').nth(1).fill(PRESENTERS_URL)
+        await dialog.locator('input').nth(2).fill(API_KEY)
+
+        // Save — the core will contact the presenters service to fetch available presenters.
+        await dialog.getByRole('button', { name: 'Save' }).click()
+
+        // The dialog should close on success.
+        await expect(dialog).toHaveCount(0, { timeout: 10000 })
+
+        // The new node should appear in the list.
+        await expect(page.getByText('E2E Presenters Node')).toBeVisible({ timeout: 5000 })
+    })
+
+    test('should add a publishers node via the GUI', async ({ page }) => {
+        await login(page)
+        await page.goto('/v2/config/publishers?tab=nodes')
+        await page.getByRole('tab', { name: 'Publishers Nodes' }).waitFor({ state: 'visible', timeout: 10000 })
+
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible({ timeout: 5000 })
+
+        await dialog.locator('input').nth(0).fill('E2E Publishers Node')
+        await dialog.locator('input').nth(1).fill(PUBLISHERS_URL)
+        await dialog.locator('input').nth(2).fill(API_KEY)
+
+        await dialog.getByRole('button', { name: 'Save' }).click()
+
+        await expect(dialog).toHaveCount(0, { timeout: 10000 })
+        await expect(page.getByText('E2E Publishers Node')).toBeVisible({ timeout: 5000 })
+    })
+
+    test('should add a collectors node via the GUI', async ({ page }) => {
+        await login(page)
+        await page.goto('/v2/config/collectors?tab=nodes')
+        await page.getByRole('tab', { name: 'Collectors Nodes' }).waitFor({ state: 'visible', timeout: 10000 })
+
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible({ timeout: 5000 })
+
+        await dialog.locator('input').nth(0).fill('E2E Collectors Node')
+        await dialog.locator('input').nth(1).fill(COLLECTORS_URL)
+        await dialog.locator('input').nth(2).fill(API_KEY)
+
+        await dialog.getByRole('button', { name: 'Save' }).click()
+
+        await expect(dialog).toHaveCount(0, { timeout: 10000 })
+        await expect(page.getByText('E2E Collectors Node')).toBeVisible({ timeout: 5000 })
+    })
+
+    test('should add a manual OSINT source via the GUI', async ({ page }) => {
+        await login(page)
+        await page.goto('/v2/config/collectors?tab=sources')
+        await page.getByRole('tab', { name: 'OSINT Sources' }).waitFor({ state: 'visible', timeout: 10000 })
+
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible({ timeout: 5000 })
+
+        const sourceName = generateTestName('E2E Manual Source')
+
+        // Select the first collectors node from the dropdown.
+        const nodeSelect = dialog.locator('.v-select').first()
+        await nodeSelect.click()
+        const nodeItems = page.locator('.v-overlay__content:visible .v-list-item')
+        await nodeItems.first().click()
+
+        // Select the MANUAL_COLLECTOR from the second dropdown.
+        const collectorSelect = dialog.locator('.v-select').nth(1)
+        await collectorSelect.click()
+        const collectorItems = page.locator('.v-overlay__content:visible .v-list-item')
+        // Find the "Manual" collector option.
+        const manualItem = collectorItems.filter({ hasText: /manual/i }).first()
+        await manualItem.click()
+
+        // Fill in name and description.
+        await dialog.locator('input').first().fill(sourceName)
+        await dialog.locator('textarea').first().fill('Manual OSINT source for E2E testing')
+
+        // Save.
+        await dialog.getByRole('button', { name: 'Save' }).click()
+        await expect(dialog).toHaveCount(0, { timeout: 10000 })
+
+        // Verify the source appears in the list.
+        await expect(page.getByText(sourceName)).toBeVisible({ timeout: 5000 })
+    })
+
+    test('should add a product type via the GUI', async ({ page }) => {
+        await login(page)
+        await page.goto('/v2/config/presenters?tab=types')
+        await page.getByRole('tab', { name: 'Product Types' }).waitFor({ state: 'visible', timeout: 10000 })
+
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible({ timeout: 5000 })
+
+        const productTypeName = generateTestName('E2E Product Type')
+
+        // Fill title and description.
+        await dialog.locator('input').first().fill(productTypeName)
+        await dialog.locator('textarea').first().fill('Test product type for E2E publish confirmation')
+
+        // Select the first presenters node from the dropdown.
+        const nodeSelect = dialog.locator('.v-select').first()
+        await nodeSelect.click()
+        const nodeItems = page.locator('.v-overlay__content:visible .v-list-item')
+        await nodeItems.first().click()
+
+        // Select the first presenter from the second dropdown (if present).
+        const presenterSelect = dialog.locator('.v-select').nth(1)
+        const presenterVisible = await presenterSelect.count()
+        if (presenterVisible > 0) {
+            await presenterSelect.click()
+            const presenterItems = page.locator('.v-overlay__content:visible .v-list-item')
+            const presenterCount = await presenterItems.count()
+            if (presenterCount > 0) {
+                await presenterItems.first().click()
+            }
+        }
+
+        // Save.
+        await dialog.getByRole('button', { name: 'Save' }).click()
+        await expect(dialog).toHaveCount(0, { timeout: 10000 })
+
+        // Verify the product type appears in the list.
+        await expect(page.getByText(productTypeName)).toBeVisible({ timeout: 5000 })
+    })
+
+    test('should add a publisher preset via the GUI', async ({ page }) => {
+        await login(page)
+        await page.goto('/v2/config/publishers?tab=presets')
+        await page.getByRole('tab', { name: 'Publisher Presets' }).waitFor({ state: 'visible', timeout: 10000 })
+
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible({ timeout: 5000 })
+
+        const presetName = generateTestName('E2E Publisher Preset')
+
+        // Fill name.
+        await dialog.locator('input').first().fill(presetName)
+
+        // Select the first publishers node from the dropdown.
+        const nodeSelect = dialog.locator('.v-select').first()
+        await nodeSelect.click()
+        const nodeItems = page.locator('.v-overlay__content:visible .v-list-item')
+        await nodeItems.first().click()
+
+        // Select the first publisher from the second dropdown (if present).
+        const publisherSelect = dialog.locator('.v-select').nth(1)
+        const publisherVisible = await publisherSelect.count()
+        if (publisherVisible > 0) {
+            await publisherSelect.click()
+            const publisherItems = page.locator('.v-overlay__content:visible .v-list-item')
+            const publisherCount = await publisherItems.count()
+            if (publisherCount > 0) {
+                await publisherItems.first().click()
+            }
+        }
+
+        // Save.
+        await dialog.getByRole('button', { name: 'Save' }).click()
+        await expect(dialog).toHaveCount(0, { timeout: 10000 })
+
+        // Verify the preset appears in the list.
+        await expect(page.getByText(presetName)).toBeVisible({ timeout: 5000 })
+    })
+})

--- a/src/gui-v3/tests/e2e/assess-badges.spec.js
+++ b/src/gui-v3/tests/e2e/assess-badges.spec.js
@@ -1,0 +1,173 @@
+import { test, expect } from '@playwright/test'
+import { login } from '../helpers/test-helpers'
+import {
+    createApiContext,
+    getFirstReportItemTypeId,
+    getCompletedStateId,
+    getInitialStateId,
+    createReportItem,
+    updateReportItemState,
+    cleanupSeedData,
+    findAggregateIdByTitle
+} from '../helpers/api-seed'
+
+/**
+ * Assess dual-badge E2E Tests
+ *
+ * Verifies that news items linked to report items show two separate chips:
+ *  - orange "Analysis in progress" for non-final reports
+ *  - green "Analyzed" for completed (final) reports
+ *
+ * The news item is created via the GUI "Add News Item" dialog (tests that flow),
+ * then report items are linked via the API. Cleanup is via the API afterward.
+ */
+
+const ASSESS_URL = '/v2/assess'
+const NEWS_ITEM_TITLE = 'E2E Badge Test Item'
+
+test.describe('Assess report badges', () => {
+    let apiCtx
+    let aggregateId
+    let inProgressReportId
+    let completedReportId
+    let reportItemTypeId
+    let completedStateId
+    let initialStateId
+
+    test.beforeAll(async ({ playwright }) => {
+        apiCtx = await createApiContext(playwright)
+        const { request, token } = apiCtx
+
+        reportItemTypeId = await getFirstReportItemTypeId(request, token)
+        completedStateId = await getCompletedStateId(request, token)
+        initialStateId = await getInitialStateId(request, token)
+    })
+
+    test.afterAll(async () => {
+        if (apiCtx) {
+            await cleanupSeedData(apiCtx.request, apiCtx.token, {
+                reportItemIds: [inProgressReportId, completedReportId].filter(Boolean),
+                aggregateIds: [aggregateId].filter(Boolean)
+            })
+            await apiCtx.request.dispose()
+        }
+    })
+
+    test('create a news item via the GUI Add News Item dialog', async ({ page }) => {
+        await login(page)
+        await page.goto(ASSESS_URL)
+
+        // Wait for the toolbar to render. Use exact match to avoid matching
+        // the empty-state "No news items found" paragraph.
+        await expect(page.getByText('News Items', { exact: true })).toBeVisible({ timeout: 10000 })
+
+        // The "Add New" button only appears when manual OSINT sources are configured.
+        const addBtn = page.getByRole('button', { name: 'Add New' })
+        await expect(addBtn).toBeVisible({ timeout: 5000 })
+
+        // Open the Add News Item dialog.
+        await addBtn.click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible({ timeout: 5000 })
+
+        // Fill in the form. The title field is the first text input in the form.
+        await dialog.locator('input[type="text"]').first().fill(NEWS_ITEM_TITLE)
+        await dialog.locator('textarea').first().fill('News item for dual-badge testing')
+        await dialog.locator('input[type="text"]').nth(1).fill('E2E')
+
+        // Save — the dialog closes after a short success delay.
+        await dialog.getByRole('button', { name: 'Save' }).click()
+        await expect(dialog).toHaveCount(0, { timeout: 10000 })
+
+        // The news item should appear in the Assess list.
+        await expect(page.getByText(NEWS_ITEM_TITLE)).toBeVisible({ timeout: 10000 })
+
+        // Look up the aggregate ID via the API so we can attach report items.
+        const { request, token } = apiCtx
+        aggregateId = await findAggregateIdByTitle(request, token, NEWS_ITEM_TITLE)
+
+        // Create an in-progress report item linked to the aggregate.
+        inProgressReportId = await createReportItem(request, token, {
+            aggregateId,
+            title: 'E2E Badge In-Progress Report',
+            reportItemTypeId,
+            stateId: initialStateId
+        })
+
+        // Create a completed report item linked to the aggregate.
+        completedReportId = await createReportItem(request, token, {
+            aggregateId,
+            title: 'E2E Badge Completed Report',
+            reportItemTypeId,
+            stateId: completedStateId
+        })
+        // If the report was created in a non-final state, force it to completed.
+        if (completedReportId && initialStateId === completedStateId) {
+            await updateReportItemState(request, token, completedReportId, completedStateId)
+        }
+    })
+
+    test('should show orange "Analysis in progress" badge for in-progress reports', async ({ page }) => {
+        await login(page)
+        await page.goto(ASSESS_URL)
+
+        // Find the card containing the seeded news-item title.
+        const card = page.locator('.aggregate-card-wrapper').filter({ hasText: NEWS_ITEM_TITLE })
+        await expect(card).toBeVisible({ timeout: 10000 })
+
+        // The orange in-progress chip should be present.
+        const inProgressChip = card.locator('.v-chip').filter({ hasText: /Analysis in progress/i })
+        await expect(inProgressChip.first()).toBeVisible()
+    })
+
+    test('should show green "Analyzed" badge for completed reports', async ({ page }) => {
+        await login(page)
+        await page.goto(ASSESS_URL)
+
+        const card = page.locator('.aggregate-card-wrapper').filter({ hasText: NEWS_ITEM_TITLE })
+        await expect(card).toBeVisible({ timeout: 10000 })
+
+        // The green analyzed chip should be present.
+        const analyzedChip = card.locator('.v-chip').filter({ hasText: /Analyzed/i })
+        await expect(analyzedChip.first()).toBeVisible()
+    })
+
+    test('clicking the in-progress badge opens the reports dialog with the in-progress report', async ({ page }) => {
+        await login(page)
+        await page.goto(ASSESS_URL)
+
+        const card = page.locator('.aggregate-card-wrapper').filter({ hasText: NEWS_ITEM_TITLE })
+        await expect(card).toBeVisible({ timeout: 10000 })
+
+        const inProgressChip = card
+            .locator('.v-chip')
+            .filter({ hasText: /Analysis in progress/i })
+            .first()
+        await expect(inProgressChip).toBeVisible()
+        await inProgressChip.click()
+
+        // Two reports exist total; clicking the in-progress badge filters to 1.
+        // With only one in-progress report, it opens directly — check for the dialog.
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible({ timeout: 5000 })
+    })
+
+    test('clicking the analyzed badge opens the reports dialog with the completed report', async ({ page }) => {
+        await login(page)
+        await page.goto(ASSESS_URL)
+
+        const card = page.locator('.aggregate-card-wrapper').filter({ hasText: NEWS_ITEM_TITLE })
+        await expect(card).toBeVisible({ timeout: 10000 })
+
+        const analyzedChip = card
+            .locator('.v-chip')
+            .filter({ hasText: /Analyzed/i })
+            .first()
+        await expect(analyzedChip).toBeVisible()
+        await analyzedChip.click()
+
+        // With only one completed report, it opens directly.
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible({ timeout: 5000 })
+    })
+})

--- a/src/gui-v3/tests/e2e/publish-confirm.spec.js
+++ b/src/gui-v3/tests/e2e/publish-confirm.spec.js
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test'
+import { login, generateTestName } from '../helpers/test-helpers'
+
+/**
+ * Publish confirmation dialog E2E Tests
+ *
+ * Verifies that the publish confirmation dialog (ConfirmationDialog) shows:
+ *  - the product title
+ *  - the product type name
+ *  - the selected publisher preset names
+ *
+ * These tests open the New Product dialog, fill minimal fields, select a publisher
+ * preset, and click Publish — then assert the confirmation dialog content.
+ * They are skipped when the environment has no product types or publisher presets.
+ */
+
+const PUBLISH_URL = '/v2/publish'
+
+test.describe('Publish confirmation dialog', () => {
+    test.beforeEach(async ({ page }) => {
+        await login(page)
+        await page.goto(PUBLISH_URL)
+        await expect(page).toHaveURL(/\/publish/)
+    })
+
+    test('should show product type and publisher preset in the publish confirmation', async ({ page }) => {
+        // Open the New Product dialog.
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible()
+        const form = dialog.locator('.v-card-text').first()
+
+        // Fill a unique title.
+        const productTitle = generateTestName('E2E Publish Confirm')
+        await form.locator('input').nth(1).fill(productTitle)
+
+        // Select the first product type from the combobox.
+        // Vuetify 3 teleports the dropdown to body; scope to visible list items.
+        const typeCombo = form.locator('.v-combobox').first()
+        await typeCombo.click()
+        const dropdownItems = page.locator('.v-overlay__content:visible .v-list-item')
+        await dropdownItems.first().click()
+
+        // Select the first publisher preset checkbox.
+        const presetCheckbox = form.locator('.v-checkbox').first()
+        await presetCheckbox.locator('input').check()
+
+        // Click Publish — this triggers handlePublishConfirmation → showPublishConfirmation.
+        await dialog.getByRole('button', { name: 'Publish product' }).click()
+
+        // The ConfirmationDialog appears.
+        const confirmDialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(confirmDialog).toBeVisible({ timeout: 5000 })
+
+        // The confirmation should contain the product title.
+        await expect(confirmDialog).toContainText(productTitle)
+
+        // It should contain the "Product Type" label and the "Publisher Presets" label.
+        await expect(confirmDialog).toContainText(/Product Type/i)
+        await expect(confirmDialog).toContainText(/Publisher Presets/i)
+
+        // Cancel — don't actually publish a throwaway product.
+        await confirmDialog.getByRole('button', { name: 'Cancel' }).click()
+        await expect(confirmDialog).toHaveCount(0)
+    })
+
+    test('should not render the Publish button without publisher presets', async ({ page }) => {
+        // When no publisher presets are configured, canPublish is false and the
+        // "Publish product" button is not rendered at all — so there's nothing
+        // to confirm. This test verifies that absence rather than trying to click
+        // a button that doesn't exist.
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible()
+
+        const publishBtn = dialog.getByRole('button', { name: 'Publish product' })
+        const publishVisible = await publishBtn.count()
+
+        if (publishVisible === 0) {
+            // No publisher presets in the environment → Publish button correctly absent.
+            // Close the dialog and pass.
+            await dialog.locator('.v-toolbar .v-btn').first().click()
+            return
+        }
+
+        // If publisher presets DO exist, verify the button doesn't trigger a
+        // confirmation without selecting one (the validation toast blocks it).
+        await publishBtn.click()
+        await page.waitForTimeout(1000)
+
+        // Only the New Product dialog should be visible — no confirmation overlay.
+        const overlays = page.locator('.v-dialog.v-overlay--active')
+        // The confirmation dialog contains "Do you really want" — it should NOT appear.
+        await expect(overlays.filter({ hasText: /Do you really want/i })).toHaveCount(0)
+
+        await dialog.locator('.v-toolbar .v-btn').first().click()
+    })
+})

--- a/src/gui-v3/tests/e2e/publish-incomplete-reports.spec.js
+++ b/src/gui-v3/tests/e2e/publish-incomplete-reports.spec.js
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test'
+import { login, generateTestName } from '../helpers/test-helpers'
+import {
+    createApiContext,
+    createNewsItem,
+    getFirstReportItemTypeId,
+    getInitialStateId,
+    getFirstOSINTSourceId,
+    createReportItem,
+    cleanupSeedData
+} from '../helpers/api-seed'
+
+/**
+ * "Add Incomplete Reports" confirmation dialog E2E Tests
+ *
+ * Verifies that adding an in-progress (non-final) report item to a product
+ * triggers the "Add Incomplete Reports" confirmation dialog listing the report
+ * titles, but only when the CASCADE_STATES_ENABLED app setting is on.
+ *
+ * Seeds one news-item aggregate + one in-progress report item via the API,
+ * then opens the New Product dialog, adds the report via the ReportItemSelector,
+ * and asserts the confirmation dialog content.
+ */
+
+const PUBLISH_URL = '/v2/publish'
+
+test.describe('Add Incomplete Reports confirmation', () => {
+    let apiCtx
+    let aggregateId
+    let inProgressReportId
+    let reportItemTypeId
+    let initialStateId
+    let reportTitle
+
+    test.beforeAll(async ({ playwright }) => {
+        apiCtx = await createApiContext(playwright)
+        const { request, token } = apiCtx
+
+        reportItemTypeId = await getFirstReportItemTypeId(request, token)
+        initialStateId = await getInitialStateId(request, token)
+        const osintSourceId = await getFirstOSINTSourceId(request, token)
+
+        // Create a news-item aggregate.
+        const result = await createNewsItem(request, token, {
+            title: 'E2E Incomplete Reports Item',
+            description: 'News item for incomplete-reports-confirm testing',
+            osintSourceId
+        })
+        aggregateId = result.aggregateId
+
+        // Create an in-progress report item linked to the aggregate.
+        reportTitle = generateTestName('E2E Incomplete Report')
+        inProgressReportId = await createReportItem(request, token, {
+            aggregateId,
+            title: reportTitle,
+            reportItemTypeId,
+            stateId: initialStateId
+        })
+    })
+
+    test.afterAll(async () => {
+        if (apiCtx) {
+            await cleanupSeedData(apiCtx.request, apiCtx.token, {
+                reportItemIds: [inProgressReportId].filter(Boolean),
+                aggregateIds: [aggregateId].filter(Boolean)
+            })
+            await apiCtx.request.dispose()
+        }
+    })
+
+    test('should show the "Add Incomplete Reports" confirmation with report names when cascade is enabled', async ({ page }) => {
+        await login(page)
+        await page.goto(PUBLISH_URL)
+
+        // Open the New Product dialog.
+        await page.getByRole('button', { name: 'Add New' }).click()
+        const dialog = page.locator('.v-dialog.v-overlay--active')
+        await expect(dialog).toBeVisible()
+
+        // Click the "Add report items" button to open the ReportItemSelector.
+        await dialog.getByRole('button', { name: /select/i }).click()
+
+        // Wait for the fullscreen selector to appear.
+        const selector = page.locator('.v-dialog.v-overlay--active')
+        await expect(selector).toBeVisible({ timeout: 5000 })
+
+        // Find and click the seeded in-progress report item card to select it.
+        const reportCard = selector.locator('.card-analyze-stub, [class*="card-analyze"]').filter({ hasText: reportTitle })
+        // If the card is rendered as a stub (unit), or a full card (e2e), try clicking by title text.
+        if ((await reportCard.count()) > 0) {
+            await reportCard.first().click()
+        } else {
+            // Fallback: click anywhere matching the report title in the selector.
+            await selector.getByText(reportTitle).first().click()
+        }
+
+        // Click "Add Items" to confirm the selection.
+        await selector.getByRole('button', { name: /add items/i }).click()
+
+        // The "Add Incomplete Reports" confirmation dialog should appear
+        // (CASCADE_STATES_ENABLED defaults to on in the E2E environment).
+        const confirmDialog = page.locator('.v-dialog.v-overlay--active').filter({ hasText: 'Add Incomplete Reports' })
+        await expect(confirmDialog).toBeVisible({ timeout: 5000 })
+
+        // The confirmation should list the in-progress report's title.
+        await expect(confirmDialog).toContainText(reportTitle)
+
+        // Cancel — don't actually add the report.
+        await confirmDialog.getByRole('button', { name: 'Cancel' }).click()
+    })
+})

--- a/src/gui-v3/tests/helpers/api-seed.js
+++ b/src/gui-v3/tests/helpers/api-seed.js
@@ -1,0 +1,285 @@
+/**
+ * API-based seed helpers for E2E tests.
+ *
+ * Creates throwaway news-items, report-items, and products for the badge/
+ * confirmation-dialog E2E specs. Each creator returns the created entity's
+ * ID so the test can clean it up via the matching deleter. All helpers are
+ * best-effort and must tolerate a missing backend.
+ */
+
+const CORE_API = process.env.E2E_CORE_API || 'http://127.0.0.1:8082/api/v1'
+
+async function getToken(request, username = 'admin', password = 'admin') {
+    // Poll until the backend is reachable — the E2E webServer may have just
+    // rebuilt the Docker core image, and the backend can take a while to warm up.
+    const maxAttempts = 60
+    for (let i = 0; i < maxAttempts; i++) {
+        try {
+            const res = await request.post(`${CORE_API}/auth/login`, { data: { username, password } })
+            if (res.ok()) {
+                const body = await res.json()
+                return body.access_token
+            }
+        } catch {
+            // backend not yet reachable — keep polling
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+    }
+    throw new Error(`E2E seed: backend not reachable at ${CORE_API} after ${maxAttempts} attempts`)
+}
+
+/**
+ * Create a standalone authenticated API request context.
+ * @param {import('@playwright/test').Playwright} playwright
+ * @returns {Promise<{ request: import('@playwright/test').APIRequestContext, token: string }>}
+ */
+export async function createApiContext(playwright) {
+    const request = await playwright.request.newContext()
+    const token = await getToken(request)
+    return { request, token }
+}
+
+function authHeaders(token) {
+    return { Authorization: `Bearer ${token}` }
+}
+
+/**
+ * Fetch the first OSINT source ID that belongs to a group.
+ * Needed because createNewsItem requires a valid osint_source_id for the
+ * aggregate to be assigned to an OSINT source group (otherwise it never
+ * appears in the Assess view).
+ */
+export async function getFirstOSINTSourceId(request, token) {
+    try {
+        const res = await request.get(`${CORE_API}/collectors/osint-source-groups?search=`, { headers: authHeaders(token) })
+        if (!res.ok()) return null
+        const body = await res.json()
+        const groups = body?.items || body?.data?.items || []
+        for (const group of groups) {
+            const sources = group.osint_sources || []
+            if (sources.length > 0) {
+                const first = sources[0]
+                return first.id || first
+            }
+        }
+        return null
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Create a manual news item aggregate via the Assess API.
+ * @returns {Promise<{ aggregateId: number | null }>} the created aggregate ID (or null on failure)
+ */
+export async function createNewsItem(request, token, { title, description = 'E2E test item', osintSourceId }) {
+    try {
+        // The AddNewsItem endpoint expects a NewsItemData-shaped payload.
+        const time = new Date().toISOString()
+        const res = await request.post(`${CORE_API}/assess/news-items`, {
+            headers: authHeaders(token),
+            data: {
+                title,
+                review: description,
+                source: 'E2E',
+                link: '',
+                published: time,
+                author: 'E2E',
+                collected: time,
+                content: description,
+                osint_source_id: osintSourceId || null
+            }
+        })
+        if (!res.ok()) return { aggregateId: null }
+        // The endpoint returns no body; fetch the aggregate by searching.
+        const groupsRes = await request.get(`${CORE_API}/assess/news-item-aggregates-by-group/all`, {
+            headers: authHeaders(token),
+            params: { offset: 0, limit: 50, sort: 'DATE_DESC', search: title }
+        })
+        if (!groupsRes.ok()) return { aggregateId: null }
+        const body = await groupsRes.json()
+        const items = body?.items || body?.data?.items || []
+        const match = items.find((it) => it.title === title)
+        return { aggregateId: match ? match.id : null }
+    } catch {
+        return { aggregateId: null }
+    }
+}
+
+/**
+ * Look up a news-item aggregate ID by its title (after GUI-based creation).
+ * @returns {Promise<number | null>} the aggregate ID, or null if not found
+ */
+export async function findAggregateIdByTitle(request, token, title) {
+    try {
+        const groupsRes = await request.get(`${CORE_API}/assess/news-item-aggregates-by-group/all`, {
+            headers: authHeaders(token),
+            params: { offset: 0, limit: 50, sort: 'DATE_DESC', search: title }
+        })
+        if (!groupsRes.ok()) return null
+        const body = await groupsRes.json()
+        const items = body?.items || body?.data?.items || []
+        const match = items.find((it) => it.title === title)
+        return match ? match.id : null
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Fetch the first report-item-type ID (needed to create report items).
+ */
+export async function getFirstReportItemTypeId(request, token) {
+    try {
+        const res = await request.get(`${CORE_API}/analyze/report-item-types`, { headers: authHeaders(token) })
+        if (!res.ok()) return null
+        const body = await res.json()
+        const item = (body?.items || [])[0]
+        return item ? item.id : null
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Fetch the COMPLETED state definition ID for report_items.
+ */
+export async function getCompletedStateId(request, token) {
+    try {
+        const res = await request.get(`${CORE_API}/state/entity-types/report_item/states`, { headers: authHeaders(token) })
+        if (!res.ok()) return null
+        const body = await res.json()
+        const states = body?.states || []
+        // Prefer a FINAL state; fall back to one named "completed".
+        const final = states.find((s) => s.state_type === 'final')
+        if (final) return final.id
+        const completed = states.find((s) => s.display_name?.toLowerCase() === 'completed')
+        return completed ? completed.id : null
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Fetch the initial/default state definition ID for report_items.
+ */
+export async function getInitialStateId(request, token) {
+    try {
+        const res = await request.get(`${CORE_API}/state/entity-types/report_item/states`, { headers: authHeaders(token) })
+        if (!res.ok()) return null
+        const body = await res.json()
+        const states = body?.states || []
+        const initial = states.find((s) => s.state_type === 'initial')
+        if (initial) return initial.id
+        const wip = states.find((s) => s.display_name?.toLowerCase() === 'work_in_progress')
+        return wip ? wip.id : null
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Create a report item linked to a news-item aggregate.
+ * @param {object} opts
+ * @param {number} opts.aggregateId - news-item aggregate ID to attach
+ * @param {string} opts.title - report item title
+ * @param {number} opts.reportItemTypeId - report-item-type ID
+ * @param {number|null} [opts.stateId] - state ID (null = default/initial)
+ * @returns {Promise<number|null>} the created report-item ID
+ */
+export async function createReportItem(request, token, { aggregateId, title, reportItemTypeId, stateId = null }) {
+    try {
+        const payload = {
+            title,
+            title_prefix: '',
+            report_item_type_id: reportItemTypeId,
+            news_item_aggregates: aggregateId ? [aggregateId] : [],
+            attributes: []
+        }
+        if (stateId !== null) {
+            payload.state_id = stateId
+        }
+        const res = await request.post(`${CORE_API}/analyze/report-items`, {
+            headers: authHeaders(token),
+            data: payload
+        })
+        if (!res.ok()) return null
+        const id = await res.json()
+        return typeof id === 'number' ? id : null
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Update a report item's state.
+ */
+export async function updateReportItemState(request, token, reportItemId, stateId) {
+    try {
+        await request.put(`${CORE_API}/analyze/report-items/${reportItemId}`, {
+            headers: authHeaders(token),
+            data: { update: true, state_id: stateId }
+        })
+    } catch {
+        // best-effort
+    }
+}
+
+/**
+ * Delete a report item.
+ */
+export async function deleteReportItem(request, token, reportItemId) {
+    try {
+        await request.delete(`${CORE_API}/analyze/report-items/${reportItemId}`, { headers: authHeaders(token) })
+    } catch {
+        // best-effort
+    }
+}
+
+/**
+ * Delete a news-item aggregate.
+ */
+export async function deleteNewsItemAggregate(request, token, aggregateId) {
+    try {
+        await request.delete(`${CORE_API}/assess/news-item-aggregates/${aggregateId}`, { headers: authHeaders(token) })
+    } catch {
+        // best-effort
+    }
+}
+
+/**
+ * Delete a product type.
+ */
+export async function deleteProductType(request, token, productTypeId) {
+    try {
+        await request.delete(`${CORE_API}/config/product-types/${productTypeId}`, { headers: authHeaders(token) })
+    } catch {
+        // best-effort
+    }
+}
+
+/**
+ * Delete a publisher preset.
+ */
+export async function deletePublisherPreset(request, token, presetId) {
+    try {
+        await request.delete(`${CORE_API}/config/publishers-presets/${presetId}`, { headers: authHeaders(token) })
+    } catch {
+        // best-effort
+    }
+}
+
+/**
+ * Best-effort cleanup: deletes the given report-item IDs then news-item-aggregate IDs.
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {string} token
+ * @param {{ reportItemIds: number[], aggregateIds: number[] }} ids
+ */
+export async function cleanupSeedData(request, token, { reportItemIds = [], aggregateIds = [] }) {
+    for (const id of reportItemIds) {
+        await deleteReportItem(request, token, id)
+    }
+    for (const id of aggregateIds) {
+        await deleteNewsItemAggregate(request, token, id)
+    }
+}

--- a/src/gui-v3/tests/helpers/test-helpers.js
+++ b/src/gui-v3/tests/helpers/test-helpers.js
@@ -5,19 +5,48 @@
  */
 
 /**
+ * Wait for the backend API to be reachable and responsive.
+ *
+ * The Playwright webServer boots the backend via test-setup.sh, but the dev-server
+ * `url` check only confirms the frontend is up — the backend login endpoint may still
+ * be warming up. This helper polls until the backend responds or times out.
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @param {number} timeoutMs - max time to wait (default 60s)
+ */
+export async function waitForBackendReady(page, timeoutMs = 60000) {
+    const deadline = Date.now() + timeoutMs
+    // Poll the /isalive endpoint via page.request (shares the browser context).
+    while (Date.now() < deadline) {
+        try {
+            const res = await page.request.get('/api/v1/isalive')
+            if (res.ok()) return
+        } catch {
+            // backend not yet reachable — keep polling
+        }
+        await page.waitForTimeout(1000)
+    }
+    throw new Error(`Backend did not become ready within ${timeoutMs}ms`)
+}
+
+/**
  * Login helper - authenticates user and stores credentials
  * @param {import('@playwright/test').Page} page - Playwright page object
  * @param {string} username - Username (default: 'admin')
  * @param {string} password - Password (default: 'admin')
  */
 export async function login(page, username = 'admin', password = 'admin') {
+    // Ensure the backend is ready before attempting login — the first test in a
+    // run can race the just-booted backend (webServer only checks the frontend URL).
+    await waitForBackendReady(page)
+
     await page.goto('/v2/login')
     await page.locator('[data-test="login-username"] input').fill(username)
     await page.locator('[data-test="login-password"] input').fill(password)
     await page.locator('[data-test="login-submit"]').click()
 
-    // Wait for navigation to complete
-    await page.waitForURL(/\/v2\/(dashboard)?$/)
+    // Wait for navigation to complete — allow extra time for the initial login
+    // (first test after webServer boot may be slower due to cold backend caches).
+    await page.waitForURL(/\/v2\/(dashboard)?$/, { timeout: 30000 })
 }
 
 /**

--- a/src/gui-v3/tests/unit/ContentDataSSE.spec.js
+++ b/src/gui-v3/tests/unit/ContentDataSSE.spec.js
@@ -176,7 +176,6 @@ describe('SSE consumer components', () => {
     })
 
     it('ContentDataPublish reloads on product-updated and stops after unmount', async () => {
-        vi.useFakeTimers()
         let wrapper
 
         try {
@@ -188,15 +187,11 @@ describe('SSE consumer components', () => {
             })
 
             await flushPromises()
-            await vi.runAllTimersAsync()
-            await flushPromises()
 
             expect(mockPublishStore.loadProducts).toHaveBeenCalledTimes(1)
             expect(mockGetAllProductTypes).toHaveBeenCalledTimes(1)
 
             window.dispatchEvent(new CustomEvent('product-updated', { detail: {} }))
-            await flushPromises()
-            await vi.runAllTimersAsync()
             await flushPromises()
 
             const productReloadCalls = mockPublishStore.loadProducts.mock.calls.length
@@ -213,7 +208,6 @@ describe('SSE consumer components', () => {
             expect(mockGetAllProductTypes).toHaveBeenCalledTimes(productTypeReloadCalls)
         } finally {
             wrapper?.unmount()
-            vi.useRealTimers()
         }
     })
 })

--- a/src/gui-v3/tests/unit/ContentDataScroll.spec.js
+++ b/src/gui-v3/tests/unit/ContentDataScroll.spec.js
@@ -150,7 +150,6 @@ describe('Content data scroll guards', () => {
     })
 
     it('ContentDataAnalyze stops append loading when all report items are already loaded', async () => {
-        vi.useFakeTimers()
         const wrapper = mountWithPlugins(ContentDataAnalyze, {
             props: { remoteReports: false },
             global: {
@@ -160,8 +159,6 @@ describe('Content data scroll guards', () => {
 
         try {
             await flushPromises()
-            await vi.runAllTimersAsync()
-            await flushPromises()
 
             expect(mockAnalyzeStore.loadReportItems).toHaveBeenCalledTimes(1)
             expect(mockAnalyzeStore.loadReportItemTypes).toHaveBeenCalledTimes(1)
@@ -173,12 +170,10 @@ describe('Content data scroll guards', () => {
             expect(mockAnalyzeStore.loadReportItemTypes).toHaveBeenCalledTimes(1)
         } finally {
             wrapper.unmount()
-            vi.useRealTimers()
         }
     })
 
     it('ContentDataPublish stops append loading when all products are already loaded', async () => {
-        vi.useFakeTimers()
         const wrapper = mountWithPlugins(ContentDataPublish, {
             props: { selection: [] },
             global: {
@@ -188,8 +183,6 @@ describe('Content data scroll guards', () => {
 
         try {
             await flushPromises()
-            await vi.runAllTimersAsync()
-            await flushPromises()
 
             expect(mockPublishStore.loadProducts).toHaveBeenCalledTimes(1)
             expect(mockGetAllProductTypes).toHaveBeenCalledTimes(1)
@@ -201,7 +194,6 @@ describe('Content data scroll guards', () => {
             expect(mockGetAllProductTypes).toHaveBeenCalledTimes(1)
         } finally {
             wrapper.unmount()
-            vi.useRealTimers()
         }
     })
 })

--- a/src/gui-v3/tests/unit/DeleteConfirmationDialog.spec.js
+++ b/src/gui-v3/tests/unit/DeleteConfirmationDialog.spec.js
@@ -80,6 +80,19 @@ describe('DeleteConfirmationDialog', () => {
             const dialog = wrapper.findComponent(VDialogStub)
             expect(dialog.props('maxWidth')).toBe('600px')
         })
+
+        it('should show the default ALERT_CIRCLE icon when no icon prop is passed', async () => {
+            const wrapper = mountDialog()
+
+            expect(wrapper.html()).toContain('mdi-alert-circle')
+        })
+
+        it('should render a custom icon when the icon prop is passed', async () => {
+            const wrapper = mountDialog({ icon: 'mdi-send-outline' })
+
+            expect(wrapper.html()).toContain('mdi-send-outline')
+            expect(wrapper.html()).not.toContain('mdi-alert-circle')
+        })
     })
 
     // ── Slot Content ──────────────────────────────

--- a/src/shared/shared/schema/news_item.py
+++ b/src/shared/shared/schema/news_item.py
@@ -228,6 +228,7 @@ class NewsItemAggregateSchema(Schema):
     me_like = fields.Bool()
     me_dislike = fields.Bool()
     in_reports_count = fields.Int()
+    completed_reports_count = fields.Int()
     news_items = fields.Nested(NewsItemPresentationSchema, many=True)
 
 


### PR DESCRIPTION
## Loading state & empty states

- Removed artificial `setTimeout(1000)` in `ContentDataAnalyze.vue` and `ContentDataPublish.vue`; flip `dataLoaded` to `true` in `finally` (matches Assess's `loading` pattern)
- Initialize `dataLoaded = true` so the "Loading more items..." spinner doesn't flash on mount; only show it when `collections.length > 0`
- Hide "End of list" when the list is empty (now consistent across Assess, Analyze, Publish)
- Add dedicated empty-state rows with icons (`NEWSPAPER_VARIANT_OUTLINE`, `FILE_TABLE_OUTLINE`, `SEND_OUTLINE`) and `no_items` i18n in en/cs/sk
- Parallelize list fetch + type-catalog fetch via `Promise.all` in Analyze/Publish `updateData` (cuts one serial round-trip)
- Guard infinite-scroll handler against `totalCount === 0` so empty pages never try to append

## Assess dual badge (Analysis in progress / Analyzed)

- **Backend:** add `completed_reports_count` to `NewsItemAggregateSchema`; optimize `get_by_group_json` to batch-compute `(total_count, completed_count)` in two grouped queries (replaces N+1 per-aggregate `count()` calls)
- **GUI:** split the orange "Analysis in progress" chip into two chips in `CardAssess.vue` — orange for in-progress reports, green "Analyzed" for completed ones, each showing its count
- `ReportsListDialog`: click-through filters by `completed` / `in_progress` / `all`; single-match still opens directly; fetch-once-then-filter avoids double round-trip
- i18n: add `card_item.analyzed` and per-filter empty-state strings to en/cs/sk
- Vue 2 GUI untouched — new `completed_reports_count` JSON key is simply ignored

## Publish cascade for added reports

- **Backend:** in `Product.update_product`, capture existing report IDs and call new `_auto_complete_added_reports` to auto-complete newly-added non-final reports when the product is already in a FINAL state (closes the gap where adding a WIP report to an already-published product left it WIP)
- **GUI:** in `ReportItemSelector`, show "Add Incomplete Reports" confirmation listing offending report titles — fires only when `CASCADE_STATES_ENABLED` is on (read via `useSettingsStore`)
- Adapt message/button depending on whether the product is already published (auto-complete vs. later cascade)
- i18n: `product.add_incomplete_reports.{title,message,message_published,confirm,confirm_published,untitled}` in en/cs/sk

## Publish confirmation dialog

- Use the shared `ConfirmationDialog` component instead of an inline v-dialog; show product title, Product Type label/value, and selected Publisher Preset names
- Make `ConfirmationDialog` accept an optional `icon` prop (defaults to `ICONS.ALERT_CIRCLE`) so it can be reused for non-destructive actions
- i18n: `product.{no_type,no_publisher_in_dialog,publish_confirmation_message}` in en/cs/sk

## Tests

- **Unit:** drop `vi.useFakeTimers()` / `runAllTimersAsync` from `ContentDataScroll.spec.js` and `ContentDataSSE.spec.js` (no longer needed after `setTimeout` removal); add `ConfirmationDialog` icon-prop tests
- **E2E (new):** `00-config-seed`, `assess-badges`, `publish-confirm`, `publish-incomplete-reports` with API seed/cleanup helpers in `tests/helpers/api-seed.js`
- `test-setup.sh` now starts collectors/presenters/publishers with port mappings in `docker-compose.e2e.yml` and waits for all containers
- `playwright.config.js` gains a `setup` project (runs `00-config-seed.spec.js` once in Chromium) that the browser projects depend on
- `test-helpers.js`: add `waitForBackendReady` + retry-loop login so tests don't race a cold backend

> ⚠️ E2E specs are in place but currently blocked by an upstream bug. Re-run after #1328 fix lands.

## Changed files

| Area | Files |
| --- | --- |
| Backend | `src/core/model/news_item.py`, `src/core/model/product.py`, `src/shared/shared/schema/news_item.py` |
| GUI | `src/gui-v3/src/components/{analyze,assess,publish,common}/**`, `src/gui-v3/src/i18n/{en,cs,sk}.json`, `src/gui-v3/src/config/ui-constants.ts` |
| Tests | `src/gui-v3/tests/{unit,e2e}/**`, `src/gui-v3/tests/helpers/**` |
| Infra | `scripts/test-setup.sh`, `docker/docker-compose.e2e.yml` |