### PR TITLE
Fix Vue 3 lint errors and Node runtime compatibility

### DIFF
--- a/src/gui-v3/eslint.config.js
+++ b/src/gui-v3/eslint.config.js
@@ -1,10 +1,10 @@
 import js from '@eslint/js'
 import pluginVue from 'eslint-plugin-vue'
+import * as jsoncParser from 'jsonc-eslint-parser'
 import pluginVueI18n from '@intlify/eslint-plugin-vue-i18n'
 import eslintConfigPrettier from 'eslint-config-prettier'
 import tsParser from '@typescript-eslint/parser'
 import vueParser from 'vue-eslint-parser'
-import * as jsoncParser from 'jsonc-eslint-parser'
 
 const sharedGlobals = {
     // Browser globals

--- a/src/gui-v3/src/components/dashboard/WordCloud.vue
+++ b/src/gui-v3/src/components/dashboard/WordCloud.vue
@@ -102,7 +102,7 @@
     const layoutSize = ref({ width: 800, height: 420 })
     const layingOut = ref(false)
 
-    let resizeObserver: ResizeObserver | null = null
+    let resizeObserver: { observe: (target: Element) => void; disconnect: () => void } | null = null
     let resizeFrame = 0
     let layoutGeneration = 0
     let activeLayout: { start: () => unknown; stop: () => unknown } | null = null
@@ -221,7 +221,7 @@
     })
 
     onMounted(() => {
-        resizeObserver = new ResizeObserver(scheduleLayout)
+        resizeObserver = new window.ResizeObserver(scheduleLayout)
         if (containerRef.value) resizeObserver.observe(containerRef.value)
         scheduleLayout()
     })

--- a/src/gui-v3/tests/unit/SettingsTableLanguageOptions.spec.js
+++ b/src/gui-v3/tests/unit/SettingsTableLanguageOptions.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable vue/one-component-per-file -- test harness uses minimal inline components */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { flushPromises, mount } from '@vue/test-utils'


### PR DESCRIPTION
## Title

Fix Vue 3 lint errors and Node runtime compatibility

## Summary

This PR fixes the Vue 3 lint failures reported by CI and makes the ESLint configuration work consistently across supported Node versions.

## Changes

- Reference `ResizeObserver` through the browser `window` object instead of relying on an implicit global.
- Use an explicit structural type for the word-cloud resize observer.
- Document the intentional use of multiple inline stub components in the language-settings unit test.
- Load `jsonc-eslint-parser` before the Vue i18n ESLint plugin, preventing an ESM initialization cycle on newer Node runtimes.

## Why

The original lint run reported two `no-undef` errors for `ResizeObserver` and two `vue/one-component-per-file` warnings in the test harness.

Additionally, ESLint could crash during configuration loading on Node 22 and newer with:

`ReferenceError: Cannot access 'VisitorKeys' before initialization`

The import-order adjustment removes that runtime compatibility problem without changing lint rules or application behavior.

## Verification

- ESLint passes with zero errors and zero warnings.
- Verified on Node 22, Node 23, and Node 24.
- Vue TypeScript check passes.
- The affected language-settings unit test passes.
- `git diff --check` passes.