### PR TITLE
add grace period of 5 minutes to the core to prevent long migrations from killing core at startup

### DIFF
--- a/docker/Dockerfile.core
+++ b/docker/Dockerfile.core
@@ -70,7 +70,7 @@ ENV GUNICORN_CMD_ARGS="--timeout 120"
 
 VOLUME ["/data"]
 
-HEALTHCHECK --interval=5s --timeout=3s --retries=5 CMD curl --fail http://localhost/api/v1/isalive || exit 1
+HEALTHCHECK --interval=5s --timeout=3s --start-period=300s --retries=5 CMD curl --fail http://localhost/api/v1/isalive || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/start.sh"]


### PR DESCRIPTION
add grace period of 5 minutes to the core to prevent long migrations from killing core at startup