### PR TITLE
restore remaining Vue 3 functional parity

### DIFF
--- a/src/gui-v3/src/api/config.ts
+++ b/src/gui-v3/src/api/config.ts
@@ -291,7 +291,9 @@ export function importOSINTSources(form_data) {
 }
 
 export function exportOSINTSources(data) {
-    return ApiService.download('/config/export-osint-sources', data, 'osint_sources_export.json')
+    // Keep the response observable by the caller so the UI can report failures
+    // instead of treating a failed download as a successful export.
+    return ApiService.post('/config/export-osint-sources', data, { responseType: 'blob' })
 }
 
 export function getAllOSINTSourceGroups(filter) {

--- a/src/gui-v3/src/components/assess/AddNewsItemDialog.vue
+++ b/src/gui-v3/src/components/assess/AddNewsItemDialog.vue
@@ -174,10 +174,12 @@
         defineProps<{
             modelValue?: boolean
             manualSources?: unknown[]
+            initialSourceId?: string | number | null
         }>(),
         {
             modelValue: false,
-            manualSources: () => []
+            manualSources: () => [],
+            initialSourceId: null
         }
     )
 
@@ -237,17 +239,16 @@
 
     // Initialize selected source
     watch(
-        () => props.modelValue,
-        (newVal: boolean) => {
-            if (newVal && props.manualSources.length > 0) {
-                // Set to first source if only one, otherwise let user select
-                if (props.manualSources.length === 1) {
-                    selectedSourceId.value = (props.manualSources[0] as ManualSource).id
-                } else if (!selectedSourceId.value) {
-                    selectedSourceId.value = (props.manualSources[0] as ManualSource).id
-                }
+        [() => props.modelValue, () => props.manualSources, () => props.initialSourceId],
+        ([isDialogOpen]) => {
+            if (isDialogOpen && props.manualSources.length > 0) {
+                const requestedSource = (props.manualSources as ManualSource[]).find(
+                    (source) => props.initialSourceId !== null && String(source.id) === String(props.initialSourceId)
+                )
+                selectedSourceId.value = requestedSource?.id ?? (props.manualSources[0] as ManualSource).id
             }
-        }
+        },
+        { immediate: true }
     )
 
     const appendLeadingZeroes = (n: number): string | number => {

--- a/src/gui-v3/src/components/common/nodes/NodeDialog.vue
+++ b/src/gui-v3/src/components/common/nodes/NodeDialog.vue
@@ -194,6 +194,7 @@
             emit('saved')
             return true
         } catch (error) {
+            console.error(`Error saving ${props.type} node:`, error)
             window.dispatchEvent(
                 new CustomEvent('notification', {
                     detail: { type: 'error', loc: 'common.error_saving' }

--- a/src/gui-v3/src/components/common/nodes/NodesManager.vue
+++ b/src/gui-v3/src/components/common/nodes/NodesManager.vue
@@ -66,12 +66,17 @@
 
     const list = computed<NodeListState>(() => storeAny[config.value.listKey] as NodeListState)
 
+    const notify = (type: 'success' | 'error', loc: string): void => {
+        window.dispatchEvent(new CustomEvent('notification', { detail: { type, loc } }))
+    }
+
     const loadData = async (): Promise<void> => {
         loading.value = true
         try {
             await storeAny[config.value.loadAction](filter.value)
         } catch (error) {
             console.error(`Error loading ${props.type} nodes:`, error)
+            notify('error', 'common.error')
         } finally {
             loading.value = false
         }
@@ -85,9 +90,11 @@
     const handleDelete = async (node: NodeItem): Promise<void> => {
         try {
             await config.value.deleteFn(node)
+            notify('success', 'common.deleted_successfully')
             await loadData()
         } catch (error) {
             console.error(`Error deleting ${props.type} node:`, error)
+            notify('error', 'common.error_deleting')
         }
     }
 

--- a/src/gui-v3/src/components/config/collectors/OSINTSourceBulkActions.vue
+++ b/src/gui-v3/src/components/config/collectors/OSINTSourceBulkActions.vue
@@ -1,0 +1,238 @@
+<template>
+    <div class="d-flex align-center justify-end ga-2 flex-wrap">
+        <template v-if="canExport && sourceCount > 0">
+            <v-btn
+                v-if="selectedIds.length < sourceCount"
+                variant="text"
+                size="small"
+                @click="emit('select-all')"
+            >
+                {{ t('collectors.sources.tooltip.select_all') }}
+            </v-btn>
+            <v-btn
+                v-if="selectedIds.length > 0"
+                variant="text"
+                size="small"
+                @click="emit('clear-selection')"
+            >
+                {{ t('collectors.sources.tooltip.unselect_all') }}
+            </v-btn>
+            <span class="text-caption text-medium-emphasis">
+                {{ t('collectors.sources.selected_count', { count: selectedIds.length }) }}
+            </span>
+        </template>
+
+        <v-btn
+            v-if="canImport"
+            color="primary"
+            variant="outlined"
+            prepend-icon="mdi-import"
+            :disabled="importing"
+            @click="openImportDialog"
+        >
+            {{ t('collectors.sources.import') }}
+        </v-btn>
+
+        <v-btn
+            v-if="canExport"
+            color="primary"
+            variant="outlined"
+            prepend-icon="mdi-export"
+            :loading="exporting"
+            :disabled="exporting"
+            :title="t(selectedIds.length > 0 ? 'collectors.sources.export_selected_hint' : 'collectors.sources.export_all_hint')"
+            @click="exportSources"
+        >
+            {{ t('collectors.sources.export') }}
+        </v-btn>
+    </div>
+
+    <v-dialog
+        v-model="dialog"
+        max-width="600"
+        persistent
+    >
+        <v-card>
+            <v-card-title>{{ t('collectors.sources.dialog_import') }}</v-card-title>
+            <v-card-text>
+                <v-form
+                    ref="formRef"
+                    @submit.prevent="importSources"
+                >
+                    <v-select
+                        v-model="selectedNodeId"
+                        :items="nodes"
+                        item-title="name"
+                        item-value="id"
+                        :label="t('collectors.sources.node')"
+                        :loading="loadingNodes"
+                        :disabled="importing"
+                        :rules="[(value) => value !== null || t('collectors.sources.node_required')]"
+                        variant="outlined"
+                    />
+                    <v-file-input
+                        v-model="importFile"
+                        accept="application/json,.json"
+                        :label="t('collectors.sources.file')"
+                        :disabled="importing || selectedNodeId === null"
+                        :rules="[(value) => hasFile(value) || t('collectors.sources.file_required')]"
+                        variant="outlined"
+                    />
+                </v-form>
+            </v-card-text>
+            <v-card-actions>
+                <v-spacer />
+                <v-btn
+                    :disabled="importing"
+                    @click="closeImportDialog"
+                >
+                    {{ t('common.cancel') }}
+                </v-btn>
+                <v-btn
+                    color="primary"
+                    :loading="importing"
+                    :disabled="importing"
+                    @click="importSources"
+                >
+                    {{ t('collectors.sources.import') }}
+                </v-btn>
+            </v-card-actions>
+        </v-card>
+    </v-dialog>
+</template>
+
+<script setup lang="ts">
+    import { ref } from 'vue'
+    import { useI18n } from 'vue-i18n'
+    import { exportOSINTSources, importOSINTSources } from '@/api/config'
+
+    type CollectorNode = {
+        id: string | number
+        name?: string
+    }
+
+    type FormValidationResult = {
+        valid: boolean
+    }
+
+    type ExportResponse = {
+        data: Blob
+        headers?: Record<string, string>
+    }
+
+    const props = withDefaults(
+        defineProps<{
+            canImport: boolean
+            canExport: boolean
+            nodes: CollectorNode[]
+            loadingNodes?: boolean
+            selectedIds: Array<string | number>
+            sourceCount: number
+        }>(),
+        { loadingNodes: false }
+    )
+
+    const emit = defineEmits<{
+        (event: 'load-nodes'): void
+        (event: 'import-complete'): void
+        (event: 'select-all'): void
+        (event: 'clear-selection'): void
+    }>()
+
+    const { t } = useI18n()
+    const dialog = ref(false)
+    const importing = ref(false)
+    const exporting = ref(false)
+    const selectedNodeId = ref<string | number | null>(null)
+    const importFile = ref<File | File[] | null>(null)
+    const formRef = ref<{ validate: () => Promise<FormValidationResult>; resetValidation: () => void } | null>(null)
+
+    const notify = (type: 'success' | 'error' | 'info', loc: string, timeout?: number): void => {
+        window.dispatchEvent(
+            new CustomEvent('notification', {
+                detail: { id: 'osint-source-bulk-operation', type, loc, timeout }
+            })
+        )
+    }
+
+    const hasFile = (value: File | File[] | null): boolean => Boolean(Array.isArray(value) ? value[0] : value)
+
+    const selectedFile = (): File | null => {
+        if (Array.isArray(importFile.value)) return importFile.value[0] ?? null
+        return importFile.value
+    }
+
+    const openImportDialog = (): void => {
+        if (!props.canImport) return
+        dialog.value = true
+        emit('load-nodes')
+    }
+
+    const closeImportDialog = (): void => {
+        if (importing.value) return
+        dialog.value = false
+        selectedNodeId.value = null
+        importFile.value = null
+        formRef.value?.resetValidation()
+    }
+
+    const importSources = async (): Promise<void> => {
+        if (!props.canImport || importing.value || !formRef.value) return
+
+        const { valid } = await formRef.value.validate()
+        const file = selectedFile()
+        if (!valid || selectedNodeId.value === null || !file) return
+
+        const formData = new FormData()
+        formData.append('file', file)
+        formData.append('collectors_node_id', String(selectedNodeId.value))
+
+        importing.value = true
+        notify('info', 'collectors.sources.import_progress', 0)
+        try {
+            await importOSINTSources(formData)
+            notify('success', 'collectors.sources.import_success')
+            importing.value = false
+            closeImportDialog()
+            emit('import-complete')
+        } catch {
+            notify('error', 'collectors.sources.import_error')
+        } finally {
+            importing.value = false
+        }
+    }
+
+    const filenameFromResponse = (response: ExportResponse): string => {
+        const disposition = response.headers?.['content-disposition']
+        const match = disposition?.match(/filename\*?=(?:UTF-8'')?["]?([^";\r\n]+)["]?/i)
+        return match?.[1] ? decodeURIComponent(match[1]) : 'osint_sources_export.json'
+    }
+
+    const triggerDownload = (response: ExportResponse): void => {
+        const url = window.URL.createObjectURL(new Blob([response.data], { type: 'application/json' }))
+        const link = document.createElement('a')
+        link.href = url
+        link.download = filenameFromResponse(response)
+        document.body.appendChild(link)
+        link.click()
+        link.remove()
+        window.URL.revokeObjectURL(url)
+    }
+
+    const exportSources = async (): Promise<void> => {
+        if (!props.canExport || exporting.value) return
+
+        exporting.value = true
+        notify('info', 'collectors.sources.export_progress', 0)
+        try {
+            const payload = props.selectedIds.length > 0 ? { selection: props.selectedIds } : {}
+            const response = (await exportOSINTSources(payload)) as ExportResponse
+            triggerDownload(response)
+            notify('success', 'collectors.sources.export_success')
+        } catch {
+            notify('error', 'collectors.sources.export_error')
+        } finally {
+            exporting.value = false
+        }
+    }
+</script>

--- a/src/gui-v3/src/components/config/collectors/OSINTSourceBulkList.vue
+++ b/src/gui-v3/src/components/config/collectors/OSINTSourceBulkList.vue
@@ -1,0 +1,70 @@
+<template>
+    <v-container
+        fluid
+        class="pa-4"
+    >
+        <CardCompact
+            v-for="item in items"
+            :key="item.id"
+            :card="item"
+            delete-permission="CONFIG_OSINT_SOURCE_DELETE"
+            :multi-select-active="selectionEnabled"
+            :preselected="selectedIds.includes(item.id)"
+            @delete="emit('delete', item)"
+            @edit="emit('edit', item)"
+            @selection-change="emit('selection-change', item.id, $event)"
+        />
+
+        <v-row
+            v-if="items.length === 0 && !loading"
+            justify="center"
+            class="mt-8"
+        >
+            <v-col class="text-center">
+                <v-icon
+                    size="64"
+                    color="grey-lighten-1"
+                >
+                    mdi-database-off
+                </v-icon>
+                <p class="text-h6 text-grey-lighten-1 mt-4">{{ t('common.no_data') }}</p>
+            </v-col>
+        </v-row>
+
+        <v-row
+            v-if="loading"
+            justify="center"
+            class="mt-4"
+        >
+            <v-progress-circular
+                indeterminate
+                color="primary"
+            />
+        </v-row>
+    </v-container>
+</template>
+
+<script setup lang="ts">
+    import { useI18n } from 'vue-i18n'
+    import CardCompact from '@/components/common/CardCompact.vue'
+
+    type OSINTSourceItem = {
+        id: string | number
+        [key: string]: unknown
+    }
+
+    defineProps<{
+        items: OSINTSourceItem[]
+        loading: boolean
+        selectionEnabled: boolean
+        selectedIds: Array<string | number>
+    }>()
+
+    const emit = defineEmits<{
+        (event: 'delete', item: OSINTSourceItem): void
+        (event: 'edit', item: OSINTSourceItem): void
+        (event: 'selection-change', id: string | number, selected: boolean): void
+    }>()
+
+    const { t } = useI18n()
+</script>

--- a/src/gui-v3/src/i18n/cs.json
+++ b/src/gui-v3/src/i18n/cs.json
@@ -1132,7 +1132,19 @@
             },
             "dialog_import": "Importovat zdroje OSINT",
             "import": "Importovat",
-            "export": "Exportovat"
+            "export": "Exportovat",
+            "import_progress": "Probíhá import zdrojů OSINT...",
+            "import_success": "Zdroje OSINT byly úspěšně importovány",
+            "import_error": "Zdroje OSINT se nepodařilo importovat",
+            "export_progress": "Probíhá export zdrojů OSINT...",
+            "export_success": "Zdroje OSINT byly úspěšně exportovány",
+            "export_error": "Zdroje OSINT se nepodařilo exportovat",
+            "file": "Soubor pro import",
+            "file_required": "Vyberte soubor k importu",
+            "node_required": "Vyberte uzel kolektoru",
+            "export_all_hint": "Exportovat všechny zdroje",
+            "export_selected_hint": "Exportovat vybrané zdroje",
+            "selected_count": "Vybráno: {count}"
         },
         "nodes": {
             "tab_description": "Zde můžete spravovat uzly sběračů.",

--- a/src/gui-v3/src/i18n/en.json
+++ b/src/gui-v3/src/i18n/en.json
@@ -1132,7 +1132,19 @@
             },
             "dialog_import": "Import OSINT Sources",
             "import": "Import",
-            "export": "Export"
+            "export": "Export",
+            "import_progress": "Importing OSINT sources...",
+            "import_success": "OSINT sources were imported successfully",
+            "import_error": "Could not import OSINT sources",
+            "export_progress": "Exporting OSINT sources...",
+            "export_success": "OSINT sources were exported successfully",
+            "export_error": "Could not export OSINT sources",
+            "file": "Import file",
+            "file_required": "Select an import file",
+            "node_required": "Select a collectors node",
+            "export_all_hint": "Export all sources",
+            "export_selected_hint": "Export selected sources",
+            "selected_count": "{count} selected"
         },
         "nodes": {
             "tab_description": "Here you can manage collector nodes.",

--- a/src/gui-v3/src/i18n/sk.json
+++ b/src/gui-v3/src/i18n/sk.json
@@ -1132,7 +1132,19 @@
             },
             "dialog_import": "Importovať OSINT zdroje",
             "import": "Importovať",
-            "export": "Exportovať"
+            "export": "Exportovať",
+            "import_progress": "Prebieha import OSINT zdrojov...",
+            "import_success": "OSINT zdroje boli úspešne importované",
+            "import_error": "OSINT zdroje sa nepodarilo importovať",
+            "export_progress": "Prebieha export OSINT zdrojov...",
+            "export_success": "OSINT zdroje boli úspešne exportované",
+            "export_error": "OSINT zdroje sa nepodarilo exportovať",
+            "file": "Súbor na import",
+            "file_required": "Vyberte súbor na import",
+            "node_required": "Vyberte uzol kolektora",
+            "export_all_hint": "Exportovať všetky zdroje",
+            "export_selected_hint": "Exportovať vybrané zdroje",
+            "selected_count": "Vybrané: {count}"
         },
         "nodes": {
             "tab_description": "Tu môžete spravovať uzly zberačov.",

--- a/src/gui-v3/src/router.ts
+++ b/src/gui-v3/src/router.ts
@@ -36,6 +36,14 @@ const routes: RouteRecordRaw[] = [
         meta: { requiresAuth: true, requiresPerm: [Permissions.ASSESS_ACCESS] }
     },
     {
+        path: '/enter/source/:sourceId',
+        redirect: (to) => ({
+            name: 'assess',
+            params: { groupId: 'all' },
+            query: { ...to.query, manualSource: String(to.params['sourceId']) }
+        })
+    },
+    {
         path: '/analyze',
         redirect: '/analyze/local'
     },
@@ -246,6 +254,29 @@ const routes: RouteRecordRaw[] = [
             nav: () => import('./views/nav/ConfigNav.vue')
         },
         meta: { requiresAuth: true, requiresPerm: [Permissions.MY_ASSETS_CONFIG] }
+    },
+    { path: '/config/users', redirect: { path: '/config/access-management', query: { tab: 'users' } } },
+    { path: '/config/roles', redirect: { path: '/config/access-management', query: { tab: 'roles' } } },
+    { path: '/config/acls', redirect: { path: '/config/access-management', query: { tab: 'acls' } } },
+    {
+        path: '/config/organizations',
+        redirect: { path: '/config/access-management', query: { tab: 'organizations' } }
+    },
+    { path: '/config/collectors/sources', redirect: { path: '/config/collectors', query: { tab: 'sources' } } },
+    { path: '/config/collectors/groups', redirect: { path: '/config/collectors', query: { tab: 'groups' } } },
+    { path: '/config/collectors/nodes', redirect: { path: '/config/collectors', query: { tab: 'nodes' } } },
+    { path: '/config/presenters/nodes', redirect: { path: '/config/presenters', query: { tab: 'nodes' } } },
+    { path: '/config/product/types', redirect: { path: '/config/presenters', query: { tab: 'types' } } },
+    { path: '/config/publishers/nodes', redirect: { path: '/config/publishers', query: { tab: 'nodes' } } },
+    { path: '/config/publishers/presets', redirect: { path: '/config/publishers', query: { tab: 'presets' } } },
+    { path: '/config/bots/nodes', redirect: { path: '/config/bots', query: { tab: 'nodes' } } },
+    { path: '/config/bots/presets', redirect: { path: '/config/bots', query: { tab: 'presets' } } },
+    { path: '/config/remote/access', redirect: { path: '/config/remote', query: { tab: 'access' } } },
+    { path: '/config/remote/nodes', redirect: { path: '/config/remote', query: { tab: 'nodes' } } },
+    { path: '/config/reportitems/types', redirect: { path: '/config/reports', query: { tab: 'types' } } },
+    {
+        path: '/config/reportitems/attributes',
+        redirect: { path: '/config/reports', query: { tab: 'attributes' } }
     },
     { path: '/config/external/users', redirect: { path: '/config/external', query: { tab: 'users' } } },
     { path: '/config/external/groups', redirect: { path: '/config/external', query: { tab: 'groups' } } },

--- a/src/gui-v3/src/views/admin/OSINTSourcesView.vue
+++ b/src/gui-v3/src/views/admin/OSINTSourcesView.vue
@@ -10,34 +10,50 @@
             @update-filter="handleFilterUpdate"
         >
             <template #addbutton>
-                <NewOSINTSource
-                    :edit-item="editItem"
-                    @saved="handleSaved"
-                />
+                <div class="d-flex align-center justify-end ga-2 flex-wrap">
+                    <OSINTSourceBulkActions
+                        :can-import="canImport"
+                        :can-export="canExport"
+                        :nodes="collectorNodes"
+                        :loading-nodes="loadingNodes"
+                        :selected-ids="selectedIds"
+                        :source-count="sourceItems.length"
+                        @load-nodes="loadCollectorNodes"
+                        @import-complete="handleImportComplete"
+                        @select-all="selectAll"
+                        @clear-selection="clearSelection"
+                    />
+                    <NewOSINTSource
+                        :edit-item="editItem"
+                        @saved="handleSaved"
+                    />
+                </div>
             </template>
         </ToolbarFilter>
 
         <!-- Content -->
-        <ContentData
-            :items="configStore.osintSources.items"
-            card-item="CardCompact"
-            delete-permission="CONFIG_OSINT_SOURCE_DELETE"
+        <OSINTSourceBulkList
+            :items="sourceItems"
             :loading="loading"
+            :selection-enabled="canExport"
+            :selected-ids="selectedIds"
             @delete="handleDelete"
             @edit="handleEdit"
-            @refresh="loadData"
+            @selection-change="handleSelectionChange"
         />
     </v-container>
 </template>
 
 <script setup lang="ts">
-    import { ref, onMounted } from 'vue'
+    import { computed, ref, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useConfigStore } from '@/stores/config'
     import { deleteOSINTSource } from '@/api/config'
+    import { useAuth } from '@/composables/useAuth'
     import ToolbarFilter from '@/components/common/ToolbarFilter.vue'
-    import ContentData from '@/components/common/ContentData.vue'
     import NewOSINTSource from '@/components/config/collectors/NewOSINTSource.vue'
+    import OSINTSourceBulkActions from '@/components/config/collectors/OSINTSourceBulkActions.vue'
+    import OSINTSourceBulkList from '@/components/config/collectors/OSINTSourceBulkList.vue'
 
     const { t } = useI18n()
     const configStore = useConfigStore()
@@ -47,7 +63,7 @@
     }
 
     type OSINTSourceItem = {
-        id?: string | number | null
+        id: string | number
         name?: string
         description?: string
         feed_url?: string
@@ -58,8 +74,16 @@
     }
 
     const loading = ref(false)
+    const loadingNodes = ref(false)
     const filter = ref<FilterState>({ search: '' })
     const editItem = ref<OSINTSourceItem | null>(null)
+    const selectedIds = ref<Array<string | number>>([])
+    const { checkPermission } = useAuth()
+
+    const canImport = computed(() => checkPermission('CONFIG_OSINT_SOURCE_CREATE'))
+    const canExport = computed(() => checkPermission('CONFIG_OSINT_SOURCE_ACCESS'))
+    const sourceItems = computed(() => configStore.osintSources.items as OSINTSourceItem[])
+    const collectorNodes = computed(() => configStore.collectorsNodes.items as Array<{ id: string | number; name?: string }>)
 
     const loadData = async (): Promise<void> => {
         loading.value = true
@@ -94,6 +118,40 @@
     const handleSaved = (): void => {
         editItem.value = null
         loadData()
+    }
+
+    const loadCollectorNodes = async (): Promise<void> => {
+        if (!canImport.value || loadingNodes.value || collectorNodes.value.length > 0) return
+        loadingNodes.value = true
+        try {
+            await configStore.loadCollectorsNodes({ search: '' })
+        } catch {
+            window.dispatchEvent(new CustomEvent('notification', { detail: { type: 'error', loc: 'collectors.sources.import_error' } }))
+        } finally {
+            loadingNodes.value = false
+        }
+    }
+
+    const handleSelectionChange = (id: string | number, selected: boolean): void => {
+        if (!canExport.value) return
+        const selection = new Set(selectedIds.value)
+        if (selected) selection.add(id)
+        else selection.delete(id)
+        selectedIds.value = [...selection]
+    }
+
+    const selectAll = (): void => {
+        if (!canExport.value) return
+        selectedIds.value = sourceItems.value.map((source) => source.id)
+    }
+
+    const clearSelection = (): void => {
+        selectedIds.value = []
+    }
+
+    const handleImportComplete = async (): Promise<void> => {
+        clearSelection()
+        await loadData()
     }
 
     onMounted(() => {

--- a/src/gui-v3/src/views/users/AssessView.vue
+++ b/src/gui-v3/src/views/users/AssessView.vue
@@ -16,6 +16,7 @@
                         v-if="canCreateNewsItem"
                         v-model="showAddNewsItemDialog"
                         :manual-sources="assessStore.getManualOSINTSourcesList"
+                        :initial-source-id="requestedManualSourceId"
                         @news-item-added="handleNewsItemAdded"
                     >
                         <template #activator="{ props: activatorProps }">
@@ -78,6 +79,7 @@
     const toolbarFilter = ref<any>(null)
     const contentData = ref<any>(null)
     const showAddNewsItemDialog = ref(false)
+    const requestedManualSourceId = ref<string | null>(null)
     const newReportItem = ref<any>(null)
     const canCreateNewsItem = computed(() => checkPermission(Permissions.ASSESS_CREATE))
     const hasManualSources = computed(() => assessStore.getManualOSINTSourcesList && assessStore.getManualOSINTSourcesList.length > 0)
@@ -142,12 +144,36 @@
         }
     }
 
-    onMounted(() => {
+    onMounted(async () => {
+        const manualSourceQuery = route.query['manualSource']
+        const sourceId = Array.isArray(manualSourceQuery) ? manualSourceQuery[0] : manualSourceQuery
+        requestedManualSourceId.value = sourceId ?? null
+
+        if (manualSourceQuery !== undefined) {
+            const query = { ...route.query }
+            delete query['manualSource']
+            await router.replace({ name: 'assess', params: { groupId: route.params['groupId'] }, query })
+        }
+
         if (canCreateNewsItem.value) {
             // Load manual OSINT sources to show "Add New" button (non-blocking)
-            assessStore.loadManualOSINTSources().catch((error) => {
+            try {
+                await assessStore.loadManualOSINTSources()
+                if (
+                    requestedManualSourceId.value &&
+                    assessStore.getManualOSINTSourcesList.some(
+                        (source) =>
+                            typeof source === 'object' &&
+                            source !== null &&
+                            'id' in source &&
+                            String(source.id) === requestedManualSourceId.value
+                    )
+                ) {
+                    showAddNewsItemDialog.value = true
+                }
+            } catch (error) {
                 console.error('Error loading manual OSINT sources:', error)
-            })
+            }
         }
 
         if (route.path.includes('/group/')) {

--- a/src/gui-v3/tests/unit/NodesManagerFeedback.spec.js
+++ b/src/gui-v3/tests/unit/NodesManagerFeedback.spec.js
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import NodesManager from '@/components/common/nodes/NodesManager.vue'
+
+const mocks = vi.hoisted(() => ({
+    loadCollectorsNodes: vi.fn(),
+    deleteCollectorsNode: vi.fn()
+}))
+
+vi.mock('@/stores/config', () => ({
+    useConfigStore: () => ({
+        collectorsNodes: { items: [], total_count: 0 },
+        loadCollectorsNodes: mocks.loadCollectorsNodes
+    })
+}))
+
+vi.mock('@/api/config', () => ({
+    createNewCollectorsNode: vi.fn(),
+    updateCollectorsNode: vi.fn(),
+    deleteCollectorsNode: mocks.deleteCollectorsNode,
+    createNewPresentersNode: vi.fn(),
+    updatePresentersNode: vi.fn(),
+    deletePresentersNode: vi.fn(),
+    createNewPublishersNode: vi.fn(),
+    updatePublishersNode: vi.fn(),
+    deletePublishersNode: vi.fn(),
+    createNewBotsNode: vi.fn(),
+    updateBotsNode: vi.fn(),
+    deleteBotsNode: vi.fn()
+}))
+
+const mountedWrappers = []
+
+const mountManager = () => {
+    const wrapper = mount(NodesManager, {
+        props: { type: 'collectors' },
+        global: {
+            stubs: {
+                VContainer: { template: '<div><slot /></div>' },
+                ToolbarFilter: { template: '<div><slot name="addbutton" /></div>' },
+                ContentData: true,
+                NodeDialog: true
+            }
+        }
+    })
+    mountedWrappers.push(wrapper)
+    return wrapper
+}
+
+const notificationDetails = (dispatchEvent) =>
+    dispatchEvent.mock.calls.filter(([event]) => event.type === 'notification').map(([event]) => event.detail)
+
+describe('NodesManager feedback', () => {
+    let dispatchEvent
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mocks.loadCollectorsNodes.mockResolvedValue(undefined)
+        mocks.deleteCollectorsNode.mockResolvedValue(undefined)
+        dispatchEvent = vi.spyOn(window, 'dispatchEvent')
+        vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    })
+
+    afterEach(() => {
+        for (const wrapper of mountedWrappers.splice(0)) wrapper.unmount()
+        vi.restoreAllMocks()
+    })
+
+    it('shows an error notification and preserves diagnostics when loading fails', async () => {
+        const error = new Error('load failed')
+        mocks.loadCollectorsNodes.mockRejectedValue(error)
+
+        mountManager()
+        await flushPromises()
+
+        expect(notificationDetails(dispatchEvent)).toContainEqual({ type: 'error', loc: 'common.error' })
+        expect(console.error).toHaveBeenCalledWith('Error loading collectors nodes:', error)
+    })
+
+    it('shows success feedback after deleting a node', async () => {
+        const wrapper = mountManager()
+        await flushPromises()
+
+        await wrapper.vm.handleDelete({ id: 'node-1' })
+
+        expect(mocks.deleteCollectorsNode).toHaveBeenCalledWith({ id: 'node-1' })
+        expect(notificationDetails(dispatchEvent)).toContainEqual({
+            type: 'success',
+            loc: 'common.deleted_successfully'
+        })
+        expect(mocks.loadCollectorsNodes).toHaveBeenCalledTimes(2)
+    })
+
+    it('shows an error notification and preserves diagnostics when deletion fails', async () => {
+        const error = new Error('delete failed')
+        mocks.deleteCollectorsNode.mockRejectedValue(error)
+        const wrapper = mountManager()
+        await flushPromises()
+
+        await wrapper.vm.handleDelete({ id: 'node-1' })
+
+        expect(notificationDetails(dispatchEvent)).toContainEqual({ type: 'error', loc: 'common.error_deleting' })
+        expect(console.error).toHaveBeenCalledWith('Error deleting collectors node:', error)
+        expect(mocks.loadCollectorsNodes).toHaveBeenCalledOnce()
+    })
+})

--- a/src/gui-v3/tests/unit/OSINTSourceBulkActions.spec.js
+++ b/src/gui-v3/tests/unit/OSINTSourceBulkActions.spec.js
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { mountWithPlugins } from '../helpers/mount-helpers'
+import OSINTSourceBulkActions from '@/components/config/collectors/OSINTSourceBulkActions.vue'
+
+const { importOSINTSources, exportOSINTSources } = vi.hoisted(() => ({
+    importOSINTSources: vi.fn(),
+    exportOSINTSources: vi.fn()
+}))
+
+vi.mock('@/api/config', () => ({
+    importOSINTSources,
+    exportOSINTSources
+}))
+
+const VDialogStub = {
+    name: 'VDialog',
+    props: ['modelValue'],
+    template: '<div v-if="modelValue"><slot /></div>'
+}
+
+const VFormStub = {
+    name: 'VForm',
+    methods: {
+        validate: vi.fn().mockResolvedValue({ valid: true }),
+        resetValidation: vi.fn()
+    },
+    template: '<form><slot /></form>'
+}
+
+const VSelectStub = {
+    name: 'VSelect',
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<button class="choose-node" @click.prevent="$emit(\'update:modelValue\', \'node-7\')">node</button>'
+}
+
+const VFileInputStub = {
+    name: 'VFileInput',
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<button class="choose-file" @click.prevent="$emit(\'update:modelValue\', testFile)">file</button>',
+    data: () => ({ testFile: new File(['{}'], 'sources.json', { type: 'application/json' }) })
+}
+
+const mountActions = (props = {}) =>
+    mountWithPlugins(OSINTSourceBulkActions, {
+        props: {
+            canImport: true,
+            canExport: true,
+            nodes: [{ id: 'node-7', name: 'Node 7' }],
+            selectedIds: [],
+            sourceCount: 3,
+            ...props
+        },
+        global: {
+            stubs: {
+                VDialog: VDialogStub,
+                VForm: VFormStub,
+                VSelect: VSelectStub,
+                VFileInput: VFileInputStub
+            }
+        }
+    })
+
+const buttonWithText = (wrapper, text) => wrapper.findAllComponents({ name: 'VBtn' }).find((button) => button.text() === text)
+const lastButtonWithText = (wrapper, text) =>
+    wrapper
+        .findAllComponents({ name: 'VBtn' })
+        .filter((button) => button.text() === text)
+        .at(-1)
+
+describe('OSINT source bulk actions', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        importOSINTSources.mockResolvedValue({})
+        exportOSINTSources.mockResolvedValue({
+            data: new Blob(['{}'], { type: 'application/json' }),
+            headers: { 'content-disposition': 'attachment; filename="sources.json"' }
+        })
+        vi.spyOn(window.URL, 'createObjectURL').mockReturnValue('blob:test')
+        vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => {})
+        vi.spyOn(window.HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    })
+
+    it('does not render operations without their permissions', () => {
+        const wrapper = mountActions({ canImport: false, canExport: false })
+
+        expect(buttonWithText(wrapper, 'Import')).toBeUndefined()
+        expect(buttonWithText(wrapper, 'Export')).toBeUndefined()
+    })
+
+    it('exports all sources when the selection is empty', async () => {
+        const wrapper = mountActions()
+
+        await buttonWithText(wrapper, 'Export').trigger('click')
+        await flushPromises()
+
+        expect(exportOSINTSources).toHaveBeenCalledWith({})
+        expect(window.HTMLAnchorElement.prototype.click).toHaveBeenCalledOnce()
+    })
+
+    it('exports only the selected source IDs when a selection exists', async () => {
+        const wrapper = mountActions({ selectedIds: ['source-1', 'source-3'] })
+
+        await buttonWithText(wrapper, 'Export').trigger('click')
+        await flushPromises()
+
+        expect(exportOSINTSources).toHaveBeenCalledWith({ selection: ['source-1', 'source-3'] })
+    })
+
+    it('reports a direct export request failure without triggering a download', async () => {
+        exportOSINTSources.mockRejectedValue(new Error('failed'))
+        const notifications = []
+        const handler = (event) => notifications.push(event.detail)
+        window.addEventListener('notification', handler)
+        const wrapper = mountActions()
+
+        await buttonWithText(wrapper, 'Export').trigger('click')
+        await flushPromises()
+        window.removeEventListener('notification', handler)
+
+        expect(window.HTMLAnchorElement.prototype.click).not.toHaveBeenCalled()
+        expect(notifications.at(-1)).toMatchObject({ type: 'error', loc: 'collectors.sources.export_error' })
+    })
+
+    it('imports the JSON file into the selected collector node and requests a refresh', async () => {
+        const wrapper = mountActions()
+
+        await lastButtonWithText(wrapper, 'Import').trigger('click')
+        await wrapper.find('.choose-node').trigger('click')
+        await wrapper.find('.choose-file').trigger('click')
+        await lastButtonWithText(wrapper, 'Import').trigger('click')
+        await flushPromises()
+
+        expect(importOSINTSources).toHaveBeenCalledOnce()
+        const body = importOSINTSources.mock.calls[0][0]
+        expect(body).toBeInstanceOf(FormData)
+        expect(body.get('collectors_node_id')).toBe('node-7')
+        expect(body.get('file')).toBeInstanceOf(File)
+        expect(wrapper.emitted('import-complete')).toHaveLength(1)
+        expect(wrapper.emitted('load-nodes')).toHaveLength(1)
+    })
+
+    it('reports failures and does not emit import completion', async () => {
+        importOSINTSources.mockRejectedValue(new Error('failed'))
+        const notifications = []
+        const handler = (event) => notifications.push(event.detail)
+        window.addEventListener('notification', handler)
+        const wrapper = mountActions()
+
+        await buttonWithText(wrapper, 'Import').trigger('click')
+        await wrapper.find('.choose-node').trigger('click')
+        await wrapper.find('.choose-file').trigger('click')
+        await lastButtonWithText(wrapper, 'Import').trigger('click')
+        await flushPromises()
+        window.removeEventListener('notification', handler)
+
+        expect(wrapper.emitted('import-complete')).toBeUndefined()
+        expect(notifications.at(-1)).toMatchObject({ type: 'error', loc: 'collectors.sources.import_error' })
+    })
+})

--- a/src/gui-v3/tests/unit/OSINTSourceBulkApi.spec.js
+++ b/src/gui-v3/tests/unit/OSINTSourceBulkApi.spec.js
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ApiService from '@/services/api_service'
+import { exportOSINTSources } from '@/api/config'
+
+describe('OSINT source bulk API', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('uses a direct blob POST so callers can handle download success and failure', async () => {
+        const response = { data: new Blob(['{}']), headers: {} }
+        const post = vi.spyOn(ApiService, 'post').mockResolvedValue(response)
+
+        await expect(exportOSINTSources({ selection: ['source-1'] })).resolves.toBe(response)
+        expect(post).toHaveBeenCalledWith('/config/export-osint-sources', { selection: ['source-1'] }, { responseType: 'blob' })
+    })
+
+    it('propagates export request errors to the UI', async () => {
+        const failure = new Error('export failed')
+        vi.spyOn(ApiService, 'post').mockRejectedValue(failure)
+
+        await expect(exportOSINTSources({})).rejects.toBe(failure)
+    })
+})

--- a/src/gui-v3/tests/unit/legacy-route-manual-entry.spec.js
+++ b/src/gui-v3/tests/unit/legacy-route-manual-entry.spec.js
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { mountWithPlugins } from '../helpers/mount-helpers'
+import AssessView from '@/views/users/AssessView.vue'
+
+const authState = vi.hoisted(() => ({
+    allowed: true,
+    checkPermission: vi.fn()
+}))
+
+vi.mock('@/composables/useAuth', () => ({
+    useAuth: () => ({ checkPermission: authState.checkPermission })
+}))
+
+vi.mock('@/composables/useKeyboard', () => ({
+    default: () => ({
+        onInit: vi.fn(),
+        keyAction: vi.fn(),
+        reindexCardItems: vi.fn(),
+        setDetailDialogCloseCallback: vi.fn(),
+        setReloadCallback: vi.fn()
+    })
+}))
+
+vi.mock('@/api/assess', async () => {
+    const actual = await vi.importActual('@/api/assess')
+    return {
+        ...actual,
+        getManualOSINTSources: vi.fn().mockResolvedValue({
+            data: [
+                { id: 'manual-1', name: 'First source' },
+                { id: 'manual-42', name: 'Bookmarked source' }
+            ]
+        })
+    }
+})
+
+const AddNewsItemDialogStub = {
+    name: 'AddNewsItemDialog',
+    props: ['modelValue', 'manualSources', 'initialSourceId'],
+    template: '<div class="add-news-item-dialog" />'
+}
+
+const ContentDataAssessStub = {
+    name: 'ContentDataAssess',
+    methods: { updateData: vi.fn() },
+    template: '<div />'
+}
+
+async function mountLegacyEntry() {
+    const router = createRouter({
+        history: createMemoryHistory(),
+        routes: [{ path: '/assess/group/:groupId', name: 'assess', component: AssessView }]
+    })
+    await router.push('/assess/group/all?manualSource=manual-42')
+    await router.isReady()
+
+    const wrapper = mountWithPlugins(AssessView, {
+        global: {
+            plugins: [router],
+            stubs: {
+                ViewLayout: { template: '<div><slot name="panel" /><slot name="content" /></div>' },
+                ToolbarFilterAssess: { template: '<div><slot name="addbutton" /></div>' },
+                ContentDataAssess: ContentDataAssessStub,
+                AddNewsItemDialog: AddNewsItemDialogStub,
+                AddNewButton: true,
+                NewReportItem: true
+            }
+        }
+    })
+    await flushPromises()
+
+    return { router, wrapper }
+}
+
+describe('legacy manual-entry route', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        authState.allowed = true
+        authState.checkPermission.mockImplementation(() => authState.allowed)
+    })
+
+    it('opens manual entry with the requested source and canonicalizes the URL', async () => {
+        const { router, wrapper } = await mountLegacyEntry()
+        const dialog = wrapper.findComponent({ name: 'AddNewsItemDialog' })
+
+        expect(dialog.props('modelValue')).toBe(true)
+        expect(dialog.props('initialSourceId')).toBe('manual-42')
+        expect(router.currentRoute.value.fullPath).toBe('/assess/group/all')
+    })
+
+    it('does not load sources or open manual entry without ASSESS_CREATE', async () => {
+        authState.allowed = false
+        const assessApi = await import('@/api/assess')
+        const { router, wrapper } = await mountLegacyEntry()
+
+        expect(assessApi.getManualOSINTSources).not.toHaveBeenCalled()
+        expect(wrapper.findComponent({ name: 'AddNewsItemDialog' }).exists()).toBe(false)
+        expect(router.currentRoute.value.fullPath).toBe('/assess/group/all')
+    })
+})

