### PR TITLE
Fix core initial healthcheck grace period

### DIFF
--- a/docker/Dockerfile.core
+++ b/docker/Dockerfile.core
@@ -70,7 +70,7 @@ ENV GUNICORN_CMD_ARGS="--timeout 120"
 
 VOLUME ["/data"]
 
-HEALTHCHECK --interval=5s --timeout=3s --retries=5 CMD curl --fail http://localhost/api/v1/isalive || exit 1
+HEALTHCHECK --interval=5s --timeout=3s --start-period=300s --retries=5 CMD curl --fail http://localhost/api/v1/isalive || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/start.sh"]

--- a/src/gui-v3/src/components/analyze/NewReportItem.vue
+++ b/src/gui-v3/src/components/analyze/NewReportItem.vue
@@ -306,6 +306,23 @@
                                                                 <span class="text-truncate">{{
                                                                     attribute_item.attribute_group_item.title
                                                                 }}</span>
+                                                                <v-tooltip
+                                                                    v-if="attribute_item.attribute_group_item.description"
+                                                                    :text="attribute_item.attribute_group_item.description"
+                                                                    location="top"
+                                                                >
+                                                                    <template #activator="{ props: tooltipProps }">
+                                                                        <v-icon
+                                                                            v-bind="tooltipProps"
+                                                                            class="attribute-description-help ml-1"
+                                                                            color="primary"
+                                                                            size="x-small"
+                                                                            @click.stop
+                                                                        >
+                                                                            {{ ICONS.INFORMATION_OUTLINE }}
+                                                                        </v-icon>
+                                                                    </template>
+                                                                </v-tooltip>
                                                                 <span
                                                                     v-if="getAttributeMeta(attribute_item)"
                                                                     class="attribute-meta text-medium-emphasis text-no-wrap ml-auto mr-2"

--- a/src/gui-v3/tests/unit/NewReportItemAttributes.spec.js
+++ b/src/gui-v3/tests/unit/NewReportItemAttributes.spec.js
@@ -88,6 +88,7 @@ const VOverlayStub = {
 
 const EDITABLE_TITLE = 'Editable attribute'
 const LABEL_ONLY_TITLE = 'Label only attribute'
+const EDITABLE_DESCRIPTION = 'Guidance for the editable attribute.'
 
 // A report type with one ordinary attribute and one label-only attribute (max_occurrence 0).
 function makeReportType() {
@@ -102,6 +103,7 @@ function makeReportType() {
                     {
                         id: 11,
                         title: EDITABLE_TITLE,
+                        description: EDITABLE_DESCRIPTION,
                         min_occurrence: 1,
                         max_occurrence: 1,
                         attribute: { type: 'STRING' }
@@ -109,6 +111,7 @@ function makeReportType() {
                     {
                         id: 12,
                         title: LABEL_ONLY_TITLE,
+                        description: '',
                         min_occurrence: 0,
                         max_occurrence: 0,
                         attribute: { type: 'RADIO' }
@@ -196,5 +199,18 @@ describe('NewReportItem — label-only attributes (max_occurrence 0)', () => {
     it('renders exactly one attribute editor for the two configured attributes', async () => {
         const wrapper = await mountOpenedEditor()
         expect(wrapper.findAll('.attribute-container-stub')).toHaveLength(1)
+    })
+
+    it('shows an information tooltip only for an attribute with a description', async () => {
+        const wrapper = await mountOpenedEditor()
+
+        const describedPanel = panelFor(wrapper, EDITABLE_TITLE)
+        const undescribedPanel = panelFor(wrapper, LABEL_ONLY_TITLE)
+        const tooltip = describedPanel.findComponent({ name: 'VTooltip' })
+
+        expect(tooltip.exists()).toBe(true)
+        expect(tooltip.props('text')).toBe(EDITABLE_DESCRIPTION)
+        expect(describedPanel.find('.attribute-description-help').exists()).toBe(true)
+        expect(undescribedPanel.findComponent({ name: 'VTooltip' }).exists()).toBe(false)
     })
 })

--- a/src/gui/src/components/analyze/NewReportItem.vue
+++ b/src/gui/src/components/analyze/NewReportItem.vue
@@ -139,6 +139,15 @@
                                                                 <span>
                                                                     {{ attribute_item.attribute_group_item.title }}
                                                                 </span>
+                                                                <v-tooltip v-if="attribute_item.attribute_group_item.description" right>
+                                                                    <template v-slot:activator="{ on, attrs }">
+                                                                        <v-icon small color="primary" class="ml-1"
+                                                                                v-bind="attrs" v-on="on" @click.stop>
+                                                                            {{ UI.ICON.HELP }}
+                                                                        </v-icon>
+                                                                    </template>
+                                                                    <span>{{ attribute_item.attribute_group_item.description }}</span>
+                                                                </v-tooltip>
                                                             </v-row>
                                                         </v-expansion-panel-header>
                                                         <v-expansion-panel-content class="pt-0">


### PR DESCRIPTION
Long migrations prevented `core` container from starting, because the health check kicked in immediately and killed the container prematurely. This introduces initial delay of 5 minutes.