### PR TITLE
Restore report attachment management in Vue 3

### DIFF
--- a/src/core/api/analyze.py
+++ b/src/core/api/analyze.py
@@ -313,6 +313,25 @@ class ReportItemRemoveAttachment(Resource):
         sse_manager.report_item_updated(data)
         sse_manager.remote_access_report_items_updated(updated_report_item.report_item_type_id)
 
+    @auth_required("ANALYZE_UPDATE", ACLCheck.REPORT_ITEM_MODIFY)
+    def put(self, report_item_id: int, attribute_id: int) -> tuple[dict, int] | dict:
+        """Update the description of an existing attachment."""
+        payload = request.get_json(silent=True) or {}
+        description = payload.get("description", "")
+        if not isinstance(description, str):
+            return {"error": "Attachment description must be a string"}, HTTPStatus.BAD_REQUEST
+
+        try:
+            user = auth_manager.get_user_from_jwt()
+            data = ReportItem.update_attachment_description(report_item_id, attribute_id, user, description)
+            updated_report_item = ReportItem.find(report_item_id)
+            asset_manager.report_item_changed(updated_report_item)
+            sse_manager.report_item_updated(data)
+            sse_manager.remote_access_report_items_updated(updated_report_item.report_item_type_id)
+            return data
+        except ValueError as error:
+            return {"error": str(error)}, HTTPStatus.NOT_FOUND
+
 
 class ReportItemDownloadAttachment(Resource):
     """Download a report item attachment."""

--- a/src/core/api/analyze.py
+++ b/src/core/api/analyze.py
@@ -321,16 +321,16 @@ class ReportItemRemoveAttachment(Resource):
         if not isinstance(description, str):
             return {"error": "Attachment description must be a string"}, HTTPStatus.BAD_REQUEST
 
-        try:
-            user = auth_manager.get_user_from_jwt()
-            data = ReportItem.update_attachment_description(report_item_id, attribute_id, user, description)
-            updated_report_item = ReportItem.find(report_item_id)
-            asset_manager.report_item_changed(updated_report_item)
-            sse_manager.report_item_updated(data)
-            sse_manager.remote_access_report_items_updated(updated_report_item.report_item_type_id)
-            return data
-        except ValueError as error:
-            return {"error": str(error)}, HTTPStatus.NOT_FOUND
+        user = auth_manager.get_user_from_jwt()
+        data = ReportItem.update_attachment_description(report_item_id, attribute_id, user, description)
+        if data is None:
+            return {"error": "Attachment not found"}, HTTPStatus.NOT_FOUND
+
+        updated_report_item = ReportItem.find(report_item_id)
+        asset_manager.report_item_changed(updated_report_item)
+        sse_manager.report_item_updated(data)
+        sse_manager.remote_access_report_items_updated(updated_report_item.report_item_type_id)
+        return data
 
 
 class ReportItemDownloadAttachment(Resource):

--- a/src/core/model/report_item.py
+++ b/src/core/model/report_item.py
@@ -1136,6 +1136,38 @@ class ReportItem(db.Model):
         return data
 
     @classmethod