--- a/src/gui-v3/tests/unit/legacy-route-redirects.spec.js
+++ b/src/gui-v3/tests/unit/legacy-route-redirects.spec.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import router from '@/router'
+
+const legacyConfigRoutes = [
+    ['/config/users', '/config/access-management', 'users'],
+    ['/config/roles', '/config/access-management', 'roles'],
+    ['/config/acls', '/config/access-management', 'acls'],
+    ['/config/organizations', '/config/access-management', 'organizations'],
+    ['/config/collectors/sources', '/config/collectors', 'sources'],
+    ['/config/collectors/groups', '/config/collectors', 'groups'],
+    ['/config/collectors/nodes', '/config/collectors', 'nodes'],
+    ['/config/presenters/nodes', '/config/presenters', 'nodes'],
+    ['/config/product/types', '/config/presenters', 'types'],
+    ['/config/publishers/nodes', '/config/publishers', 'nodes'],
+    ['/config/publishers/presets', '/config/publishers', 'presets'],
+    ['/config/bots/nodes', '/config/bots', 'nodes'],
+    ['/config/bots/presets', '/config/bots', 'presets'],
+    ['/config/remote/access', '/config/remote', 'access'],
+    ['/config/remote/nodes', '/config/remote', 'nodes'],
+    ['/config/reportitems/types', '/config/reports', 'types'],
+    ['/config/reportitems/attributes', '/config/reports', 'attributes'],
+    ['/config/external/users', '/config/external', 'users'],
+    ['/config/external/groups', '/config/external', 'groups'],
+    ['/config/external/templates', '/config/external', 'templates']
+]
+
+describe('legacy route redirects', () => {
+    it.each(legacyConfigRoutes)('%s redirects to %s?tab=%s', (legacyPath, path, tab) => {
+        const route = router.getRoutes().find((candidate) => candidate.path === legacyPath)
+
+        expect(route).toBeDefined()
+        expect(route.redirect).toEqual({ path, query: { tab } })
+    })
+
+    it('maps legacy source entry to the Assess dialog handoff', () => {
+        const route = router.getRoutes().find((candidate) => candidate.path === '/enter/source/:sourceId')
+
+        expect(route).toBeDefined()
+        expect(typeof route.redirect).toBe('function')
+        expect(route.redirect({ params: { sourceId: 'manual-42' }, query: { from: 'bookmark' } })).toEqual({
+            name: 'assess',
+            params: { groupId: 'all' },
+            query: { from: 'bookmark', manualSource: 'manual-42' }
+        })
+    })
+})


