### PR TITLE
remove traefik dependency on gui and core

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -317,10 +317,6 @@ services:
 #         max-file: "10"
 
   traefik:
-    depends_on:
-      - "gui"
-#      - "gui-v3"
-      - "core"
     restart: unless-stopped
     image: "traefik:3.6.9"
     environment:


### PR DESCRIPTION
traefik should be able to start even if gui/core are down; and NOT be restarted when they are.