+    def update_attachment_description(  # noqa: A002
+        cls, id: int, attribute_id: int, user: User, description: str
+    ) -> dict:
+        """Update an attachment's human-readable description.
+
+        The attachment resource already owns upload, download, and deletion. Keeping the
+        description update on that resource avoids treating binary metadata as an ordinary
+        text attribute while extending the API without changing any existing contract.
+        """
+        report_item = db.session.get(cls, id)
+        attribute = cls._find_attribute(report_item, attribute_id) if report_item is not None else None
+        if attribute is None or attribute.binary_mime_type is None:
+            raise ValueError("Attachment not found")
+
+        if attribute.binary_description != description:
+            attribute.binary_description = description
+            attribute.user = user
+            attribute.last_updated = datetime.now(TZ)
+            attribute.version = (attribute.version or 1) + 1
+            report_item.last_updated = datetime.now(TZ)
+            db.session.commit()
+
+        return {
+            "update": True,
+            "user_id": user.id,
+            "report_item_id": int(id),
+            "attribute_id": attribute.id,
+            "binary_description": attribute.binary_description,
+            "attribute_version": attribute.version or 1,
+        }
+
+    @classmethod
     def delete_report_item(cls, id: int) -> tuple[str, int] | None:  # noqa: A002
         """Delete a report item by its ID.
 

--- a/src/core/model/report_item.py
+++ b/src/core/model/report_item.py
@@ -1136,19 +1136,23 @@ class ReportItem(db.Model):
         return data
 
     @classmethod
-    def update_attachment_description(  # noqa: A002
-        cls, id: int, attribute_id: int, user: User, description: str
-    ) -> dict:
+    def update_attachment_description(
+        cls,
+        report_item_id: int,
+        attribute_id: int,
+        user: User,
+        description: str,
+    ) -> dict | None:
         """Update an attachment's human-readable description.
 
         The attachment resource already owns upload, download, and deletion. Keeping the
         description update on that resource avoids treating binary metadata as an ordinary
         text attribute while extending the API without changing any existing contract.
         """
-        report_item = db.session.get(cls, id)
+        report_item = db.session.get(cls, report_item_id)
         attribute = cls._find_attribute(report_item, attribute_id) if report_item is not None else None
         if attribute is None or attribute.binary_mime_type is None:
-            raise ValueError("Attachment not found")
+            return None
 
         if attribute.binary_description != description:
             attribute.binary_description = description
@@ -1161,7 +1165,7 @@ class ReportItem(db.Model):
         return {
             "update": True,
             "user_id": user.id,
-            "report_item_id": int(id),
+            "report_item_id": report_item_id,
             "attribute_id": attribute.id,
             "binary_description": attribute.binary_description,
             "attribute_version": attribute.version or 1,

--- a/src/gui-v3/src/api/analyze.ts
+++ b/src/gui-v3/src/api/analyze.ts
@@ -171,6 +171,20 @@ export function removeAttachment(data) {
     return ApiService.delete('/analyze/report-items/' + data.report_item_id + '/file-attributes/' + data.attribute_id)
 }
 
+export function uploadAttachment(report_item_id, attribute_group_item_id, file, description = '') {
+    const formData = new FormData()
+    formData.append('file', file)
+    formData.append('attribute_group_item_id', String(attribute_group_item_id))
+    formData.append('description', description)
+    return ApiService.upload('/analyze/report-items/' + report_item_id + '/file-attributes', formData)
+}
+
+export function updateAttachmentDescription(data) {
+    return ApiService.put('/analyze/report-items/' + data.report_item_id + '/file-attributes/' + data.attribute_id, {
+        description: data.description
+    })
+}
+
 export function aiGenerate(attribute_id, news_item_agreggate_ids) {
     return ApiService.post('/analyze/report-item-attributes/' + attribute_id + '/llm-generate', {
         news_item_agreggate_ids

--- a/src/gui-v3/src/components/analyze/NewReportItem.vue
+++ b/src/gui-v3/src/components/analyze/NewReportItem.vue
@@ -437,7 +437,8 @@
         getReportItem,
         getReportItemData,
         getReportItemLocks,
-        aiGenerate
+        aiGenerate,
+        uploadAttachment
     } from '@/api/analyze'
     import { getEntityTypeStates } from '@/api/state'
     import AttributeContainer from '@/components/common/attribute/AttributeContainer.vue'
@@ -694,8 +695,18 @@
         }
 
         try {
-            const response = await createNewReportItem(report_item)
-            report_item.id = response.data
+            if (!report_item.id) {
+                const response = await createNewReportItem(report_item)
+                report_item.id = response.data
+            }
+
+            const attachmentsUploaded = await uploadPendingAttachments(report_item.id)
+            if (!attachmentsUploaded) {
+                show_error.value = true
+                overlay.value = false
+                return false
+            }
+
             overlay.value = false
             closeDialog()
             emit('data-updated')
@@ -707,6 +718,41 @@
             overlay.value = false
             return false
         }
+    }
+
+    const uploadPendingAttachments = async (reportItemId: number): Promise<boolean> => {
+        let allUploaded = true
+
+        for (const group of attribute_groups.value) {
+            for (const attributeItem of group.attribute_group_items) {
+                if (attributeItem.attribute_group_item.attribute.type !== 'ATTACHMENT') continue
+
+                for (const value of attributeItem.values) {
+                    if (!(value.file instanceof File)) continue
+
+                    value.uploading = true
+                    value.uploadError = false
+                    try {
+                        const response = await uploadAttachment(
+                            reportItemId,
+                            attributeItem.attribute_group_item.id,
+                            value.file,
+                            value.binary_description || ''
+                        )
+                        value.id = Number(response.data.attribute_id)
+                        delete value.file
+                        value.uploading = false
+                    } catch (error) {
+                        console.error('Failed to upload report attachment:', error)
+                        value.uploading = false
+                        value.uploadError = true
+                        allUploaded = false
+                    }
+                }
+            }
+        }
+
+        return allUploaded
     }
 
     const saveReportItem = (field_id: ReportField) => {

--- a/src/gui-v3/src/components/common/attribute/AttributeAttachment.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeAttachment.vue
@@ -225,6 +225,11 @@
     }
 
     type DescriptionMode = 'new' | 'edit' | 'detail'
+    type FileInputControl = {
+        click: () => void
+        files: ArrayLike<File> | null
+        value: string
+    }
 
     const props = withDefaults(
         defineProps<{
@@ -246,7 +251,7 @@
     // Besides the field-editing helpers, this composable keeps the values synchronized when
     // another analyst uploads, updates, or deletes an attachment over SSE.
     useAttributes(props)
-    const fileInput = ref<HTMLInputElement | null>(null)
+    const fileInput = ref<FileInputControl | null>(null)
     const dragActive = ref(false)
     const operationError = ref(false)
     const pendingFiles = ref<File[]>([])
@@ -292,7 +297,7 @@
     }
 
     const handleFileInput = (event: Event): void => {
-        const input = event.target as HTMLInputElement
+        const input = event.target as unknown as FileInputControl
         acceptFiles(Array.from(input.files ?? []))
         input.value = ''
     }

--- a/src/gui-v3/src/components/common/attribute/AttributeAttachment.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeAttachment.vue
@@ -2,105 +2,234 @@
     <AttributeItemLayout
         :add-button="false"
         :values="values"
-        @add-value="add"
     >
         <template #content>
-            <div
-                v-for="(value, index) in values"
-                :key="`${value.index}-${index}`"
-                class="value-holder"
-            >
-                <!-- Read-only or remote -->
+            <div class="attachment-list">
+                <button
+                    v-if="canAddAttachment"
+                    type="button"
+                    class="attachment-dropzone"
+                    :class="{ 'attachment-dropzone--active': dragActive }"
+                    :disabled="uploading"
+                    @click="openFilePicker"
+                    @dragenter.prevent="dragActive = true"
+                    @dragover.prevent="dragActive = true"
+                    @dragleave.prevent="dragActive = false"
+                    @drop.prevent="handleDrop"
+                >
+                    <v-icon size="28">mdi-cloud-upload-outline</v-icon>
+                    <span>{{ t('drop_zone.default_message') }}</span>
+                </button>
+                <input
+                    ref="fileInput"
+                    class="attachment-file-input"
+                    type="file"
+                    multiple
+                    :disabled="!canAddAttachment || uploading"
+                    @change="handleFileInput"
+                />
+
+                <v-alert
+                    v-if="operationError"
+                    type="error"
+                    variant="tonal"
+                    density="compact"
+                    closable
+                    class="mb-2"
+                    @click:close="operationError = false"
+                >
+                    {{ t('error.server_error') }}
+                </v-alert>
+
                 <div
-                    v-if="readOnly || value.remote"
-                    class="attachment-display d-flex align-center pa-3"
+                    v-for="(value, index) in values"
+                    :key="attachmentKey(value, index)"
+                    class="attachment-row"
+                    :class="{ 'attachment-row--remote': value.remote }"
                 >
                     <v-icon
                         color="primary"
-                        class="mr-3"
+                        class="attachment-row__icon"
                     >
                         {{ ICONS.FILE_DOCUMENT }}
                     </v-icon>
-                    <div class="flex-grow-1">
-                        <div class="text-body-2 font-weight-medium">
-                            {{ value.binary_description || 'Attachment' }}
-                        </div>
-                        <div class="text-caption text-grey">{{ value.binary_mime_type }} - {{ formatFileSize(value.binary_size) }}</div>
-                    </div>
+
+                    <button
+                        type="button"
+                        class="attachment-row__details"
+                        :disabled="value.uploading"
+                        @click="openDetails(value)"
+                    >
+                        <span class="attachment-row__name">{{ attachmentName(value) }}</span>
+                        <span
+                            v-if="value.binary_description"
+                            class="attachment-row__description"
+                        >
+                            {{ value.binary_description }}
+                        </span>
+                        <span class="attachment-row__meta">
+                            {{ value.binary_mime_type || value.file?.type || 'application/octet-stream' }}
+                            <template v-if="attachmentSize(value) > 0"> · {{ formatFileSize(attachmentSize(value)) }}</template>
+                            <template v-if="value.last_updated"> · {{ t('drop_zone.last_updated') }} {{ value.last_updated }}</template>
+                            <template v-if="value.user?.name"> · {{ value.user.name }}</template>
+                        </span>
+                    </button>
+
+                    <v-progress-circular
+                        v-if="value.uploading"
+                        indeterminate
+                        color="primary"
+                        size="22"
+                        width="2"
+                    />
                     <v-btn
-                        size="small"
+                        v-else-if="value.uploadError && value.file"
                         variant="text"
+                        size="small"
+                        color="error"
+                        :title="t('attribute.add_attachment')"
+                        @click="uploadValue(value)"
+                    >
+                        <v-icon>mdi-reload</v-icon>
+                    </v-btn>
+                    <v-btn
+                        v-if="canDownload(value)"
+                        variant="text"
+                        size="small"
+                        :title="t('drop_zone.download')"
                         @click="downloadAttachmentNow(value)"
                     >
                         <v-icon>{{ ICONS.DOWNLOAD }}</v-icon>
                     </v-btn>
+                    <v-btn
+                        v-if="canManageValue(value)"
+                        variant="text"
+                        size="small"
+                        :title="t('common.edit')"
+                        @click="openDescriptionEditor(value)"
+                    >
+                        <v-icon>mdi-pencil-outline</v-icon>
+                    </v-btn>
+                    <v-btn
+                        v-if="canManageValue(value)"
+                        variant="text"
+                        size="small"
+                        color="error"
+                        :title="t('common.delete')"
+                        @click="requestDelete(value)"
+                    >
+                        <v-icon>mdi-delete-outline</v-icon>
+                    </v-btn>
                 </div>
-
-                <!-- Editable -->
-                <AttributeValueLayout
-                    v-if="!readOnly && canModify && !value.remote"
-                    :del-button="false"
-                    :occurrence="attributeGroup.min_occurrence"
-                    :values="values"
-                    :val-index="index"
-                    @del-value="del(index)"
-                >
-                    <template #col_middle>
-                        <div class="d-flex align-center">
-                            <div
-                                v-if="value.binary_description"
-                                class="mr-3"
-                            >
-                                <div class="text-body-2">
-                                    {{ value.binary_description }}
-                                </div>
-                                <div class="text-caption text-grey">
-                                    {{ value.binary_mime_type }} - {{ formatFileSize(value.binary_size) }}
-                                </div>
-                            </div>
-                            <v-btn
-                                v-if="(value.id ?? 0) > 0"
-                                size="small"
-                                variant="text"
-                                @click="downloadAttachmentNow(value)"
-                            >
-                                <v-icon>{{ ICONS.DOWNLOAD }}</v-icon>
-                            </v-btn>
-                        </div>
-                    </template>
-                </AttributeValueLayout>
             </div>
         </template>
     </AttributeItemLayout>
+
+    <v-dialog
+        v-model="descriptionDialog"
+        max-width="620px"
+        persistent
+    >
+        <v-card>
+            <v-card-title class="d-flex align-center">
+                <v-icon
+                    color="primary"
+                    class="mr-2"
+                >
+                    {{ ICONS.FILE_DOCUMENT }}
+                </v-icon>
+                {{ descriptionMode === 'new' ? t('drop_zone.attachment_load') : t('drop_zone.attachment_detail') }}
+            </v-card-title>
+            <v-card-text>
+                <div class="text-body-2 font-weight-medium mb-3">
+                    {{ descriptionMode === 'new' ? currentPendingFile?.name : attachmentName(selectedValue) }}
+                </div>
+                <v-textarea
+                    v-model="descriptionDraft"
+                    :label="t('drop_zone.file_description')"
+                    rows="3"
+                    auto-grow
+                    autofocus
+                    :readonly="descriptionMode === 'detail'"
+                />
+            </v-card-text>
+            <v-card-actions>
+                <v-spacer />
+                <v-btn
+                    variant="text"
+                    @click="cancelDescriptionDialog"
+                >
+                    {{ t('common.cancel') }}
+                </v-btn>
+                <v-btn
+                    v-if="descriptionMode !== 'detail'"
+                    color="primary"
+                    variant="elevated"
+                    :loading="savingDescription"
+                    @click="confirmDescription"
+                >
+                    {{ t('common.save') }}
+                </v-btn>
+                <v-btn
+                    v-else
+                    color="primary"
+                    variant="text"
+                    @click="descriptionDialog = false"
+                >
+                    {{ t('common.done') }}
+                </v-btn>
+            </v-card-actions>
+        </v-card>
+    </v-dialog>
+
+    <ConfirmationDialog
+        v-model="deleteDialog"
+        @confirm="deleteSelectedAttachment"
+    >
+        {{ attachmentName(selectedValue) }}
+    </ConfirmationDialog>
 </template>
 
 <script setup lang="ts">
+    import { computed, ref } from 'vue'
+    import { useI18n } from 'vue-i18n'
     import { ICONS } from '@/config/ui-constants'
+    import AuthService from '@/services/auth_service'
+    import Permissions from '@/services/auth/permissions'
     import AttributeItemLayout from './AttributeItemLayout.vue'
-    import AttributeValueLayout from './AttributeValueLayout.vue'
     import { useAttributes } from './useAttributes'
-    import { downloadAttachment } from '@/api/analyze'
+    import ConfirmationDialog from '@/components/common/dialogs/ConfirmationDialog.vue'
+    import { downloadAttachment, removeAttachment, updateAttachmentDescription, uploadAttachment } from '@/api/analyze'
 
-    type AttributeValueItem = {
+    type AttachmentValue = {
         id?: number
         index?: string | number
+        value?: string
         remote?: boolean
         locked?: boolean
         binary_description?: string
         binary_mime_type?: string
         binary_size?: number
+        last_updated?: string
+        user?: { name?: string } | null
+        file?: File
+        uploading?: boolean
+        uploadError?: boolean
         [key: string]: unknown
     }
 
     type AttributeGroup = {
-        min_occurrence?: number
+        id?: number
+        max_occurrence?: number | null
         [key: string]: unknown
     }
+
+    type DescriptionMode = 'new' | 'edit' | 'detail'
 
     const props = withDefaults(
         defineProps<{
             attributeGroup: AttributeGroup
-            values: AttributeValueItem[]
+            values: AttachmentValue[]
             readOnly?: boolean
             edit?: boolean
             modify?: boolean
@@ -113,32 +242,295 @@
         }
     )
 
-    const { canModify, add, del } = useAttributes(props)
+    const { t } = useI18n()
+    // Besides the field-editing helpers, this composable keeps the values synchronized when
+    // another analyst uploads, updates, or deletes an attachment over SSE.
+    useAttributes(props)
+    const fileInput = ref<HTMLInputElement | null>(null)
+    const dragActive = ref(false)
+    const operationError = ref(false)
+    const pendingFiles = ref<File[]>([])
+    const currentPendingFile = ref<File | null>(null)
+    const selectedValue = ref<AttachmentValue | null>(null)
+    const descriptionDraft = ref('')
+    const descriptionDialog = ref(false)
+    const descriptionMode = ref<DescriptionMode>('detail')
+    const savingDescription = ref(false)
+    const deleteDialog = ref(false)
+    let temporaryId = -1
 
-    const formatFileSize = (bytes: number | null | undefined): string => {
+    const mayCreate = computed(() => AuthService.hasPermission(Permissions.ANALYZE_CREATE))
+    const mayUpdate = computed(() => AuthService.hasPermission(Permissions.ANALYZE_UPDATE) && props.modify === true)
+    const canManage = computed(() => !props.readOnly && (props.edit ? mayUpdate.value : mayCreate.value))
+    const uploading = computed(() => props.values.some((value) => value.uploading))
+    const canAddAttachment = computed(() => {
+        const maximum = props.attributeGroup.max_occurrence ?? Infinity
+        const describing = currentPendingFile.value ? 1 : 0
+        return canManage.value && props.values.length + pendingFiles.value.length + describing < maximum
+    })
+
+    const attachmentKey = (value: AttachmentValue, index: number): string => String(value.id ?? value.index ?? index)
+    const attachmentName = (value: AttachmentValue | null): string => value?.value || value?.file?.name || t('attribute.select_attachment')
+    const attachmentSize = (value: AttachmentValue): number => Number(value.binary_size ?? value.file?.size ?? 0)
+
+    const formatFileSize = (bytes: number): string => {
         if (!bytes) return '0 B'
-        const k = 1024
-        const sizes = ['B', 'KB', 'MB', 'GB']
-        const i = Math.floor(Math.log(bytes) / Math.log(k))
-        return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + (sizes[i] ?? 'B')
+        const units = ['B', 'KB', 'MB', 'GB', 'TB']
+        const unit = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
+        return `${parseFloat((bytes / Math.pow(1024, unit)).toFixed(2))} ${units[unit]}`
     }
 
-    const downloadAttachmentNow = (attrValue: AttributeValueItem): void => {
-        if (!attrValue || !attrValue.id) return
-        const fileName = attrValue.binary_description || 'attachment'
-        const downloadLink = `/analyze/report-items/${props.reportItemId}/file-attributes/${attrValue.id}/file`
-        downloadAttachment(downloadLink, fileName)
+    const openFilePicker = (): void => fileInput.value?.click()
+
+    const acceptFiles = (files: File[]): void => {
+        if (!canAddAttachment.value || files.length === 0) return
+        const maximum = props.attributeGroup.max_occurrence ?? Infinity
+        const describing = currentPendingFile.value ? 1 : 0
+        const available = Math.max(0, maximum - props.values.length - pendingFiles.value.length - describing)
+        pendingFiles.value.push(...files.slice(0, available))
+        openNextFileDescription()
+    }
+
+    const handleFileInput = (event: Event): void => {
+        const input = event.target as HTMLInputElement
+        acceptFiles(Array.from(input.files ?? []))
+        input.value = ''
+    }
+
+    const handleDrop = (event: DragEvent): void => {
+        dragActive.value = false
+        acceptFiles(Array.from(event.dataTransfer?.files ?? []))
+    }
+
+    const openNextFileDescription = (): void => {
+        if (descriptionDialog.value || currentPendingFile.value || pendingFiles.value.length === 0) return
+        currentPendingFile.value = pendingFiles.value.shift() ?? null
+        descriptionDraft.value = ''
+        descriptionMode.value = 'new'
+        descriptionDialog.value = currentPendingFile.value !== null
+    }
+
+    const queueAttachment = (file: File, description: string): AttachmentValue => {
+        const value: AttachmentValue = {
+            id: temporaryId--,
+            index: props.values.length,
+            value: file.name,
+            binary_description: description,
+            binary_mime_type: file.type || 'application/octet-stream',
+            binary_size: file.size,
+            user: null,
+            remote: false,
+            file
+        }
+        props.values.push(value)
+        return value
+    }
+
+    const uploadValue = async (value: AttachmentValue): Promise<boolean> => {
+        if (!value.file || !props.reportItemId || !props.attributeGroup.id) return false
+        value.uploading = true
+        value.uploadError = false
+        operationError.value = false
+        try {
+            const response = await uploadAttachment(props.reportItemId, props.attributeGroup.id, value.file, value.binary_description || '')
+            value.id = Number(response.data.attribute_id)
+            value.index = props.values.indexOf(value)
+            delete value.file
+            value.uploading = false
+            return true
+        } catch (error) {
+            console.error('Failed to upload attachment:', error)
+            value.uploading = false
+            value.uploadError = true
+            operationError.value = true
+            return false
+        }
+    }
+
+    const confirmDescription = async (): Promise<void> => {
+        if (descriptionMode.value === 'new' && currentPendingFile.value) {
+            const value = queueAttachment(currentPendingFile.value, descriptionDraft.value)
+            currentPendingFile.value = null
+            descriptionDialog.value = false
+            if (props.edit) await uploadValue(value)
+            openNextFileDescription()
+            return
+        }
+
+        if (descriptionMode.value === 'edit' && selectedValue.value) {
+            savingDescription.value = true
+            operationError.value = false
+            try {
+                if (props.edit && props.reportItemId && selectedValue.value.id && selectedValue.value.id > 0) {
+                    const response = await updateAttachmentDescription({
+                        report_item_id: props.reportItemId,
+                        attribute_id: selectedValue.value.id,
+                        description: descriptionDraft.value
+                    })
+                    selectedValue.value.binary_description = response.data.binary_description ?? descriptionDraft.value
+                    selectedValue.value.uploadError = false
+                } else {
+                    selectedValue.value.binary_description = descriptionDraft.value
+                }
+                descriptionDialog.value = false
+            } catch (error) {
+                console.error('Failed to update attachment description:', error)
+                operationError.value = true
+            } finally {
+                savingDescription.value = false
+            }
+        }
+    }
+
+    const cancelDescriptionDialog = (): void => {
+        const wasNew = descriptionMode.value === 'new'
+        currentPendingFile.value = null
+        descriptionDialog.value = false
+        if (wasNew) openNextFileDescription()
+    }
+
+    const canDownload = (value: AttachmentValue): boolean => !!props.reportItemId && !!value.id && value.id > 0 && !value.uploading
+    const canManageValue = (value: AttachmentValue): boolean => canManage.value && !value.remote && !value.locked && !value.uploading
+
+    const downloadAttachmentNow = (value: AttachmentValue): void => {
+        if (!canDownload(value)) return
+        downloadAttachment(`/analyze/report-items/${props.reportItemId}/file-attributes/${value.id}/file`, attachmentName(value))
+    }
+
+    const openDescriptionEditor = (value: AttachmentValue): void => {
+        selectedValue.value = value
+        descriptionDraft.value = value.binary_description || ''
+        descriptionMode.value = 'edit'
+        descriptionDialog.value = true
+    }
+
+    const openDetails = (value: AttachmentValue): void => {
+        if (canManageValue(value)) {
+            openDescriptionEditor(value)
+            return
+        }
+        selectedValue.value = value
+        descriptionDraft.value = value.binary_description || ''
+        descriptionMode.value = 'detail'
+        descriptionDialog.value = true
+    }
+
+    const requestDelete = (value: AttachmentValue): void => {
+        selectedValue.value = value
+        deleteDialog.value = true
+    }
+
+    const deleteSelectedAttachment = async (): Promise<void> => {
+        const value = selectedValue.value
+        if (!value) return
+        operationError.value = false
+        try {
+            if (props.edit && props.reportItemId && value.id && value.id > 0) {
+                await removeAttachment({ report_item_id: props.reportItemId, attribute_id: value.id })
+            }
+            const index = props.values.indexOf(value)
+            if (index >= 0) props.values.splice(index, 1)
+            props.values.forEach((item, itemIndex) => (item.index = itemIndex))
+            selectedValue.value = null
+        } catch (error) {
+            console.error('Failed to delete attachment:', error)
+            operationError.value = true
+        }
     }
 </script>
 
 <style scoped>
-    .attachment-display {
-        border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
-        border-radius: 4px;
+    .attachment-list {
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+        width: 100%;
+        overflow: hidden;
+        border: 1px solid rgba(var(--v-border-color), 0.5);
+        border-radius: 6px;
     }
 
-    .value-holder {
-        width: 100%;
-        margin-bottom: 2px;
+    .attachment-file-input {
+        display: none;
+    }
+
+    .attachment-dropzone {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+        min-height: 68px;
+        padding: 12px;
+        color: rgb(var(--v-theme-primary));
+        background: rgba(var(--v-theme-primary), 0.05);
+        border: 1px dashed rgba(var(--v-theme-primary), 0.55);
+        cursor: pointer;
+        transition:
+            background-color 120ms ease,
+            border-color 120ms ease;
+    }
+
+    .attachment-dropzone:hover,
+    .attachment-dropzone:focus-visible,
+    .attachment-dropzone--active {
+        background: rgba(var(--v-theme-primary), 0.12);
+        border-color: rgb(var(--v-theme-primary));
+        outline: none;
+    }
+
+    .attachment-row {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        min-height: 58px;
+        padding: 7px 8px 7px 12px;
+        background: rgb(var(--v-theme-surface));
+        border-top: 1px solid rgba(var(--v-border-color), 0.35);
+    }
+
+    .attachment-row--remote {
+        background: rgba(var(--v-theme-primary), 0.035);
+    }
+
+    .attachment-row__icon {
+        flex: 0 0 auto;
+        margin-right: 6px;
+    }
+
+    .attachment-row__details {
+        display: flex;
+        flex: 1 1 auto;
+        flex-direction: column;
+        min-width: 0;
+        padding: 3px 6px;
+        color: inherit;
+        text-align: left;
+        background: transparent;
+        border: 0;
+        cursor: pointer;
+    }
+
+    .attachment-row__details:focus-visible {
+        border-radius: 3px;
+        outline: 2px solid rgb(var(--v-theme-primary));
+    }
+
+    .attachment-row__name,
+    .attachment-row__description,
+    .attachment-row__meta {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .attachment-row__name {
+        font-size: 0.9rem;
+        font-weight: 600;
+    }
+
+    .attachment-row__description,
+    .attachment-row__meta {
+        color: rgba(var(--v-theme-on-surface), 0.66);
+        font-size: 0.75rem;
     }
 </style>

--- a/src/gui-v3/src/components/common/attribute/AttributeItemLayout.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeItemLayout.vue
@@ -73,7 +73,7 @@
         last_updated?: unknown
         user?: {
             name?: string
-        }
+        } | null
         [key: string]: unknown
     }
 

--- a/src/gui-v3/src/components/common/attribute/useAttributes.ts
+++ b/src/gui-v3/src/components/common/attribute/useAttributes.ts
@@ -37,7 +37,7 @@ type ConflictPayload = {
 type AttributeGroup = {
     id?: number
     min_occurrence?: number
-    max_occurrence?: number
+    max_occurrence?: number | null
     attribute?: {
         type?: string
         enum_values?: unknown[]
@@ -571,6 +571,15 @@ export function useAttributes<T extends UseAttributesProps>(props: Readonly<T>) 
                         }
                         item.value = toLocalValue(itemData.attribute_value)
                         item.value_description = String(itemData.attribute_value_description ?? '')
+                        if (itemData.binary_description !== undefined) {
+                            item.binary_description = itemData.binary_description
+                        }
+                        if (itemData.binary_mime_type !== undefined) {
+                            item.binary_mime_type = itemData.binary_mime_type
+                        }
+                        if (itemData.binary_size !== undefined) {
+                            item.binary_size = itemData.binary_size
+                        }
                         item.last_updated = itemData.attribute_last_updated
                         item.user = { name: String(itemData.attribute_user ?? '') }
                         if (itemData.attribute_version !== undefined) {

--- a/src/gui-v3/tests/unit/AttributeComponents.spec.js
+++ b/src/gui-v3/tests/unit/AttributeComponents.spec.js
@@ -19,6 +19,8 @@ import AttributeCPE from '@/components/common/attribute/AttributeCPE.vue'
 import AttributeCVSS from '@/components/common/attribute/AttributeCVSS.vue'
 import AttributeRichText from '@/components/common/attribute/AttributeRichText.vue'
 import AttributeAttachment from '@/components/common/attribute/AttributeAttachment.vue'
+import AuthService from '@/services/auth_service'
+import { removeAttachment, updateAttachmentDescription, uploadAttachment } from '@/api/analyze'
 
 // ── API mocks (prevent network calls from useAttributes) ─────────────────────
 vi.mock('@/api/analyze', () => ({
@@ -27,7 +29,10 @@ vi.mock('@/api/analyze', () => ({
     lockReportItem: vi.fn().mockResolvedValue({}),
     unlockReportItem: vi.fn().mockResolvedValue({}),
     updateReportItem: vi.fn().mockResolvedValue({}),
-    downloadAttachment: vi.fn().mockResolvedValue({})
+    downloadAttachment: vi.fn().mockResolvedValue({}),
+    removeAttachment: vi.fn().mockResolvedValue({}),
+    updateAttachmentDescription: vi.fn().mockResolvedValue({ data: {} }),
+    uploadAttachment: vi.fn().mockResolvedValue({ data: { attribute_id: 99 } })
 }))
 
 // Stub layout sub-components so we don't need to wire up their Pinia deps
@@ -61,11 +66,19 @@ const CalculatorCVSSStub = {
     emits: ['update:modelValue']
 }
 
+const DialogStub = {
+    name: 'VDialog',
+    props: ['modelValue'],
+    template: '<div class="dialog-stub"><slot /></div>',
+    emits: ['update:modelValue']
+}
+
 const globalStubs = {
     AttributeItemLayout: AttributeItemLayoutStub,
     AttributeValueLayout: AttributeValueLayoutStub,
     Editor: EditorStub,
-    CalculatorCVSS: CalculatorCVSSStub
+    CalculatorCVSS: CalculatorCVSSStub,
+    VDialog: DialogStub
 }
 
 // ── Shared prop factories ─────────────────────────────────────────────────────
@@ -587,7 +600,11 @@ describe('AttributeRichText', () => {
 // ── AttributeAttachment ───────────────────────────────────────────────────────
 
 describe('AttributeAttachment', () => {
-    beforeEach(() => setActivePinia(createPinia()))
+    beforeEach(() => {
+        setActivePinia(createPinia())
+        vi.clearAllMocks()
+        vi.spyOn(AuthService, 'hasPermission').mockReturnValue(true)
+    })
 
     const attachmentValue = {
         id: 10,
@@ -606,13 +623,88 @@ describe('AttributeAttachment', () => {
 
     it('shows read-only attachment display', () => {
         const wrapper = mountAttr(AttributeAttachment, readOnlyProps(attachmentValue))
-        expect(wrapper.find('.attachment-display').exists()).toBe(true)
+        expect(wrapper.find('.attachment-row').exists()).toBe(true)
+        expect(wrapper.find('.attachment-dropzone').exists()).toBe(false)
     })
 
     it('shows editable layout in edit mode', () => {
-        const wrapper = mountAttr(AttributeAttachment, baseProps(attachmentValue))
-        // Attachment edit mode shows a value-layout stub with file info / download button
-        expect(wrapper.find('.value-layout-stub').exists()).toBe(true)
+        const wrapper = mountAttr(AttributeAttachment, { ...baseProps(attachmentValue), modify: true })
+        expect(wrapper.find('.attachment-row').exists()).toBe(true)
+        expect(wrapper.find('.attachment-dropzone').exists()).toBe(true)
+    })
+
+    it('queues a selected file with its description while creating a report', async () => {
+        const props = {
+            ...baseProps({}, { attribute: { type: 'ATTACHMENT' } }),
+            values: [],
+            edit: false,
+            modify: true,
+            reportItemId: null
+        }
+        const wrapper = mountAttr(AttributeAttachment, props)
+        const file = new File(['contents'], 'evidence.txt', { type: 'text/plain' })
+
+        wrapper.vm.acceptFiles([file])
+        await wrapper.vm.$nextTick()
+        wrapper.vm.descriptionDraft = 'Collected evidence'
+        await wrapper.vm.confirmDescription()
+
+        expect(props.values).toHaveLength(1)
+        expect(props.values[0]).toMatchObject({
+            value: 'evidence.txt',
+            binary_description: 'Collected evidence',
+            binary_mime_type: 'text/plain',
+            binary_size: 8,
+            file
+        })
+        expect(uploadAttachment).not.toHaveBeenCalled()
+    })
+
+    it('uploads a selected file immediately for an existing report', async () => {
+        const props = {
+            ...baseProps({}, { attribute: { type: 'ATTACHMENT' } }),
+            values: [],
+            modify: true
+        }
+        const wrapper = mountAttr(AttributeAttachment, props)
+        const file = new File(['contents'], 'evidence.txt', { type: 'text/plain' })
+
+        wrapper.vm.acceptFiles([file])
+        await wrapper.vm.$nextTick()
+        wrapper.vm.descriptionDraft = 'Collected evidence'
+        await wrapper.vm.confirmDescription()
+
+        expect(uploadAttachment).toHaveBeenCalledWith(42, 'ag-1', file, 'Collected evidence')
+        expect(props.values[0]).toMatchObject({ id: 99, value: 'evidence.txt', binary_description: 'Collected evidence' })
+        expect(props.values[0].file).toBeUndefined()
+    })
+
+    it('updates an existing attachment description', async () => {
+        updateAttachmentDescription.mockResolvedValueOnce({ data: { binary_description: 'Updated description' } })
+        const props = { ...baseProps({ ...attachmentValue, binary_description: 'Old description' }), modify: true }
+        const wrapper = mountAttr(AttributeAttachment, props)
+
+        wrapper.vm.openDescriptionEditor(props.values[0])
+        wrapper.vm.descriptionDraft = 'Updated description'
+        await wrapper.vm.confirmDescription()
+
+        expect(updateAttachmentDescription).toHaveBeenCalledWith({
+            report_item_id: 42,
+            attribute_id: 10,
+            description: 'Updated description'
+        })
+        expect(props.values[0].binary_description).toBe('Updated description')
+    })
+
+    it('deletes an existing attachment after confirmation', async () => {
+        const props = { ...baseProps(attachmentValue), modify: true }
+        const wrapper = mountAttr(AttributeAttachment, props)
+
+        wrapper.vm.selectedValue = props.values[0]
+        await wrapper.vm.deleteSelectedAttachment()
+
+        expect(removeAttachment).toHaveBeenCalledWith({ report_item_id: 42, attribute_id: 10 })
+        expect(props.values).toHaveLength(0)
     })
 })
 

--- a/src/gui-v3/tests/unit/NewReportItemAttributes.spec.js
+++ b/src/gui-v3/tests/unit/NewReportItemAttributes.spec.js
@@ -71,7 +71,8 @@ vi.mock('@/api/analyze', () => ({
     getReportItem: vi.fn(),
     getReportItemData: vi.fn(),
     getReportItemLocks: vi.fn(),
-    aiGenerate: vi.fn()
+    aiGenerate: vi.fn(),
+    uploadAttachment: vi.fn()
 }))
 
 const VDialogStub = {

--- a/src/gui-v3/tests/unit/NewReportItemSSE.spec.js
+++ b/src/gui-v3/tests/unit/NewReportItemSSE.spec.js
@@ -91,7 +91,8 @@ vi.mock('@/api/analyze', () => ({
     getReportItem: vi.fn(),
     getReportItemData: vi.fn(),
     getReportItemLocks: vi.fn(),
-    aiGenerate: vi.fn()
+    aiGenerate: vi.fn(),
+    uploadAttachment: vi.fn()
 }))
 
 const VDialogStub = {

--- a/src/gui-v3/tests/unit/analyze.api.spec.js
+++ b/src/gui-v3/tests/unit/analyze.api.spec.js
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { createNewReportItem } from '@/api/analyze'
+import { createNewReportItem, updateAttachmentDescription, uploadAttachment } from '@/api/analyze'
 import ApiService from '@/services/api_service'
 
 vi.mock('@/services/api_service', () => ({
     default: {
-        post: vi.fn()
+        post: vi.fn(),
+        put: vi.fn(),
+        upload: vi.fn()
     }
 }))
 
@@ -40,5 +42,24 @@ describe('analyze api', () => {
             remote_report_items: [{ id: 22 }],
             attributes: [{ id: -1, attribute_group_item_id: 5, value: 'test' }]
         })
+    })
+
+    it('uploads an attachment with the backend multipart field names', () => {
+        const file = new File(['evidence'], 'evidence.txt', { type: 'text/plain' })
+
+        uploadAttachment(42, 7, file, 'Collected evidence')
+
+        expect(ApiService.upload).toHaveBeenCalledOnce()
+        const [url, formData] = ApiService.upload.mock.calls[0]
+        expect(url).toBe('/analyze/report-items/42/file-attributes')
+        expect(formData.get('file')).toBe(file)
+        expect(formData.get('attribute_group_item_id')).toBe('7')
+        expect(formData.get('description')).toBe('Collected evidence')
+    })
+
+    it('updates an attachment description on the existing attachment resource', () => {
+        updateAttachmentDescription({ report_item_id: 42, attribute_id: 9, description: 'Updated' })
+
+        expect(ApiService.put).toHaveBeenCalledWith('/analyze/report-items/42/file-attributes/9', { description: 'Updated' })
     })
 })

--- a/src/gui-v3/tests/unit/useAttributes.spec.js
+++ b/src/gui-v3/tests/unit/useAttributes.spec.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
-import { effectScope } from 'vue'
+import { defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
 import { useAttributes, isLabelOnly } from '@/components/common/attribute/useAttributes'
 
 // Mock dependencies
@@ -45,14 +46,18 @@ function makeProps(overrides = {}) {
     }
 }
 
-// Helper: run composable in a Vue effect scope (provides onUnmounted support)
+// Mount a host component so lifecycle hooks run with an active component instance.
 function setupComposable(props) {
     let result
-    const scope = effectScope()
-    scope.run(() => {
-        result = useAttributes(props)
-    })
-    return { result, scope }
+    const wrapper = mount(
+        defineComponent({
+            setup() {
+                result = useAttributes(props)
+                return () => null
+            }
+        })
+    )
+    return { result, scope: { stop: () => wrapper.unmount() } }
 }
 
 describe('useAttributes', () => {


### PR DESCRIPTION
## Restore report attachment management in Vue 3

### Summary

Restores the attachment functionality available in the legacy report-item editor but missing from the Vue 3 GUI.

- Add attachments using file selection or drag and drop
- Enter a description for each attachment
- Queue attachments while creating a new report and upload them after the report receives its ID
- Upload immediately when editing an existing report
- Display filename, MIME type, size, description, author, and update time
- Edit attachment descriptions
- Download existing attachments
- Delete attachments after confirmation
- Keep failed uploads visible and retryable
- Respect report permissions, read-only state, locks, and occurrence limits
- Synchronize attachment additions, updates, and deletions through existing SSE handling

### Backend

Adds a backward-compatible `PUT` operation to the existing attachment resource:

`/analyze/report-items/<report_item_id>/file-attributes/<attribute_id>`

This updates attachment descriptions without changing the existing upload, download, or delete contracts.

### Why

The Vue 3 attachment component previously rendered existing attachments and allowed downloading, but provided no way to upload, describe, edit, or delete them. Analysts therefore had to return to the legacy GUI for normal report attachment management.

### Verification

- 123 focused unit tests passed
- Vue TypeScript checking passed
- Python syntax and whitespace checks passed
- Running Analyze/report editor smoke-tested without attachment-related browser errors