### PR TITLE
Apply Vue formatting cleanup

### DIFF
--- a/src/gui-v3/src/components/assets/CardAsset.vue
+++ b/src/gui-v3/src/components/assets/CardAsset.vue
@@ -11,9 +11,7 @@
 
         <div class="asset-card__identity">
             <strong>{{ asset.name || asset.title }}</strong>
-            <span v-if="showSerial">
-                {{ t('asset.serial') }}: {{ asset.serial }}
-            </span>
+            <span v-if="showSerial"> {{ t('asset.serial') }}: {{ asset.serial }} </span>
         </div>
 
         <p class="asset-card__description">

--- a/src/gui-v3/src/views/users/DashboardView.vue
+++ b/src/gui-v3/src/views/users/DashboardView.vue
@@ -135,7 +135,6 @@
                     viewport-fit
                     @select-word="openWordSearch"
                 />
-
             </article>
 
             <aside class="dashboard-rail">
@@ -368,7 +367,7 @@
             icon: 'mdi-package-variant-closed',
             tone: 'amber',
             to: '/publish'
-        },
+        }
     ])
 
     const toDisplayStates = (states: Record<string, DashboardStateInfo>): DisplayState[] =>
@@ -709,8 +708,7 @@
     .dashboard-cloud :deep(.word-cloud-container) {
         border-radius: 0;
         background:
-            radial-gradient(circle at 45% 48%, rgba(var(--v-theme-primary), 0.1), transparent 64%),
-            rgba(var(--v-theme-surface-variant), 0.1);
+            radial-gradient(circle at 45% 48%, rgba(var(--v-theme-primary), 0.1), transparent 64%), rgba(var(--v-theme-surface-variant), 0.1);
     }
 
     .dashboard-rail {


### PR DESCRIPTION
## Apply Vue formatting cleanup

### What changed

- Applied the repository’s Prettier formatting to:
  - `CardAsset.vue`
  - `DashboardView.vue`

### Why

These existing formatting differences caused the repository-wide Vue formatting check to fail.

### Validation

- Full Prettier check passes
- `git diff --check` passes

No functional behavior was changed.