### PR TITLE
Enforce Vue 3 configuration permissions

### DIFF
--- a/src/core/api/config.py
+++ b/src/core/api/config.py
@@ -50,7 +50,6 @@ from model import (
 from model.news_item import NewsItemAggregate
 from model.permission import Permission
 from model.state import StateDefinition, StateEntityType
-
 from shared.schema.ai_provider import AiProviderSchema
 from shared.schema.data_provider import DataProviderSchema
 from shared.schema.role import PermissionSchema
@@ -1276,7 +1275,7 @@ class RemoteAccessResource(Resource):
 class RemoteNodesResource(Resource):
     """Remote nodes API endpoint."""
 
-    @auth_required("CONFIG_REMOTE_ACCESS_ACCESS")
+    @auth_required("CONFIG_REMOTE_NODE_ACCESS")
     def get(self) -> tuple[str, dict]:
         """Get all remote nodes.
 
@@ -1286,7 +1285,7 @@ class RemoteNodesResource(Resource):
         search = request.args.get("search")
         return remote.RemoteNode.get_all_json(search)
 
-    @auth_required("CONFIG_REMOTE_ACCESS_CREATE")
+    @auth_required("CONFIG_REMOTE_NODE_CREATE")
     def post(self) -> tuple[dict, HTTPStatus] | None:
         """Create a remote node.
 
@@ -1304,7 +1303,7 @@ class RemoteNodesResource(Resource):
 class RemoteNodeResource(Resource):
     """Remote node API endpoint."""
 
-    @auth_required("CONFIG_REMOTE_ACCESS_UPDATE")
+    @auth_required("CONFIG_REMOTE_NODE_UPDATE")
     def put(self, remote_node_id: int) -> tuple[dict, HTTPStatus] | None:
         """Update a remote node.
 
@@ -1321,7 +1320,7 @@ class RemoteNodeResource(Resource):
             log_manager.store_data_error_activity(get_user_from_jwt(), msg, ex)
             return {"error": msg}, HTTPStatus.BAD_REQUEST
 
-    @auth_required("CONFIG_REMOTE_ACCESS_DELETE")
+    @auth_required("CONFIG_REMOTE_NODE_DELETE")
     def delete(self, remote_node_id: int) -> tuple[dict, HTTPStatus] | None:
         """Delete a remote node.
 
@@ -1342,7 +1341,7 @@ class RemoteNodeResource(Resource):
 class RemoteNodeConnectResource(Resource):
     """Remote node connect API endpoint."""
 
-    @auth_required("CONFIG_REMOTE_ACCESS_ACCESS")
+    @auth_required("CONFIG_REMOTE_NODE_UPDATE")
     def get(self, remote_node_id: int) -> tuple[dict, HTTPStatus]:
         """Connect to a remote node.
 

--- a/src/gui-v3/src/components/common/CardCompact.vue
+++ b/src/gui-v3/src/components/common/CardCompact.vue
@@ -352,9 +352,7 @@
         props.card?.product_type_name != null ? t('nav_menu.report_items') : t('card_item.aggregated_items')
     )
     const completedReportsCount = computed(() => Number(props.card?.completed_reports_count ?? 0))
-    const inProgressReportsCount = computed(() =>
-        Math.max(0, Number(props.card?.in_reports_count ?? 0) - completedReportsCount.value)
-    )
+    const inProgressReportsCount = computed(() => Math.max(0, Number(props.card?.in_reports_count ?? 0) - completedReportsCount.value))
     const stateLabel = computed(() => {
         const label = props.card?.state?.display_name || props.card?.state?.name || ''
         const key = `workflow.states.${label}`
@@ -404,10 +402,12 @@
     }
 
     const showDeleteDialog = (): void => {
+        if (!canDelete.value || isProtected.value) return
         deleteDialog.value = true
     }
 
     const handleDelete = (): void => {
+        if (!canDelete.value || isProtected.value) return
         deleteDialog.value = false
         emit('delete', props.card as CardData)
     }

--- a/src/gui-v3/src/components/common/ContentData.vue
+++ b/src/gui-v3/src/components/common/ContentData.vue
@@ -60,6 +60,8 @@
     import { computed } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { ICONS } from '@/config/ui-constants'
+    import { useAuth } from '@/composables/useAuth'
+    import type { PermissionKey } from '@/types/permissions'
 
     // Import available card components
     import CardCompact from '@/components/common/CardCompact.vue'
@@ -102,6 +104,7 @@
     const emit = defineEmits(['delete', 'edit', 'refresh'])
 
     const { t } = useI18n()
+    const { checkPermission } = useAuth()
 
     // Map of card component names to actual components
     const cardComponents: Record<string, any> = {
@@ -117,6 +120,7 @@
     const typedItems = computed<CardItem[]>(() => props.items as CardItem[])
 
     const handleDelete = (item: CardItem): void => {
+        if (!props.deletePermission || !checkPermission(props.deletePermission as PermissionKey)) return
         emit('delete', item)
     }
 

--- a/src/gui-v3/src/components/common/EditableEntityTable.vue
+++ b/src/gui-v3/src/components/common/EditableEntityTable.vue
@@ -14,7 +14,7 @@
                 class="flex-grow-0"
             />
             <div
-                v-if="!disabled"
+                v-if="canAdd"
                 class="ms-3"
             >
                 <AddNewButton @click="openDialog()" />
@@ -41,26 +41,26 @@
 
             <template #item.actions="{ item, index }">
                 <ActionButton
-                    v-if="reorderable && !disabled"
+                    v-if="reorderable && canEdit"
                     icon="mdi-arrow-up-bold"
                     :title="t('common.up')"
                     @click="move(index, -1)"
                 />
                 <ActionButton
-                    v-if="reorderable && !disabled"
+                    v-if="reorderable && canEdit"
                     icon="mdi-arrow-down-bold"
                     :title="t('common.down')"
                     @click="move(index, 1)"
                 />
                 <ActionButton
-                    v-if="!disabled"
+                    v-if="canEdit"
                     action="edit"
                     :title="t('common.edit')"
                     class="mr-1"
                     @click="openDialog(item as Row, index)"
                 />
                 <ActionButton
-                    v-if="!disabled"
+                    v-if="canDelete"
                     action="delete"
                     :title="t('common.delete')"
                     @click="remove(item as Row, index)"
@@ -88,12 +88,14 @@
                 :title="editedIndex === -1 ? addTitle : editTitle"
                 :saving="saving"
                 :save-disabled="saveDisabled"
+                :show-save="editedIndex === -1 ? canAdd : canEdit"
                 @cancel="requestClose"
                 @save="save"
             />
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="editedIndex === -1 ? !canAdd : !canEdit"
                     @submit.prevent="save"
                 >
                     <!-- Caller supplies the edit fields, bound to the working copy. -->
@@ -149,6 +151,10 @@
             editTitle: string
             dialogMaxWidth?: string | number
             disabled?: boolean
+            /** Fine-grained row permissions; `disabled` still overrides all three. */
+            allowAdd?: boolean
+            allowEdit?: boolean
+            allowDelete?: boolean
             reorderable?: boolean
             searchable?: boolean
             noDataText?: string
@@ -166,6 +172,9 @@
         {
             dialogMaxWidth: 600,
             disabled: false,
+            allowAdd: true,
+            allowEdit: true,
+            allowDelete: true,
             reorderable: false,
             searchable: false,
             noDataText: '',
@@ -202,6 +211,9 @@
     const editedItem = ref(props.defaultItem()) as Ref<Row>
 
     const rows = computed<Row[]>(() => (props.server ? (props.items ?? []) : model.value))
+    const canAdd = computed(() => !props.disabled && props.allowAdd)
+    const canEdit = computed(() => !props.disabled && props.allowEdit)
+    const canDelete = computed(() => !props.disabled && props.allowDelete)
 
     // Forward every "item.*"/cell slot the caller passes, except the actions column
     // (which this component renders) and the form slot (used by the dialog).
@@ -233,6 +245,7 @@
     })
 
     const openDialog = (item?: Row, index = -1): void => {
+        if (index === -1 ? !canAdd.value : !canEdit.value) return
         editedIndex.value = index
         editedItem.value = item ? ({ ...item } as Row) : props.defaultItem()
         formRef.value?.resetValidation?.()
@@ -257,6 +270,7 @@
     }
 
     const save = async (): Promise<void> => {
+        if (editedIndex.value === -1 ? !canAdd.value : !canEdit.value) return
         const result = await formRef.value?.validate()
         if (result && !result.valid) {
             return
@@ -281,6 +295,7 @@
     }
 
     const remove = (item: Row, index: number): void => {
+        if (!canDelete.value) return
         if (props.server) {
             emit('delete', item, index)
             return
@@ -292,6 +307,7 @@
     }
 
     const move = (index: number, offset: number): void => {
+        if (!canEdit.value) return
         const target = index + offset
         const list = [...model.value]
         if (target < 0 || target >= list.length) {

--- a/src/gui-v3/src/components/common/nodes/NodeDialog.vue
+++ b/src/gui-v3/src/components/common/nodes/NodeDialog.vue
@@ -17,6 +17,7 @@
             <DialogToolbar
                 :title="isEdit ? t(`${config.i18nPrefix}.edit`) : t(`${config.i18nPrefix}.add_new`)"
                 :saving="saving"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -24,6 +25,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-text-field
@@ -166,10 +168,12 @@
     const isEdit = computed(() => !!localItem.value.id)
 
     const canCreate = computed(() => checkPermission(`${config.value.permissionPrefix}_CREATE` as PermissionKey))
+    const canSave = computed(() => checkPermission(`${config.value.permissionPrefix}_${isEdit.value ? 'UPDATE' : 'CREATE'}` as PermissionKey))
 
     // Persists the form. Returns true on success so the unsaved-changes guard can
     // decide whether to close the dialog (it closes only on a successful save).
     async function persist(): Promise<boolean> {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/SettingsTable.vue
+++ b/src/gui-v3/src/components/config/SettingsTable.vue
@@ -42,6 +42,7 @@
                             color="primary"
                             hide-details
                             density="compact"
+                            :disabled="!canEditSettings"
                             @update:model-value="(val) => updateSetting(item, val ? 'true' : 'false')"
                         />
                     </template>
@@ -57,6 +58,7 @@
                             density="compact"
                             hide-details
                             :prepend-inner-icon="getSelectIcon(item)"
+                            :disabled="!canEditSettings"
                             @update:model-value="(val) => updateSetting(item, val)"
                         />
                     </template>
@@ -66,7 +68,7 @@
                         <v-chip
                             :color="getColor(item.value, item.default_val)"
                             label
-                            clickable
+                            :clickable="canEditSettings"
                             @click="openEditDialog(item)"
                         >
                             {{ item.value }}
@@ -126,6 +128,7 @@
                     {{ t('common.cancel') }}
                 </v-btn>
                 <v-btn
+                    v-if="canEditSettings"
                     color="primary"
                     variant="text"
                     @click="saveEdit"
@@ -141,6 +144,7 @@
     import { ref, computed, onMounted, watch } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useTheme } from 'vuetify'
+    import { useAuth } from '@/composables/useAuth'
     import { useSettingsStore } from '@/stores/settings'
     import { supportedLocales } from '@/i18n'
     import { Settings, type SettingKey } from '@/types/settings'
@@ -181,6 +185,7 @@
 
     const { t, te, locale } = useI18n()
     const theme = useTheme()
+    const { checkPermission } = useAuth()
     const settingsStore = useSettingsStore()
 
     const applyTheme = (themeName: string): void => {
@@ -197,6 +202,7 @@
     const editDialog = ref(false)
     const editValue = ref('')
     const editItem = ref<SettingsRecord | null>(null)
+    const canEditSettings = computed(() => !props.globalSetting || checkPermission('CONFIG_SETTINGS_UPDATE'))
 
     const maxCharsRule = (value: string | null | undefined): true | string => !value || value.length <= 150 || 'Input too long!'
 
@@ -356,6 +362,7 @@
     }
 
     const updateSetting = async (item: SettingsRecord, value: string): Promise<void> => {
+        if (!canEditSettings.value) return
         try {
             const validatedValue = validateValue(item, value)
             const settingData = {
@@ -391,12 +398,14 @@
     }
 
     const openEditDialog = (item: SettingsRecord): void => {
+        if (!canEditSettings.value) return
         editItem.value = item
         editValue.value = item.value
         editDialog.value = true
     }
 
     const saveEdit = (): void => {
+        if (!canEditSettings.value) return
         if (editItem.value && editValue.value !== null) {
             updateSetting(editItem.value, editValue.value)
         }

--- a/src/gui-v3/src/components/config/access-management/ACLTab.vue
+++ b/src/gui-v3/src/components/config/access-management/ACLTab.vue
@@ -51,6 +51,7 @@
                         @click="handleEdit(asACLItem(item))"
                     />
                     <ActionButton
+                        v-if="canDelete"
                         action="delete"
                         :title="t('common.delete')"
                         @click="handleDelete(asACLItem(item))"
@@ -69,7 +70,7 @@
 </template>
 
 <script setup lang="ts">
-    import { ref, onMounted } from 'vue'
+    import { computed, ref, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useConfigStore } from '@/stores/config'
     import { deleteACLEntry } from '@/api/config'
@@ -78,6 +79,7 @@
     import ActionButton from '@/components/common/buttons/ActionButton.vue'
     import ConfirmationDialog from '@/components/common/dialogs/ConfirmationDialog.vue'
     import SearchField from '@/components/common/SearchField.vue'
+    import { useAuth } from '@/composables/useAuth'
 
     type HeaderEntry = {
         title: string
@@ -96,6 +98,8 @@
 
     const { t } = useI18n()
     const configStore = useConfigStore()
+    const { checkPermission } = useAuth()
+    const canDelete = computed(() => checkPermission('CONFIG_ACL_DELETE'))
 
     const search = ref('')
     const editItem = ref<ACLItem | null>(null)
@@ -125,12 +129,13 @@
     }
 
     const handleDelete = (item: ACLItem): void => {
+        if (!canDelete.value) return
         itemToDelete.value = item
         deleteDialog.value = true
     }
 
     const confirmDelete = async (): Promise<void> => {
-        if (!itemToDelete.value) {
+        if (!canDelete.value || !itemToDelete.value) {
             return
         }
         try {

--- a/src/gui-v3/src/components/config/access-management/NewACL.vue
+++ b/src/gui-v3/src/components/config/access-management/NewACL.vue
@@ -17,6 +17,7 @@
             <DialogToolbar
                 :title="isEdit ? t('access_management.acls.edit') : t('access_management.acls.add_new')"
                 :saving="saving"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -24,6 +25,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-text-field
@@ -106,7 +108,7 @@
                         :items="users"
                         :headers="userHeaders"
                         :loading="loadingRecipients"
-                        :disabled="saving || localItem.everyone"
+                        :disabled="saving || !canSave || localItem.everyone"
                     />
 
                     <EntitySelectTable
@@ -115,7 +117,7 @@
                         :items="roles"
                         :headers="roleHeaders"
                         :loading="loadingRecipients"
-                        :disabled="saving || localItem.everyone"
+                        :disabled="saving || !canSave || localItem.everyone"
                     />
                 </v-form>
 
@@ -266,6 +268,7 @@
     const isEdit = computed(() => !!localItem.value.id)
 
     const canCreate = computed(() => checkPermission('CONFIG_ACL_CREATE'))
+    const canSave = computed(() => checkPermission(isEdit.value ? 'CONFIG_ACL_UPDATE' : 'CONFIG_ACL_CREATE'))
 
     // Recipients (users / roles) the ACL is granted to.
     const users = ref<UserOption[]>([])
@@ -385,6 +388,7 @@
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     async function persist(): Promise<boolean> {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/access-management/NewOrganization.vue
+++ b/src/gui-v3/src/components/config/access-management/NewOrganization.vue
@@ -17,6 +17,7 @@
             <DialogToolbar
                 :title="isEdit ? t('access_management.organizations.edit') : t('access_management.organizations.add_new')"
                 :saving="saving"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -24,6 +25,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-text-field
@@ -175,9 +177,11 @@
 
     const isEdit = computed(() => !!localItem.value.id)
     const canCreate = computed(() => checkPermission('CONFIG_ORGANIZATION_CREATE'))
+    const canSave = computed(() => checkPermission(isEdit.value ? 'CONFIG_ORGANIZATION_UPDATE' : 'CONFIG_ORGANIZATION_CREATE'))
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     async function persist(): Promise<boolean> {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/access-management/NewRole.vue
+++ b/src/gui-v3/src/components/config/access-management/NewRole.vue
@@ -17,6 +17,7 @@
             <DialogToolbar
                 :title="isEdit ? t('access_management.roles.edit') : t('access_management.roles.add_new')"
                 :saving="saving"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -24,6 +25,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-text-field
@@ -33,7 +35,7 @@
                         density="comfortable"
                         class="mb-3"
                         :rules="[(v) => !!v || t('error.required')]"
-                        :disabled="saving"
+                        :disabled="saving || !canSave"
                     />
 
                     <v-textarea
@@ -176,7 +178,7 @@
 
     const isEdit = computed(() => !!localItem.value.id)
     const canCreate = computed(() => checkPermission('CONFIG_ROLE_CREATE'))
-    const canUpdate = computed(() => checkPermission('CONFIG_ROLE_UPDATE') || !isEdit.value)
+    const canSave = computed(() => checkPermission(isEdit.value ? 'CONFIG_ROLE_UPDATE' : 'CONFIG_ROLE_CREATE'))
 
     const loadPermissions = async (): Promise<void> => {
         loadingPermissions.value = true
@@ -194,6 +196,7 @@
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     async function persist(): Promise<boolean> {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/access-management/NewUser.vue
+++ b/src/gui-v3/src/components/config/access-management/NewUser.vue
@@ -17,6 +17,7 @@
             <DialogToolbar
                 :title="isEdit ? t('access_management.users.edit') : t('access_management.users.add_new')"
                 :saving="saving"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -24,6 +25,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-row>
@@ -88,7 +90,7 @@
                         :items="organizations"
                         :headers="orgHeaders"
                         :loading="loadingOrganizations"
-                        :disabled="saving"
+                        :disabled="saving || !canSave"
                     />
 
                     <!-- Roles Selection -->
@@ -98,7 +100,7 @@
                         :items="roles"
                         :headers="roleHeaders"
                         :loading="loadingRoles"
-                        :disabled="saving"
+                        :disabled="saving || !canSave"
                     />
 
                     <!-- Permissions Selection -->
@@ -108,7 +110,7 @@
                         :items="permissions"
                         :headers="permissionHeaders"
                         :loading="loadingPermissions"
-                        :disabled="saving"
+                        :disabled="saving || !canSave"
                     />
 
                     <v-alert
@@ -239,6 +241,7 @@
 
     const isEdit = computed(() => !!localItem.value.id)
     const canCreate = computed(() => checkPermission('CONFIG_USER_CREATE'))
+    const canSave = computed(() => checkPermission(isEdit.value ? 'CONFIG_USER_UPDATE' : 'CONFIG_USER_CREATE'))
 
     const passwordRules = computed(() => {
         if (isEdit.value) {
@@ -360,6 +363,7 @@
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     const persist = async (): Promise<boolean> => {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/access-management/OrganizationsTab.vue
+++ b/src/gui-v3/src/components/config/access-management/OrganizationsTab.vue
@@ -47,6 +47,7 @@
                         @click="handleEdit(asOrganizationItem(item))"
                     />
                     <ActionButton
+                        v-if="canDelete"
                         action="delete"
                         :title="t('common.delete')"
                         @click="handleDelete(asOrganizationItem(item))"
@@ -65,7 +66,7 @@
 </template>
 
 <script setup lang="ts">
-    import { ref, onMounted } from 'vue'
+    import { computed, ref, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useConfigStore } from '@/stores/config'
     import { deleteOrganization } from '@/api/config'
@@ -73,6 +74,7 @@
     import ActionButton from '@/components/common/buttons/ActionButton.vue'
     import ConfirmationDialog from '@/components/common/dialogs/ConfirmationDialog.vue'
     import SearchField from '@/components/common/SearchField.vue'
+    import { useAuth } from '@/composables/useAuth'
 
     type HeaderEntry = {
         title: string
@@ -90,6 +92,8 @@
 
     const { t } = useI18n()
     const configStore = useConfigStore()
+    const { checkPermission } = useAuth()
+    const canDelete = computed(() => checkPermission('CONFIG_ORGANIZATION_DELETE'))
 
     const search = ref('')
     const editItem = ref<OrganizationItem | null>(null)
@@ -118,12 +122,13 @@
     }
 
     const handleDelete = (item: OrganizationItem): void => {
+        if (!canDelete.value) return
         itemToDelete.value = item
         deleteDialog.value = true
     }
 
     const confirmDelete = async (): Promise<void> => {
-        if (!itemToDelete.value) {
+        if (!canDelete.value || !itemToDelete.value) {
             return
         }
         try {

--- a/src/gui-v3/src/components/config/access-management/RolesTab.vue
+++ b/src/gui-v3/src/components/config/access-management/RolesTab.vue
@@ -47,6 +47,7 @@
                         @click="handleEdit(asRoleItem(item))"
                     />
                     <ActionButton
+                        v-if="canDelete"
                         action="delete"
                         :title="t('common.delete')"
                         @click="handleDelete(asRoleItem(item))"
@@ -65,7 +66,7 @@
 </template>
 
 <script setup lang="ts">
-    import { ref, onMounted } from 'vue'
+    import { computed, ref, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useConfigStore } from '@/stores/config'
     import { deleteRole } from '@/api/config'
@@ -73,6 +74,7 @@
     import ActionButton from '@/components/common/buttons/ActionButton.vue'
     import ConfirmationDialog from '@/components/common/dialogs/ConfirmationDialog.vue'
     import SearchField from '@/components/common/SearchField.vue'
+    import { useAuth } from '@/composables/useAuth'
 
     type HeaderEntry = {
         title: string
@@ -90,6 +92,8 @@
 
     const { t } = useI18n()
     const configStore = useConfigStore()
+    const { checkPermission } = useAuth()
+    const canDelete = computed(() => checkPermission('CONFIG_ROLE_DELETE'))
 
     const search = ref('')
     const editItem = ref<RoleItem | null>(null)
@@ -118,12 +122,13 @@
     }
 
     const handleDelete = (item: RoleItem): void => {
+        if (!canDelete.value) return
         itemToDelete.value = item
         deleteDialog.value = true
     }
 
     const confirmDelete = async (): Promise<void> => {
-        if (!itemToDelete.value) {
+        if (!canDelete.value || !itemToDelete.value) {
             return
         }
         try {

--- a/src/gui-v3/src/components/config/access-management/UsersTab.vue
+++ b/src/gui-v3/src/components/config/access-management/UsersTab.vue
@@ -58,6 +58,7 @@
                         @click="handleEdit(asUserItem(item))"
                     />
                     <ActionButton
+                        v-if="canDelete"
                         action="delete"
                         :title="t('common.delete')"
                         @click="handleDelete(asUserItem(item))"
@@ -76,7 +77,7 @@
 </template>
 
 <script setup lang="ts">
-    import { ref, onMounted } from 'vue'
+    import { computed, ref, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useConfigStore } from '@/stores/config'
     import { deleteUser } from '@/api/config'
@@ -84,6 +85,7 @@
     import ActionButton from '@/components/common/buttons/ActionButton.vue'
     import ConfirmationDialog from '@/components/common/dialogs/ConfirmationDialog.vue'
     import SearchField from '@/components/common/SearchField.vue'
+    import { useAuth } from '@/composables/useAuth'
 
     type HeaderEntry = {
         title: string
@@ -107,6 +109,8 @@
 
     const { t } = useI18n()
     const configStore = useConfigStore()
+    const { checkPermission } = useAuth()
+    const canDelete = computed(() => checkPermission('CONFIG_USER_DELETE'))
 
     const search = ref('')
     const editItem = ref<UserItem | null>(null)
@@ -136,12 +140,13 @@
     }
 
     const handleDelete = (item: UserItem): void => {
+        if (!canDelete.value) return
         itemToDelete.value = item
         deleteDialog.value = true
     }
 
     const confirmDelete = async (): Promise<void> => {
-        if (!itemToDelete.value) {
+        if (!canDelete.value || !itemToDelete.value) {
             return
         }
         try {

--- a/src/gui-v3/src/components/config/bots/NewBotPreset.vue
+++ b/src/gui-v3/src/components/config/bots/NewBotPreset.vue
@@ -19,6 +19,7 @@
                 :title="isEdit ? t('bots.presets.edit') : t('bots.presets.add_new')"
                 :saving="saving"
                 :save-disabled="!selectedBot"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -26,6 +27,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-select
@@ -241,6 +243,7 @@
 
     const isEdit = computed(() => !!localItem.value.id)
     const canCreate = computed(() => checkPermission('CONFIG_BOT_PRESET_CREATE'))
+    const canSave = computed(() => checkPermission(isEdit.value ? 'CONFIG_BOT_PRESET_UPDATE' : 'CONFIG_BOT_PRESET_CREATE'))
 
     // Watch for edit item changes
     watch(
@@ -362,6 +365,7 @@
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     const persist = async (): Promise<boolean> => {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/collectors/NewOSINTSource.vue
+++ b/src/gui-v3/src/components/config/collectors/NewOSINTSource.vue
@@ -18,7 +18,8 @@
             <DialogToolbar
                 :title="isEdit ? t('collectors.sources.edit') : t('collectors.sources.add_new')"
                 :saving="saving"
-                :save-disabled="!selectedCollector || !canUpdate"
+                :save-disabled="!selectedCollector"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -26,6 +27,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-select
@@ -38,7 +40,7 @@
                         variant="outlined"
                         density="comfortable"
                         class="mb-3"
-                        :disabled="isEdit || saving || loadingNodes || !canUpdate"
+                        :disabled="isEdit || saving || loadingNodes || !canSave"
                         :loading="loadingNodes"
                         :rules="[(v) => !!v || t('error.required')]"
                     />
@@ -54,7 +56,7 @@
                         variant="outlined"
                         density="comfortable"
                         class="mb-3"
-                        :disabled="isEdit || saving || !canUpdate"
+                        :disabled="isEdit || saving || !canSave"
                         :rules="[(v) => !!v || t('error.required')]"
                     />
 
@@ -66,7 +68,7 @@
                         density="comfortable"
                         class="mb-3"
                         :rules="[(v) => !!v || t('error.required')]"
-                        :disabled="saving || !canUpdate"
+                        :disabled="saving || !canSave"
                     />
 
                     <v-textarea
@@ -77,7 +79,7 @@
                         density="comfortable"
                         rows="3"
                         class="mb-3"
-                        :disabled="saving || !canUpdate"
+                        :disabled="saving || !canSave"
                     />
 
                     <div v-if="selectedCollector && selectedCollector.parameters && selectedCollector.parameters.length > 0">
@@ -95,7 +97,7 @@
                                 :type="typeof param.key === 'string' && param.key.includes('PASSWORD') ? 'password' : 'text'"
                                 variant="outlined"
                                 density="comfortable"
-                                :disabled="saving || !canUpdate"
+                                :disabled="saving || !canSave"
                                 :placeholder="String(param.default_value ?? '')"
                             >
                                 <template
@@ -122,7 +124,7 @@
                             :items="osintSourceGroupItems"
                             :headers="groupHeaders"
                             :loading="loadingGroups"
-                            :disabled="saving || !canUpdate"
+                            :disabled="saving || !canSave"
                         >
                             <template #header-append>
                                 <NewOSINTSourceGroup @saved="handleGroupSaved" />
@@ -135,7 +137,7 @@
                             :items="wordListItems"
                             :headers="wordListHeaders"
                             :loading="loadingWordLists"
-                            :disabled="saving || !canUpdate"
+                            :disabled="saving || !canSave"
                         />
                     </div>
                 </v-form>
@@ -311,7 +313,7 @@
 
     const isEdit = computed(() => !!localItem.value.id)
     const canCreate = computed(() => checkPermission('CONFIG_OSINT_SOURCE_CREATE'))
-    const canUpdate = computed(() => checkPermission('CONFIG_OSINT_SOURCE_UPDATE') || !isEdit.value)
+    const canSave = computed(() => checkPermission(isEdit.value ? 'CONFIG_OSINT_SOURCE_UPDATE' : 'CONFIG_OSINT_SOURCE_CREATE'))
 
     const wordListItems = computed(() => configStore.wordLists.items as IdItem[])
     const osintSourceGroupItems = computed(() => {
@@ -442,6 +444,7 @@
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     async function persist(): Promise<boolean> {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/collectors/NewOSINTSourceGroup.vue
+++ b/src/gui-v3/src/components/config/collectors/NewOSINTSourceGroup.vue
@@ -17,7 +17,7 @@
             <DialogToolbar
                 :title="isEdit ? t('collectors.groups.edit') : t('collectors.groups.add_new')"
                 :saving="saving"
-                :show-save="!isReadOnly"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -25,6 +25,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-text-field
@@ -34,7 +35,7 @@
                         density="comfortable"
                         class="mb-3"
                         :rules="[(v) => !!v || t('error.required')]"
-                        :disabled="saving || isReadOnly"
+                        :disabled="saving || !canSave"
                     />
 
                     <v-textarea
@@ -44,7 +45,7 @@
                         density="comfortable"
                         rows="3"
                         class="mb-3"
-                        :disabled="saving || isReadOnly"
+                        :disabled="saving || !canSave"
                     />
 
                     <!-- OSINT sources that belong to this group -->
@@ -54,7 +55,7 @@
                         :items="sourceItems"
                         :headers="sourceHeaders"
                         :loading="loadingSources"
-                        :disabled="saving || isReadOnly"
+                        :disabled="saving || !canSave"
                     />
                 </v-form>
 
@@ -161,9 +162,12 @@
     const localItem = ref<OSINTSourceGroupItem>({ ...defaultItem })
     const isEdit = computed(() => !!localItem.value.id)
     // The default group cannot be modified (backend forbids it): open it as a read-only view.
-    const isReadOnly = computed(() => localItem.value.default === true)
-
     const canCreate = computed(() => checkPermission('CONFIG_OSINT_SOURCE_GROUP_CREATE'))
+    const canSave = computed(
+        () =>
+            localItem.value.default !== true &&
+            checkPermission(isEdit.value ? 'CONFIG_OSINT_SOURCE_GROUP_UPDATE' : 'CONFIG_OSINT_SOURCE_GROUP_CREATE')
+    )
 
     onMounted(async () => {
         // Load all sources so they can be assigned to the group.
@@ -179,6 +183,7 @@
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     async function persist(): Promise<boolean> {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/presenters/NewProductType.vue
+++ b/src/gui-v3/src/components/config/presenters/NewProductType.vue
@@ -18,7 +18,8 @@
             <DialogToolbar
                 :title="isEdit ? t('presenters.types.edit') : t('presenters.types.add_new')"
                 :saving="saving"
-                :save-disabled="!selectedPresenter || !canUpdate"
+                :save-disabled="!selectedPresenter"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -26,6 +27,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-select
@@ -38,7 +40,7 @@
                         variant="outlined"
                         density="comfortable"
                         class="mb-3"
-                        :disabled="isEdit || saving || loadingNodes || !canUpdate"
+                        :disabled="isEdit || saving || loadingNodes || !canSave"
                         :loading="loadingNodes"
                         :rules="[(v) => !!v || t('error.required')]"
                     />
@@ -54,7 +56,7 @@
                         variant="outlined"
                         density="comfortable"
                         class="mb-3"
-                        :disabled="isEdit || saving || !canUpdate"
+                        :disabled="isEdit || saving || !canSave"
                         :rules="[(v) => !!v || t('error.required')]"
                     />
 
@@ -66,7 +68,7 @@
                         density="comfortable"
                         class="mb-3"
                         :rules="[(v) => !!v || t('error.required')]"
-                        :disabled="saving || !canUpdate"
+                        :disabled="saving || !canSave"
                     />
 
                     <v-textarea
@@ -77,7 +79,7 @@
                         density="comfortable"
                         rows="3"
                         class="mb-3"
-                        :disabled="saving || !canUpdate"
+                        :disabled="saving || !canSave"
                     />
 
                     <div v-if="selectedPresenter && selectedPresenter.parameters && selectedPresenter.parameters.length > 0">
@@ -106,7 +108,7 @@
                                 :label="String(param.name || param.key || '')"
                                 variant="outlined"
                                 density="comfortable"
-                                :disabled="saving || !canUpdate"
+                                :disabled="saving || !canSave"
                                 :placeholder="String(param.default_value ?? '')"
                             >
                                 <template
@@ -387,7 +389,7 @@
 
     const isEdit = computed(() => !!localItem.value.id)
     const canCreate = computed(() => checkPermission('CONFIG_PRODUCT_TYPE_CREATE'))
-    const canUpdate = computed(() => checkPermission('CONFIG_PRODUCT_TYPE_UPDATE') || !isEdit.value)
+    const canSave = computed(() => checkPermission(isEdit.value ? 'CONFIG_PRODUCT_TYPE_UPDATE' : 'CONFIG_PRODUCT_TYPE_CREATE'))
 
     const mapParameterValues = (presenter: Presenter, incomingValues: ParameterValue[] = []): string[] => {
         return (
@@ -468,6 +470,7 @@
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     async function persist(): Promise<boolean> {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/publishers/NewPublisherPreset.vue
+++ b/src/gui-v3/src/components/config/publishers/NewPublisherPreset.vue
@@ -19,6 +19,7 @@
                 :title="isEdit ? t('publishers.presets.edit') : t('publishers.presets.add_new')"
                 :saving="saving"
                 :save-disabled="!selectedPublisher"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -26,6 +27,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-select
@@ -253,6 +255,7 @@
 
     const isEdit = computed(() => !!localItem.value.id)
     const canCreate = computed(() => checkPermission('CONFIG_PUBLISHER_PRESET_CREATE'))
+    const canSave = computed(() => checkPermission(isEdit.value ? 'CONFIG_PUBLISHER_PRESET_UPDATE' : 'CONFIG_PUBLISHER_PRESET_CREATE'))
 
     // Watch for edit item changes
     watch(
@@ -377,6 +380,7 @@
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     const persist = async (): Promise<boolean> => {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/remote/NewRemoteAccess.vue
+++ b/src/gui-v3/src/components/config/remote/NewRemoteAccess.vue
@@ -17,6 +17,7 @@
             <DialogToolbar
                 :title="isEdit ? t('remote.access.edit') : t('remote.access.add_new')"
                 :saving="saving"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -24,6 +25,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-text-field
@@ -207,6 +209,7 @@
     const isEdit = computed(() => !!localItem.value.id)
 
     const canCreate = computed(() => checkPermission('CONFIG_REMOTE_ACCESS_CREATE'))
+    const canSave = computed(() => checkPermission(isEdit.value ? 'CONFIG_REMOTE_ACCESS_UPDATE' : 'CONFIG_REMOTE_ACCESS_CREATE'))
 
     onMounted(async () => {
         await Promise.all([loadOsintSources(), loadReportItemTypes()])
@@ -244,6 +247,7 @@
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     async function persist(): Promise<boolean> {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/remote/NewRemoteNode.vue
+++ b/src/gui-v3/src/components/config/remote/NewRemoteNode.vue
@@ -17,6 +17,7 @@
             <DialogToolbar
                 :title="isEdit ? t('remote.nodes.edit') : t('remote.nodes.add_new')"
                 :saving="saving"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -24,6 +25,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-text-field
@@ -275,6 +277,7 @@
     const isEdit = computed(() => !!localItem.value.id)
 
     const canCreate = computed(() => checkPermission('CONFIG_REMOTE_NODE_CREATE'))
+    const canSave = computed(() => checkPermission(isEdit.value ? 'CONFIG_REMOTE_NODE_UPDATE' : 'CONFIG_REMOTE_NODE_CREATE'))
 
     // Connecting needs a persisted node id (GET /remote-nodes/{id}/connect), so the
     // button is only offered once the node exists (edit mode) and is enabled.
@@ -298,6 +301,7 @@
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     async function persist(): Promise<boolean> {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/reports/AttributesTab.vue
+++ b/src/gui-v3/src/components/config/reports/AttributesTab.vue
@@ -48,6 +48,7 @@
                         @click="handleEdit(asAttributeItem(item))"
                     />
                     <ActionButton
+                        v-if="canDelete"
                         action="delete"
                         :title="t('common.delete')"
                         @click="handleDelete(asAttributeItem(item))"
@@ -59,7 +60,7 @@
 </template>
 
 <script setup lang="ts">
-    import { ref, onMounted, nextTick } from 'vue'
+    import { computed, ref, onMounted, nextTick } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useConfigStore } from '@/stores/config'
     import { deleteAttribute } from '@/api/config'
@@ -67,6 +68,7 @@
     import NewAttribute from '@/components/config/reports/NewAttribute.vue'
     import ActionButton from '@/components/common/buttons/ActionButton.vue'
     import SearchField from '@/components/common/SearchField.vue'
+    import { useAuth } from '@/composables/useAuth'
 
     // Representative icon per attribute type.
     const TYPE_ICONS: Record<string, string> = {
@@ -105,6 +107,8 @@
 
     const { t } = useI18n()
     const configStore = useConfigStore()
+    const { checkPermission } = useAuth()
+    const canDelete = computed(() => checkPermission('CONFIG_ATTRIBUTE_DELETE'))
 
     const search = ref('')
     const loading = ref(false)
@@ -138,6 +142,7 @@
     }
 
     const handleDelete = async (item: AttributeItem): Promise<void> => {
+        if (!canDelete.value) return
         try {
             await deleteAttribute(item)
             await loadData()

--- a/src/gui-v3/src/components/config/reports/NewAttribute.vue
+++ b/src/gui-v3/src/components/config/reports/NewAttribute.vue
@@ -17,6 +17,7 @@
             <DialogToolbar
                 :title="isEdit ? t('reports.attributes.edit') : t('reports.attributes.add_new')"
                 :saving="saving"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -24,6 +25,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-text-field
@@ -33,7 +35,7 @@
                         density="comfortable"
                         class="mb-3"
                         :rules="[(v) => !!v || t('error.required')]"
-                        :disabled="saving"
+                        :disabled="saving || !canSave"
                     />
 
                     <v-textarea
@@ -43,7 +45,7 @@
                         density="comfortable"
                         rows="3"
                         class="mb-3"
-                        :disabled="saving"
+                        :disabled="saving || !canSave"
                     />
 
                     <v-row>
@@ -118,7 +120,8 @@
                         :add-title="t('reports.attributes.add_constant')"
                         :edit-title="t('reports.attributes.edit_constant')"
                         :saving="constantSaving"
-                        :disabled="saving"
+                        :disabled="saving || !canSave"
+                        :allow-delete="canDeleteConstants"
                         dialog-max-width="500"
                         @update:options="onConstantsOptions"
                         @save="onConstantSave"
@@ -131,14 +134,14 @@
                                 variant="outlined"
                                 density="comfortable"
                                 class="mb-3"
-                                :disabled="constantSaving"
+                                :disabled="constantSaving || !canSave"
                             />
                             <v-text-field
                                 v-model="item.description"
                                 :label="t('reports.attributes.description')"
                                 variant="outlined"
                                 density="comfortable"
-                                :disabled="constantSaving"
+                                :disabled="constantSaving || !canSave"
                             />
                         </template>
                     </EditableEntityTable>
@@ -307,6 +310,9 @@
     const isEdit = computed(() => !!localItem.value.id)
 
     const canCreate = computed(() => checkPermission('CONFIG_ATTRIBUTE_CREATE'))
+    const canUpdate = computed(() => checkPermission('CONFIG_ATTRIBUTE_UPDATE'))
+    const canSave = computed(() => (isEdit.value ? canUpdate.value : canCreate.value))
+    const canDeleteConstants = computed(() => canSave.value && (!isEdit.value || checkPermission('CONFIG_ATTRIBUTE_DELETE')))
 
     // --- Attribute constants (enums) ---
     const constants = ref<AttributeConstant[]>([])
@@ -415,6 +421,7 @@
     }
 
     const onConstantDelete = async (constant: AttributeConstant): Promise<void> => {
+        if (!canDeleteConstants.value) return
         try {
             if (isEdit.value && localItem.value.id !== null) {
                 await deleteAttributeEnum(localItem.value.id, constant.id)
@@ -431,6 +438,7 @@
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     async function persist(): Promise<boolean> {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/reports/NewReportType.vue
+++ b/src/gui-v3/src/components/config/reports/NewReportType.vue
@@ -17,6 +17,7 @@
             <DialogToolbar
                 :title="isEdit ? t('reports.types.edit') : t('reports.types.add_new')"
                 :saving="saving"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -24,6 +25,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-text-field
@@ -53,7 +55,7 @@
                         </h3>
                         <v-spacer />
                         <AddNewButton
-                            :disabled="saving"
+                            :disabled="saving || !canSave"
                             @click="addGroup"
                         />
                     </div>
@@ -72,19 +74,19 @@
                             <ActionButton
                                 icon="mdi-arrow-up-bold"
                                 :title="t('common.up')"
-                                :disabled="saving"
+                                :disabled="saving || !canSave"
                                 @click="moveGroup(index, -1)"
                             />
                             <ActionButton
                                 icon="mdi-arrow-down-bold"
                                 :title="t('common.down')"
-                                :disabled="saving"
+                                :disabled="saving || !canSave"
                                 @click="moveGroup(index, 1)"
                             />
                             <ActionButton
                                 action="delete"
                                 :title="t('common.delete')"
-                                :disabled="saving"
+                                :disabled="saving || !canSave"
                                 @click="deleteGroup(index)"
                             />
                         </v-toolbar>
@@ -96,7 +98,7 @@
                                 variant="outlined"
                                 density="comfortable"
                                 class="mb-3"
-                                :disabled="saving"
+                                :disabled="saving || !canSave"
                             />
                             <v-textarea
                                 v-model="group.description"
@@ -120,7 +122,7 @@
                                 v-model="group.attribute_group_items"
                                 :attribute-templates="attributeTemplates"
                                 :ai-providers="aiProviders"
-                                :disabled="saving"
+                                :disabled="saving || !canSave"
                             />
                         </v-card-text>
                     </v-card>
@@ -252,6 +254,7 @@
     const isEdit = computed(() => !!localItem.value.id)
 
     const canCreate = computed(() => checkPermission('CONFIG_REPORT_TYPE_CREATE'))
+    const canSave = computed(() => checkPermission(isEdit.value ? 'CONFIG_REPORT_TYPE_UPDATE' : 'CONFIG_REPORT_TYPE_CREATE'))
 
     const notify = (type: 'success' | 'error', loc: string): void => {
         window.dispatchEvent(new CustomEvent('notification', { detail: { type, loc } }))
@@ -353,6 +356,7 @@
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     async function persist(): Promise<boolean> {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/word-lists/NewWordList.vue
+++ b/src/gui-v3/src/components/config/word-lists/NewWordList.vue
@@ -17,6 +17,7 @@
             <DialogToolbar
                 :title="isEdit ? t('word_lists.edit') : t('word_lists.add_new')"
                 :saving="saving"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -24,6 +25,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-row>
@@ -68,7 +70,7 @@
                         :add-title="t('word_lists.add_category')"
                         :edit-title="t('word_lists.edit_category')"
                         :no-data-text="t('word_lists.no_categories')"
-                        :disabled="saving"
+                        :disabled="saving || !canSave"
                         dialog-max-width="900"
                     >
                         <template #item.name="{ item }">
@@ -255,6 +257,7 @@
 
     const isEdit = computed(() => !!localItem.value.id)
     const canCreate = computed(() => checkPermission('CONFIG_WORD_LIST_CREATE'))
+    const canSave = computed(() => checkPermission(isEdit.value ? 'CONFIG_WORD_LIST_UPDATE' : 'CONFIG_WORD_LIST_CREATE'))
 
     const categoryHeaders: HeaderEntry[] = [
         { title: t('word_lists.name'), key: 'name', sortable: false },
@@ -312,6 +315,7 @@
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     const persist = async (): Promise<boolean> => {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/tests/unit/ConfigurationPermissionSemantics.spec.js
+++ b/src/gui-v3/tests/unit/ConfigurationPermissionSemantics.spec.js
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { mountWithPlugins } from '../helpers/mount-helpers'
+import NodeDialog from '@/components/common/nodes/NodeDialog.vue'
+import CardCompact from '@/components/common/CardCompact.vue'
+import EditableEntityTable from '@/components/common/EditableEntityTable.vue'
+
+const sourceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../src')
+
+const { allowedPermissions } = vi.hoisted(() => ({ allowedPermissions: new Set() }))
+
+vi.mock('@/composables/useAuth', () => ({
+    useAuth: () => ({ checkPermission: (permission) => allowedPermissions.has(permission) })
+}))
+
+vi.mock('@/api/config', () => ({
+    createNewCollectorsNode: vi.fn(),
+    updateCollectorsNode: vi.fn(),
+    deleteCollectorsNode: vi.fn(),
+    createNewPresentersNode: vi.fn(),
+    updatePresentersNode: vi.fn(),
+    deletePresentersNode: vi.fn(),
+    createNewPublishersNode: vi.fn(),
+    updatePublishersNode: vi.fn(),
+    deletePublishersNode: vi.fn(),
+    createNewBotsNode: vi.fn(),
+    updateBotsNode: vi.fn(),
+    deleteBotsNode: vi.fn()
+}))
+
+const VDialogStub = {
+    name: 'VDialog',
+    props: ['modelValue'],
+    template: '<div><slot /><slot name="activator" :props="{}" /></div>'
+}
+
+const VFormStub = {
+    name: 'VForm',
+    props: ['disabled'],
+    methods: { validate: vi.fn().mockResolvedValue({ valid: true }), resetValidation: vi.fn() },
+    template: '<form><slot /></form>'
+}
+
+const DialogToolbarStub = {
+    name: 'DialogToolbar',
+    props: ['showSave'],
+    emits: ['cancel', 'save'],
+    template: '<div class="dialog-toolbar" />'
+}
+
+const AddNewButtonStub = {
+    name: 'AddNewButton',
+    props: { show: { type: Boolean, default: true } },
+    template: '<button v-if="show" class="add-new" />'
+}
+
+const ActionButtonStub = {
+    name: 'ActionButton',
+    props: ['action'],
+    emits: ['click'],
+    template: '<button :data-action="action" @click="$emit(\'click\')" />'
+}
+
+const commonStubs = {
+    VDialog: VDialogStub,
+    VForm: VFormStub,
+    DialogToolbar: DialogToolbarStub,
+    AddNewButton: AddNewButtonStub,
+    UnsavedChangesDialog: true,
+    ActionButton: ActionButtonStub,
+    ConfirmationDialog: true,
+    HighlightedText: true
+}
+
+const mountNodeDialog = (editItem = null) =>
+    mountWithPlugins(NodeDialog, {
+        props: { type: 'collectors', editItem },
+        global: { stubs: commonStubs }
+    })
+
+describe('configuration create/update/delete roles', () => {
+    beforeEach(() => allowedPermissions.clear())
+
+    it('keeps create-only users out of existing-record editing', async () => {
+        allowedPermissions.add('CONFIG_COLLECTORS_NODE_CREATE')
+        const createDialog = mountNodeDialog()
+        expect(createDialog.find('.add-new').exists()).toBe(true)
+
+        const detail = mountNodeDialog({ id: 'node-1', name: 'Node 1' })
+        await flushPromises()
+        expect(detail.findComponent(DialogToolbarStub).props('showSave')).toBe(false)
+        expect(detail.findComponent(VFormStub).props('disabled')).toBe(true)
+    })
+
+    it('gives access-only users a genuine read-only detail view', async () => {
+        allowedPermissions.add('CONFIG_COLLECTORS_NODE_ACCESS')
+        const detail = mountNodeDialog({ id: 'node-1', name: 'Node 1' })
+        await flushPromises()
+
+        expect(detail.find('.add-new').exists()).toBe(false)
+        expect(detail.findComponent(DialogToolbarStub).props('showSave')).toBe(false)
+        expect(detail.findComponent(VFormStub).props('disabled')).toBe(true)
+    })
+
+    it('allows update without implying delete', async () => {
+        allowedPermissions.add('CONFIG_COLLECTORS_NODE_UPDATE')
+        const detail = mountNodeDialog({ id: 'node-1', name: 'Node 1' })
+        await flushPromises()
+        expect(detail.findComponent(DialogToolbarStub).props('showSave')).toBe(true)
+        expect(detail.findComponent(VFormStub).props('disabled')).toBe(false)
+
+        const card = mountWithPlugins(CardCompact, {
+            props: { card: { id: 'node-1', name: 'Node 1' }, deletePermission: 'CONFIG_COLLECTORS_NODE_DELETE' },
+            global: { stubs: commonStubs }
+        })
+        expect(card.find('[data-action="delete"]').exists()).toBe(false)
+    })
+
+    it('enables create, update, and delete for a full-access role', async () => {
+        allowedPermissions.add('CONFIG_COLLECTORS_NODE_CREATE')
+        allowedPermissions.add('CONFIG_COLLECTORS_NODE_UPDATE')
+        allowedPermissions.add('CONFIG_COLLECTORS_NODE_DELETE')
+        expect(mountNodeDialog().find('.add-new').exists()).toBe(true)
+
+        const detail = mountNodeDialog({ id: 'node-1', name: 'Node 1' })
+        await flushPromises()
+        expect(detail.findComponent(DialogToolbarStub).props('showSave')).toBe(true)
+
+        const card = mountWithPlugins(CardCompact, {
+            props: { card: { id: 'node-1', name: 'Node 1' }, deletePermission: 'CONFIG_COLLECTORS_NODE_DELETE' },
+            global: { stubs: commonStubs }
+        })
+        expect(card.find('[data-action="delete"]').exists()).toBe(true)
+    })
+})
+
+describe('fine-grained nested row actions', () => {
+    const mountTable = (props = {}) =>
+        mountWithPlugins(EditableEntityTable, {
+            props: {
+                title: 'Constants',
+                headers: [
+                    { title: 'Value', key: 'value' },
+                    { title: 'Actions', key: 'actions' }
+                ],
+                defaultItem: () => ({ value: '' }),
+                addTitle: 'Add',
+                editTitle: 'Edit',
+                items: [{ value: 'CVE-1' }],
+                server: true,
+                ...props
+            },
+            global: { stubs: commonStubs }
+        })
+
+    it('does not infer delete from update permission', () => {
+        const wrapper = mountTable({ allowAdd: true, allowEdit: true, allowDelete: false })
+
+        expect(wrapper.vm.canAdd).toBe(true)
+        expect(wrapper.vm.canEdit).toBe(true)
+        expect(wrapper.vm.canDelete).toBe(false)
+    })
+
+    it('suppresses every mutation when the parent detail is read-only', () => {
+        const wrapper = mountTable({ disabled: true })
+
+        expect(wrapper.vm.canAdd).toBe(false)
+        expect(wrapper.vm.canEdit).toBe(false)
+        expect(wrapper.vm.canDelete).toBe(false)
+    })
+})
+
+describe('configuration permission coverage matrix', () => {
+    const editorMatrix = [
+        ['components/config/access-management/NewOrganization.vue', 'CONFIG_ORGANIZATION_CREATE', 'CONFIG_ORGANIZATION_UPDATE'],
+        ['components/config/access-management/NewUser.vue', 'CONFIG_USER_CREATE', 'CONFIG_USER_UPDATE'],
+        ['components/config/access-management/NewRole.vue', 'CONFIG_ROLE_CREATE', 'CONFIG_ROLE_UPDATE'],
+        ['components/config/access-management/NewACL.vue', 'CONFIG_ACL_CREATE', 'CONFIG_ACL_UPDATE'],
+        ['components/config/remote/NewRemoteAccess.vue', 'CONFIG_REMOTE_ACCESS_CREATE', 'CONFIG_REMOTE_ACCESS_UPDATE'],
+        ['components/config/remote/NewRemoteNode.vue', 'CONFIG_REMOTE_NODE_CREATE', 'CONFIG_REMOTE_NODE_UPDATE'],
+        ['components/config/reports/NewAttribute.vue', 'CONFIG_ATTRIBUTE_CREATE', 'CONFIG_ATTRIBUTE_UPDATE'],
+        ['components/config/reports/NewReportType.vue', 'CONFIG_REPORT_TYPE_CREATE', 'CONFIG_REPORT_TYPE_UPDATE'],
+        ['components/config/word-lists/NewWordList.vue', 'CONFIG_WORD_LIST_CREATE', 'CONFIG_WORD_LIST_UPDATE'],
+        ['components/config/collectors/NewOSINTSourceGroup.vue', 'CONFIG_OSINT_SOURCE_GROUP_CREATE', 'CONFIG_OSINT_SOURCE_GROUP_UPDATE'],
+        ['components/config/collectors/NewOSINTSource.vue', 'CONFIG_OSINT_SOURCE_CREATE', 'CONFIG_OSINT_SOURCE_UPDATE'],
+        ['components/config/publishers/NewPublisherPreset.vue', 'CONFIG_PUBLISHER_PRESET_CREATE', 'CONFIG_PUBLISHER_PRESET_UPDATE'],
+        ['components/config/bots/NewBotPreset.vue', 'CONFIG_BOT_PRESET_CREATE', 'CONFIG_BOT_PRESET_UPDATE'],
+        ['components/config/presenters/NewProductType.vue', 'CONFIG_PRODUCT_TYPE_CREATE', 'CONFIG_PRODUCT_TYPE_UPDATE']
+    ]
+
+    it.each(editorMatrix)('%s explicitly gates create and update', (relativePath, createPermission, updatePermission) => {
+        const source = readFileSync(resolve(sourceRoot, relativePath), 'utf8')
+        expect(source).toContain(createPermission)
+        expect(source).toContain(updatePermission)
+        expect(source).toContain(':show-save="canSave"')
+        expect(source).toContain('if (!canSave.value) return false')
+    })
+
+    const tabDeleteMatrix = [
+        ['components/config/access-management/OrganizationsTab.vue', 'CONFIG_ORGANIZATION_DELETE'],
+        ['components/config/access-management/UsersTab.vue', 'CONFIG_USER_DELETE'],
+        ['components/config/access-management/RolesTab.vue', 'CONFIG_ROLE_DELETE'],
+        ['components/config/access-management/ACLTab.vue', 'CONFIG_ACL_DELETE'],
+        ['components/config/reports/AttributesTab.vue', 'CONFIG_ATTRIBUTE_DELETE']
+    ]
+
+    it.each(tabDeleteMatrix)('%s explicitly gates row deletion', (relativePath, deletePermission) => {
+        const source = readFileSync(resolve(sourceRoot, relativePath), 'utf8')
+        expect(source).toContain(deletePermission)
+        expect(source).toContain('v-if="canDelete"')
+        expect(source).toContain('if (!canDelete.value) return')
+    })
+
+    const compactDeleteMatrix = [
+        ['views/admin/RemoteNodesView.vue', 'CONFIG_REMOTE_NODE_DELETE'],
+        ['views/admin/RemoteAccessesView.vue', 'CONFIG_REMOTE_ACCESS_DELETE'],
+        ['views/admin/ReportTypesView.vue', 'CONFIG_REPORT_TYPE_DELETE'],
+        ['views/admin/WordListsView.vue', 'CONFIG_WORD_LIST_DELETE'],
+        ['views/admin/OSINTSourceGroupsView.vue', 'CONFIG_OSINT_SOURCE_GROUP_DELETE'],
+        ['views/admin/PublisherPresetsView.vue', 'CONFIG_PUBLISHER_PRESET_DELETE'],
+        ['views/admin/BotPresetsView.vue', 'CONFIG_BOT_PRESET_DELETE'],
+        ['views/admin/ProductTypesView.vue', 'CONFIG_PRODUCT_TYPE_DELETE'],
+        ['components/config/collectors/OSINTSourceBulkList.vue', 'CONFIG_OSINT_SOURCE_DELETE']
+    ]
+
+    it.each(compactDeleteMatrix)('%s supplies its delete permission to compact rows', (relativePath, deletePermission) => {
+        const source = readFileSync(resolve(sourceRoot, relativePath), 'utf8')
+        expect(source).toContain(deletePermission)
+    })
+
+    it('keeps global settings read-only without CONFIG_SETTINGS_UPDATE', () => {
+        const source = readFileSync(resolve(sourceRoot, 'components/config/SettingsTable.vue'), 'utf8')
+        expect(source).toContain('CONFIG_SETTINGS_UPDATE')
+        expect(source).toContain(':disabled="!canEditSettings"')
+        expect(source).toContain('if (!canEditSettings.value) return')
+    })
+
+    it('uses the registered remote-node permissions on every backend operation', () => {
+        const source = readFileSync(resolve(sourceRoot, '../../core/api/config.py'), 'utf8')
+        const remoteNodeSection = source.slice(source.indexOf('class RemoteNodesResource'), source.indexOf('class PresentersNodesResource'))
+
+        expect(remoteNodeSection).toContain('@auth_required("CONFIG_REMOTE_NODE_ACCESS")')
+        expect(remoteNodeSection).toContain('@auth_required("CONFIG_REMOTE_NODE_CREATE")')
+        expect(remoteNodeSection).toContain('@auth_required("CONFIG_REMOTE_NODE_UPDATE")')
+        expect(remoteNodeSection).toContain('@auth_required("CONFIG_REMOTE_NODE_DELETE")')
+        expect(remoteNodeSection).not.toContain('CONFIG_REMOTE_ACCESS_')
+    })
+})

--- a/src/gui-v3/tests/unit/SettingsTableLanguageOptions.spec.js
+++ b/src/gui-v3/tests/unit/SettingsTableLanguageOptions.spec.js
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
 import SettingsTable from '@/components/config/SettingsTable.vue'
 
 const { settingsStore } = vi.hoisted(() => ({
@@ -56,18 +57,25 @@ const SelectStub = defineComponent({
     template: '<div class="select-stub" />'
 })
 
-const passthroughStub = { template: '<div><slot /></div>' }
+const passthroughStub = (name) =>
+    defineComponent({
+        name,
+        template: '<div><slot /></div>'
+    })
 
 function mountTable() {
+    const pinia = createPinia()
+    setActivePinia(pinia)
     return mount(SettingsTable, {
         props: { globalSetting: false },
         global: {
+            plugins: [pinia],
             stubs: {
-                VContainer: passthroughStub,
-                VCard: passthroughStub,
-                VCardText: passthroughStub,
-                VRow: passthroughStub,
-                VCol: passthroughStub,
+                VContainer: passthroughStub('VContainer'),
+                VCard: passthroughStub('VCard'),
+                VCardText: passthroughStub('VCardText'),
+                VRow: passthroughStub('VRow'),
+                VCol: passthroughStub('VCol'),
                 VDataTable: DataTableStub,
                 VSelect: SelectStub,
                 SearchField: true,


### PR DESCRIPTION
## Enforce Vue 3 configuration permissions

### What changed

- Restored create, update, and delete permission semantics across Vue 3 configuration screens.
- Users without update permission now receive genuine read-only forms with Save hidden.
- Delete actions are hidden and defensively guarded without the corresponding permission.
- Applied consistent permission handling to:
  - Users, roles, organizations, and ACLs
  - Attributes and report types
  - OSINT sources and source groups
  - Collector, presenter, publisher, and bot nodes
  - Product types and publisher/bot presets
  - Remote access and remote nodes
  - Word lists
  - Global settings
- Corrected remote-node backend endpoints to use `CONFIG_REMOTE_NODE_*` permissions rather than unrelated remote-access permissions.
- Connecting a remote node now requires update permission.
- Added comprehensive permission-role coverage.

### Why

Vue 3 exposed editable forms and destructive actions to users lacking the required update or delete permissions, relying on backend rejection only after submission. This restores the clearer and safer behavior provided by the legacy GUI.

### Validation

- Full frontend suite: 751/751 tests passed
- Full ESLint passed
- Full TypeScript check passed
- Full Prettier check passed
- Production build passed
- Focused permission tests: 37/37 passed
- Ruff lint and formatting passed
- `git diff --check` passed