### PR TITLE
remove obsolete class from testing

### DIFF
--- a/src/gui-v3/src/components/analyze/NewReportItem.vue
+++ b/src/gui-v3/src/components/analyze/NewReportItem.vue
@@ -314,7 +314,7 @@
                                                                     <template #activator="{ props: tooltipProps }">
                                                                         <v-icon
                                                                             v-bind="tooltipProps"
-                                                                            class="attribute-description-help ml-1"
+                                                                            class="ml-1"
                                                                             color="primary"
                                                                             size="x-small"
                                                                             @click.stop


### PR DESCRIPTION
class `attribute-description-help` was only introduced for the purpose of test. This PR removes it again.