### PR TITLE
reorder the build process for speed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
-# Reduce Docker build context to only what the Dockerfiles COPY.
-# Keeps `docker build` fast and avoids leaking .git/secrets into the daemon.
+# Reduce Docker build context to only what the Dockerfiles consume.
+# `.git/` intentionally remains available as a read-only BuildKit bind mount
+# for GUI metadata generation; it is not copied into any image layer.
 
 # Version control & metadata
 .gitignore

--- a/docker/Dockerfile.gui
+++ b/docker/Dockerfile.gui
@@ -1,21 +1,34 @@
+# syntax=docker/dockerfile:1
+
+# metadata stage
+FROM node:lts-alpine AS metadata-stage
+
+RUN apk add --no-cache git
+
+WORKDIR /app
+COPY ./src/gui/git-info.js ./
+
+# The bind mount keeps .git out of image layers while still allowing the
+# application metadata to be generated from the repository checkout.
+RUN --mount=type=bind,source=.git,target=/app/.git \
+    node git-info.js
+
 # build stage
 FROM node:lts-alpine AS build-stage
 
-RUN npm install -g @vue/cli-service
-
 WORKDIR /app
-COPY ./src/gui/package*.json ./
-COPY ./src/gui/git-info.js ./
-COPY ./.git ./.git
-RUN apk add --no-cache git
+COPY ./src/gui/package.json ./src/gui/package-lock.json ./
+RUN npm ci
 
-RUN npm install
+COPY ./src/gui/babel.config.js ./
 COPY ./src/gui/public /app/public
 COPY ./src/gui/src /app/src
-COPY ./src/gui/babel.config.js .
+COPY --from=metadata-stage /app/git-info.json ./git-info.json
 
 ENV NODE_OPTIONS="--openssl-legacy-provider"
-RUN npm run build
+# git-info.json was generated in metadata-stage, so skip the prebuild hook
+# that would otherwise try to generate it again inside this stage.
+RUN npm --ignore-scripts run build
 
 # production stage
 FROM nginx:stable-alpine AS production-stage

--- a/docker/Dockerfile.gui-v3
+++ b/docker/Dockerfile.gui-v3
@@ -1,20 +1,39 @@
+# syntax=docker/dockerfile:1
+
+# metadata stage
+FROM node:lts-alpine AS metadata-stage
+
+RUN apk add --no-cache git
+
+WORKDIR /app
+COPY ./src/gui-v3/package.json ./package.json
+COPY ./src/gui-v3/scripts/update-version.cjs ./scripts/update-version.cjs
+COPY ./VERSION.md ./VERSION.md
+
+# The bind mount keeps .git out of image layers while still allowing the
+# application metadata to be generated from the repository checkout.
+RUN --mount=type=bind,source=.git,target=/app/.git \
+    node scripts/update-version.cjs
+
 # build stage
 FROM node:lts-alpine AS build-stage
 
 WORKDIR /app
-COPY ./src/gui-v3/package*.json ./
+COPY ./src/gui-v3/package.json ./src/gui-v3/package-lock.json ./
+RUN npm ci
+
 COPY ./src/gui-v3/scripts ./scripts
 COPY ./src/gui-v3/eslint.config.js .
 COPY ./src/gui-v3/vite.config.js .
-COPY ./.git ./.git
 COPY ./VERSION.md .
-RUN apk add --no-cache git
-RUN npm install
 COPY ./src/gui-v3/index.html .
 COPY ./src/gui-v3/public /app/public
 COPY ./src/gui-v3/src /app/src
+COPY --from=metadata-stage /app/git-info.json ./git-info.json
 
-RUN npm run build
+# git-info.json was generated in metadata-stage, so skip the prebuild hook
+# that would otherwise try to generate it again inside this stage.
+RUN npm --ignore-scripts run build
 
 # production stage
 FROM nginx:stable-alpine AS production-stage


### PR DESCRIPTION
reorder the build process so that minor source code changes don't require package reinstallation (before, `.git` got copied in too early.