### PR TITLE
fix clicking on "vulnerability fixed" in self service asset management

### DIFF
--- a/src/gui/src/api/assets.js
+++ b/src/gui/src/api/assets.js
@@ -41,7 +41,7 @@ export function createNewAsset(asset) {
 }
 
 export function solveVulnerability(data) {
-    return ApiService.post('/my-assets/asset-groups/' + data.group_id + '/assets/' + data.asset_id + '/vulnerabilities/' + data.report_item_id, data)
+    return ApiService.put('/my-assets/asset-groups/' + data.group_id + '/assets/' + data.asset_id + '/vulnerabilities/' + data.report_item_id, {solved: data.solved})
 }
 
 export function updateAsset(asset) {

--- a/src/gui/src/components/assets/CardVulnerability.vue
+++ b/src/gui/src/components/assets/CardVulnerability.vue
@@ -85,6 +85,7 @@
             },
             solveClicked() {
                 solveVulnerability({
+                    group_id: this.asset.asset_group_id,
                     asset_id: this.asset.id,
                     report_item_id: this.card.report_item.id,
                     solved: !this.card.solved


### PR DESCRIPTION
Self service asset management in the legacy GUI has a button to mark vulnerability as "fixed/seen". The GUI was using POST instead of PUT, reaching unimplemented API call. This PR fixes that.