### PR DESCRIPTION
## Summary

Restore remaining functional parity between the legacy GUI and the Vue 3 GUI.

## Changes

### OSINT source import and export

- Add permission-aware import and export controls to the OSINT Sources view.
- Support JSON imports with collector-node selection.
- Refresh the source list after a successful import.
- Support exporting either all sources or only selected sources.
- Download exported data as a JSON file.
- Display progress, success, and error notifications.
- Propagate export API failures so they can be reported to the user.

### Legacy route compatibility

- Redirect retained legacy configuration URLs to their corresponding Vue 3 tabs.
- Restore `/enter/source/:sourceId` compatibility.
- Open the Assess manual-entry dialog with the requested source preselected.
- Remove the one-shot source parameter after navigation.
- Preserve `ASSESS_CREATE` permission enforcement.

### Node-management feedback

- Display notifications for node loading failures.
- Display success and error notifications when deleting nodes.
- Preserve console diagnostics for troubleshooting.
- Add missing console diagnostics for node save failures.

### Localization

- Add the required OSINT import/export messages to the English, Czech, and Slovak catalogs.
- Keep localization keys synchronized across all three catalogs.

## Testing

- Added focused tests for OSINT import/export behavior and API error propagation.
- Added tests for legacy configuration redirects and manual-source entry.
- Added tests for node-management feedback.
- Verified 34 focused unit tests.
- Verified Vue typechecking, ESLint, formatting, and the production build.