### PR TITLE
Restore Vue 3 attribute dictionary administration

### DIFF
--- a/src/gui-v3/src/components/config/reports/AttributeConstantCsvImport.vue
+++ b/src/gui-v3/src/components/config/reports/AttributeConstantCsvImport.vue
@@ -1,0 +1,248 @@
+<template>
+    <v-btn
+        v-if="show"
+        type="button"
+        color="primary"
+        variant="tonal"
+        prepend-icon="mdi-upload"
+        :disabled="busy"
+        @click="openDialog"
+    >
+        {{ t('attribute.import_from_csv') }}
+    </v-btn>
+
+    <v-dialog
+        v-model="dialog"
+        max-width="820"
+        persistent
+        scrollable
+    >
+        <v-card>
+            <v-toolbar
+                color="primary"
+                density="compact"
+            >
+                <v-toolbar-title>{{ t('attribute.import_from_csv') }}</v-toolbar-title>
+                <v-spacer />
+                <v-btn
+                    type="button"
+                    variant="text"
+                    :disabled="busy"
+                    @click="closeDialog"
+                >
+                    {{ t('common.cancel') }}
+                </v-btn>
+                <v-btn
+                    type="button"
+                    variant="text"
+                    :loading="busy"
+                    :disabled="busy || previewRows.length === 0"
+                    @click="submitImport"
+                >
+                    <v-icon start>mdi-upload</v-icon>
+                    {{ t('attribute.import') }}
+                </v-btn>
+            </v-toolbar>
+
+            <v-progress-linear
+                v-if="busy"
+                indeterminate
+                color="primary"
+            />
+
+            <v-card-text>
+                <v-file-input
+                    v-model="csvFile"
+                    :label="t('attribute.load_csv_file')"
+                    accept=".csv,text/csv,text/plain"
+                    prepend-icon="mdi-file-delimited"
+                    variant="outlined"
+                    clearable
+                    :disabled="busy"
+                    @update:model-value="readCsvFile"
+                />
+
+                <div class="d-flex flex-wrap align-center ga-6 mb-3">
+                    <v-checkbox
+                        v-model="fileHasHeader"
+                        :label="t('attribute.file_has_header')"
+                        hide-details
+                        :disabled="busy"
+                        @update:model-value="parseCsv"
+                    />
+                    <v-checkbox
+                        v-model="replaceExisting"
+                        :label="t('attribute.delete_existing')"
+                        hide-details
+                        :disabled="busy"
+                    />
+                </div>
+
+                <v-row v-if="columnOptions.length">
+                    <v-col
+                        cols="12"
+                        md="6"
+                    >
+                        <v-select
+                            v-model="valueColumn"
+                            :items="columnOptions"
+                            :label="t('attribute.value')"
+                            variant="outlined"
+                            density="comfortable"
+                            :disabled="busy"
+                        />
+                    </v-col>
+                    <v-col
+                        cols="12"
+                        md="6"
+                    >
+                        <v-select
+                            v-model="descriptionColumn"
+                            :items="descriptionColumnOptions"
+                            :label="t('attribute.description')"
+                            variant="outlined"
+                            density="comfortable"
+                            clearable
+                            :disabled="busy"
+                        />
+                    </v-col>
+                </v-row>
+
+                <v-alert
+                    v-if="errorMessage"
+                    type="error"
+                    variant="tonal"
+                    class="mb-3"
+                >
+                    {{ errorMessage }}
+                </v-alert>
+
+                <v-data-table
+                    v-if="previewRows.length"
+                    :headers="previewHeaders"
+                    :items="previewRows"
+                    :items-per-page="5"
+                    density="compact"
+                />
+            </v-card-text>
+        </v-card>
+    </v-dialog>
+</template>
+
+<script setup lang="ts">
+    import { computed, ref, watch } from 'vue'
+    import { useI18n } from 'vue-i18n'
+    import { mapAttributeConstantRows, readAttributeConstantCsv, type AttributeConstantImport } from '@/utils/attribute-constant-csv'
+
+    type ColumnOption = { title: string; value: number }
+
+    const props = withDefaults(
+        defineProps<{
+            show?: boolean
+            busy?: boolean
+            error?: string
+        }>(),
+        {
+            show: true,
+            busy: false,
+            error: ''
+        }
+    )
+
+    const emit = defineEmits<{
+        (e: 'import', payload: { items: AttributeConstantImport[]; replaceExisting: boolean }): void
+    }>()
+
+    const dialog = defineModel<boolean>({ default: false })
+    const { t } = useI18n()
+    const csvFile = ref<File | File[] | null>(null)
+    const csvText = ref('')
+    const rawRecords = ref<string[][]>([])
+    const columnOptions = ref<ColumnOption[]>([])
+    const valueColumn = ref<number | null>(null)
+    const descriptionColumn = ref<number | null>(null)
+    const fileHasHeader = ref(true)
+    const replaceExisting = ref(false)
+    const readingFile = ref(false)
+    const parseError = ref('')
+
+    const busy = computed(() => props.busy || readingFile.value)
+    const errorMessage = computed(() => props.error || parseError.value)
+    const descriptionColumnOptions = computed(() => columnOptions.value.filter((option) => option.value !== valueColumn.value))
+    const previewRows = computed(() => mapAttributeConstantRows(rawRecords.value, valueColumn.value, descriptionColumn.value))
+    const previewHeaders = computed(() => [
+        { title: t('attribute.value'), key: 'value', sortable: false },
+        { title: t('attribute.description'), key: 'description', sortable: false }
+    ])
+
+    const reset = (): void => {
+        csvFile.value = null
+        csvText.value = ''
+        rawRecords.value = []
+        columnOptions.value = []
+        valueColumn.value = null
+        descriptionColumn.value = null
+        fileHasHeader.value = true
+        replaceExisting.value = false
+        readingFile.value = false
+        parseError.value = ''
+    }
+
+    const openDialog = (): void => {
+        reset()
+        dialog.value = true
+    }
+
+    const closeDialog = (): void => {
+        if (busy.value) return
+        dialog.value = false
+        reset()
+    }
+
+    const parseCsv = (): void => {
+        parseError.value = ''
+        rawRecords.value = []
+        columnOptions.value = []
+        if (!csvText.value) return
+        try {
+            const parsed = readAttributeConstantCsv(csvText.value, fileHasHeader.value)
+            rawRecords.value = parsed.records
+            columnOptions.value = parsed.headers.map((header, index) => ({ title: header, value: index }))
+            const normalizedHeaders = parsed.headers.map((header) => header.trim().toLocaleLowerCase())
+            valueColumn.value = normalizedHeaders.indexOf('value')
+            if (valueColumn.value < 0) valueColumn.value = parsed.headers.length > 0 ? 0 : null
+            descriptionColumn.value = normalizedHeaders.indexOf('description')
+            if (descriptionColumn.value < 0) descriptionColumn.value = parsed.headers.length > 1 ? 1 : null
+            if (descriptionColumn.value === valueColumn.value) descriptionColumn.value = null
+            if (previewRows.value.length === 0) parseError.value = t('common.no_data')
+        } catch {
+            parseError.value = t('common.error')
+        }
+    }
+
+    const readCsvFile = async (selection: File | File[] | null): Promise<void> => {
+        const file = Array.isArray(selection) ? selection[0] : selection
+        csvText.value = ''
+        rawRecords.value = []
+        parseError.value = ''
+        if (!file) return
+        readingFile.value = true
+        try {
+            csvText.value = await file.text()
+            parseCsv()
+        } catch {
+            parseError.value = t('common.error')
+        } finally {
+            readingFile.value = false
+        }
+    }
+
+    const submitImport = (): void => {
+        if (previewRows.value.length === 0) return
+        emit('import', { items: previewRows.value, replaceExisting: replaceExisting.value })
+    }
+
+    watch(valueColumn, (column) => {
+        if (descriptionColumn.value === column) descriptionColumn.value = null
+    })
+</script>

--- a/src/gui-v3/src/components/config/reports/NewAttribute.vue
+++ b/src/gui-v3/src/components/config/reports/NewAttribute.vue
@@ -103,6 +103,49 @@
                     </v-row>
 
                     <!-- Attribute constants (enums) -->
+                    <div
+                        v-if="canImportConstants || canReloadDictionary"
+                        class="constant-tools d-flex flex-wrap align-center ga-2 mt-2"
+                    >
+                        <v-btn
+                            v-if="canReloadDictionary"
+                            type="button"
+                            color="primary"
+                            variant="tonal"
+                            prepend-icon="mdi-refresh"
+                            :loading="dictionaryReloading"
+                            :disabled="constantOperationBusy"
+                            @click="reloadCurrentDictionary"
+                        >
+                            {{ dictionaryReloadLabel }}
+                        </v-btn>
+                        <AttributeConstantCsvImport
+                            v-model="csvDialog"
+                            :show="canImportConstants"
+                            :busy="constantImporting"
+                            :error="constantOperationError"
+                            @import="importConstants"
+                        />
+                    </div>
+
+                    <v-progress-linear
+                        v-if="constantOperationBusy"
+                        indeterminate
+                        color="primary"
+                        class="mt-2"
+                    />
+
+                    <v-alert
+                        v-if="constantOperationError && !csvDialog"
+                        type="error"
+                        variant="tonal"
+                        class="mt-2"
+                        closable
+                        @click:close="constantOperationError = ''"
+                    >
+                        {{ constantOperationError }}
+                    </v-alert>
+
                     <EditableEntityTable
                         :key="tableKey"
                         v-model:dialog="constantDialog"
@@ -190,13 +233,16 @@
         getAttributeEnums,
         addAttributeEnum,
         updateAttributeEnum,
-        deleteAttributeEnum
+        deleteAttributeEnum,
+        reloadDictionaries
     } from '@/api/config'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
     import { useUnsavedChanges } from '@/composables/useUnsavedChanges'
     import EditableEntityTable from '@/components/common/EditableEntityTable.vue'
+    import AttributeConstantCsvImport from '@/components/config/reports/AttributeConstantCsvImport.vue'
+    import { mergeAttributeConstants, type AttributeConstantImport } from '@/utils/attribute-constant-csv'
 
     type AttributeType =
         | 'STRING'
@@ -329,6 +375,15 @@
 
     const constantDialog = ref(false)
     const constantSaving = ref(false)
+    const csvDialog = ref(false)
+    const constantImporting = ref(false)
+    const dictionaryReloading = ref(false)
+    const constantOperationError = ref('')
+    const dictionaryTypes: AttributeType[] = ['CPE', 'CVE', 'CWE']
+    const canImportConstants = computed(() => (isEdit.value ? canUpdate.value && canCreate.value : canCreate.value))
+    const canReloadDictionary = computed(() => isEdit.value && canUpdate.value && dictionaryTypes.includes(localItem.value.type))
+    const constantOperationBusy = computed(() => constantImporting.value || dictionaryReloading.value)
+    const dictionaryReloadLabel = computed(() => t(`attribute.reload_${localItem.value.type.toLocaleLowerCase()}`))
 
     const constantHeaders = [
         { title: t('reports.attributes.value'), key: 'value', sortable: false },
@@ -340,6 +395,11 @@
 
     const notify = (type: 'success' | 'error', loc: string): void => {
         window.dispatchEvent(new CustomEvent('notification', { detail: { type, loc } }))
+    }
+
+    const apiErrorMessage = (error: unknown): string => {
+        const responseError = (error as { response?: { data?: { error?: unknown } } } | undefined)?.response?.data?.error
+        return typeof responseError === 'string' && responseError ? responseError : t('common.error')
     }
 
     const loadConstants = async (): Promise<void> => {
@@ -382,6 +442,10 @@
             constantPage.value = 1
             loadConstants()
         }, 300)
+    })
+
+    watch(csvDialog, (open) => {
+        if (open && !constantImporting.value) constantOperationError.value = ''
     })
 
     // Persist a constant from the table's add/edit dialog. `isNew` is true when adding.
@@ -436,6 +500,56 @@
         }
     }
 
+    const importConstants = async ({
+        items,
+        replaceExisting
+    }: {
+        items: AttributeConstantImport[]
+        replaceExisting: boolean
+    }): Promise<void> => {
+        if (!canImportConstants.value || items.length === 0) return
+        constantImporting.value = true
+        constantOperationError.value = ''
+        try {
+            if (isEdit.value && localItem.value.id !== null) {
+                await addAttributeEnum(localItem.value.id, { items, delete_existing: replaceExisting })
+                constantPage.value = 1
+                await loadConstants()
+            } else {
+                constants.value = mergeAttributeConstants(constants.value, items, replaceExisting).map((constant, index) => ({
+                    id: -1,
+                    index,
+                    ...constant
+                }))
+                constantsTotal.value = constants.value.length
+            }
+            csvDialog.value = false
+            notify('success', 'common.updated_successfully')
+        } catch (error) {
+            console.error('Error importing attribute constants:', error)
+            constantOperationError.value = apiErrorMessage(error)
+        } finally {
+            constantImporting.value = false
+        }
+    }
+
+    const reloadCurrentDictionary = async (): Promise<void> => {
+        if (!canReloadDictionary.value) return
+        dictionaryReloading.value = true
+        constantOperationError.value = ''
+        try {
+            await reloadDictionaries(localItem.value.type.toLocaleLowerCase())
+            constantPage.value = 1
+            await loadConstants()
+            notify('success', 'common.updated_successfully')
+        } catch (error) {
+            console.error('Error reloading attribute dictionary:', error)
+            constantOperationError.value = apiErrorMessage(error)
+        } finally {
+            dictionaryReloading.value = false
+        }
+    }
+
     // Persists the form. Returns true on success so the guard can decide whether to close.
     async function persist(): Promise<boolean> {
         if (!canSave.value) return false
@@ -482,6 +596,10 @@
         constantsTotal.value = 0
         constantSearch.value = ''
         constantPage.value = 1
+        csvDialog.value = false
+        constantImporting.value = false
+        dictionaryReloading.value = false
+        constantOperationError.value = ''
     }
 
     function closeDialog(): void {

--- a/src/gui-v3/src/utils/attribute-constant-csv.ts
+++ b/src/gui-v3/src/utils/attribute-constant-csv.ts
@@ -1,0 +1,56 @@
+import { parseDelimitedRecords } from '@/utils/word-list-csv'
+
+export type AttributeConstantImport = {
+    value: string
+    description: string
+}
+
+export type AttributeConstantCsv = {
+    headers: string[]
+    records: string[][]
+}
+
+export const readAttributeConstantCsv = (input: string, hasHeader: boolean): AttributeConstantCsv => {
+    const records = parseDelimitedRecords(input)
+    if (records.length === 0) return { headers: [], records: [] }
+
+    const columnCount = Math.max(...records.map((record) => record.length))
+    const generatedHeaders = Array.from({ length: columnCount }, (_, index) => `#${index + 1}`)
+    if (!hasHeader) return { headers: generatedHeaders, records }
+
+    const headerRecord = records.shift() ?? []
+    return {
+        headers: generatedHeaders.map((fallback, index) => headerRecord[index]?.trim() || fallback),
+        records
+    }
+}
+
+export const mapAttributeConstantRows = (
+    records: string[][],
+    valueColumn: number | null,
+    descriptionColumn: number | null
+): AttributeConstantImport[] => {
+    if (valueColumn === null || valueColumn < 0) return []
+
+    const unique = new Map<string, AttributeConstantImport>()
+    for (const record of records) {
+        const value = (record[valueColumn] ?? '').trim()
+        if (!value) continue
+        const description = descriptionColumn === null ? '' : (record[descriptionColumn] ?? '').trim()
+        unique.set(value.toLocaleLowerCase(), { value, description })
+    }
+    return [...unique.values()]
+}
+
+export const mergeAttributeConstants = <T extends AttributeConstantImport>(
+    existing: T[],
+    incoming: AttributeConstantImport[],
+    replaceExisting: boolean
+): AttributeConstantImport[] => {
+    const unique = new Map<string, AttributeConstantImport>()
+    const entries = replaceExisting ? incoming : [...existing, ...incoming]
+    for (const entry of entries) {
+        unique.set(entry.value.toLocaleLowerCase(), { value: entry.value, description: entry.description })
+    }
+    return [...unique.values()]
+}

--- a/src/gui-v3/tests/unit/AttributeConstantCsvImport.spec.ts
+++ b/src/gui-v3/tests/unit/AttributeConstantCsvImport.spec.ts
@@ -1,0 +1,119 @@
+import { flushPromises } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineComponent } from 'vue'
+import { mountWithPlugins } from '../helpers/mount-helpers'
+import AttributeConstantCsvImport from '@/components/config/reports/AttributeConstantCsvImport.vue'
+import { mapAttributeConstantRows, mergeAttributeConstants, readAttributeConstantCsv } from '@/utils/attribute-constant-csv'
+
+const VDialogStub = {
+    name: 'VDialog',
+    props: ['modelValue'],
+    template: '<div v-if="modelValue"><slot /></div>'
+}
+
+const VFileInputStub = {
+    name: 'VFileInput',
+    emits: ['update:modelValue'],
+    template: '<button class="choose-file" @click="$emit(\'update:modelValue\', file)">file</button>',
+    data: () => ({
+        file: new File(
+            ['summary;identifier;ignored\nRemote code execution;CVE-2026-1;x\nDuplicate;CVE-2026-1;y\nWeakness;CWE-79;z\n'],
+            'constants.csv',
+            {
+                type: 'text/csv'
+            }
+        )
+    })
+}
+
+const VSelectStub = defineComponent({
+    name: 'VSelect',
+    props: {
+        modelValue: { type: Number, default: null },
+        items: { type: Array, default: () => [] },
+        label: { type: String, default: '' }
+    },
+    emits: ['update:modelValue'],
+    template: '<div class="column-select" />'
+})
+
+describe('attribute constant CSV utilities', () => {
+    it('reads headers, maps selected columns, removes empty values, and deduplicates case-insensitively', () => {
+        const csv = readAttributeConstantCsv('description;value\nFirst;Alpha\nSecond;alpha\nEmpty;\n', true)
+
+        expect(csv.headers).toEqual(['description', 'value'])
+        expect(mapAttributeConstantRows(csv.records, 1, 0)).toEqual([{ value: 'alpha', description: 'Second' }])
+    })
+
+    it('supports merge and replace behavior', () => {
+        const existing = [{ value: 'Alpha', description: 'old' }]
+        const incoming = [
+            { value: 'alpha', description: 'new' },
+            { value: 'Beta', description: 'second' }
+        ]
+
+        expect(mergeAttributeConstants(existing, incoming, false)).toEqual([
+            { value: 'alpha', description: 'new' },
+            { value: 'Beta', description: 'second' }
+        ])
+        expect(mergeAttributeConstants(existing, incoming, true)).toEqual(incoming)
+    })
+
+    it('rejects malformed quoted CSV with a clear parser error', () => {
+        expect(() => readAttributeConstantCsv('value;description\n"unfinished', true)).toThrow('Unterminated quoted CSV field')
+    })
+})
+
+describe('AttributeConstantCsvImport', () => {
+    it('previews manually mapped headers and emits the selected replace mode', async () => {
+        const wrapper = mountWithPlugins(AttributeConstantCsvImport, {
+            global: { stubs: { VDialog: VDialogStub, VFileInput: VFileInputStub, VSelect: VSelectStub } }
+        })
+
+        const openButton = wrapper.findAllComponents({ name: 'VBtn' }).find((button) => button.text() === 'Import from CSV')
+        if (!openButton) throw new Error('CSV import button was not rendered')
+        await openButton.trigger('click')
+        await wrapper.find('.choose-file').trigger('click')
+        await flushPromises()
+
+        const selects = wrapper
+            .findAllComponents(VSelectStub)
+            .filter((select) => ['Value', 'Description'].includes(select.props('label') ?? ''))
+        expect(selects).toHaveLength(2)
+        expect(selects[0]!.props('items')).toEqual([
+            { title: 'summary', value: 0 },
+            { title: 'identifier', value: 1 },
+            { title: 'ignored', value: 2 }
+        ])
+        selects[0]!.vm.$emit('update:modelValue', 1)
+        selects[1]!.vm.$emit('update:modelValue', 0)
+        await flushPromises()
+
+        const checkbox = wrapper.findAllComponents({ name: 'VCheckbox' }).at(1)
+        if (!checkbox) throw new Error('Replace checkbox was not rendered')
+        checkbox.vm.$emit('update:modelValue', true)
+
+        const importButton = wrapper.findAllComponents({ name: 'VBtn' }).find((button) => button.text() === 'Import')
+        if (!importButton) throw new Error('CSV import confirmation button was not rendered')
+        await importButton.trigger('click')
+
+        expect(wrapper.emitted('import')?.[0]?.[0]).toEqual({
+            items: [
+                { value: 'CVE-2026-1', description: 'Duplicate' },
+                { value: 'CWE-79', description: 'Weakness' }
+            ],
+            replaceExisting: true
+        })
+    })
+
+    it('disables import and shows progress while the parent operation is busy', async () => {
+        const wrapper = mountWithPlugins(AttributeConstantCsvImport, {
+            props: { modelValue: true, busy: true },
+            global: { stubs: { VDialog: VDialogStub, VFileInput: VFileInputStub, VSelect: VSelectStub } }
+        })
+
+        expect(wrapper.findComponent({ name: 'VProgressLinear' }).exists()).toBe(true)
+        const importButton = wrapper.findAllComponents({ name: 'VBtn' }).find((button) => button.text() === 'Import')
+        expect(importButton?.attributes('disabled')).toBeDefined()
+    })
+})

--- a/src/gui-v3/tests/unit/NewAttributeDictionaryAdmin.spec.ts
+++ b/src/gui-v3/tests/unit/NewAttributeDictionaryAdmin.spec.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { mountWithPlugins } from '../helpers/mount-helpers'
+import NewAttribute from '@/components/config/reports/NewAttribute.vue'
+
+const { checkPermission } = vi.hoisted(() => ({ checkPermission: vi.fn() }))
+
+vi.mock('@/composables/useAuth', () => ({
+    useAuth: () => ({ checkPermission })
+}))
+
+vi.mock('@/api/config', () => ({
+    createNewAttribute: vi.fn(),
+    updateAttribute: vi.fn(),
+    getAttributeEnums: vi.fn().mockResolvedValue({ data: { items: [], total_count: 0 } }),
+    addAttributeEnum: vi.fn().mockResolvedValue({}),
+    updateAttributeEnum: vi.fn(),
+    deleteAttributeEnum: vi.fn(),
+    reloadDictionaries: vi.fn().mockResolvedValue({})
+}))
+
+const VDialogStub = {
+    name: 'VDialog',
+    props: ['modelValue'],
+    template: '<div v-if="modelValue"><slot /><slot name="activator" :props="{}" /></div>'
+}
+
+const DialogToolbarStub = {
+    name: 'DialogToolbar',
+    props: ['title', 'saving', 'showSave'],
+    template: '<div class="dialog-toolbar" />'
+}
+
+const EditableEntityTableStub = {
+    name: 'EditableEntityTable',
+    props: ['items', 'loading', 'disabled'],
+    template: '<div class="constants-table"><slot name="form" :item="{}" /></div>'
+}
+
+const CsvImportStub = {
+    name: 'AttributeConstantCsvImport',
+    props: ['modelValue', 'show', 'busy', 'error'],
+    emits: ['import', 'update:modelValue'],
+    template: '<button v-if="show" class="csv-import" @click="$emit(\'import\', payload)">csv</button>',
+    data: () => ({
+        payload: {
+            items: [{ value: 'CVE-2026-1', description: 'Example' }],
+            replaceExisting: true
+        }
+    })
+}
+
+const editItem = {
+    id: 42,
+    name: 'CVE',
+    description: 'CVE dictionary',
+    type: 'CVE',
+    default_value: '',
+    validator: 'NONE',
+    validator_parameter: ''
+}
+
+const mountDialog = () =>
+    mountWithPlugins(NewAttribute, {
+        props: { editItem },
+        global: {
+            stubs: {
+                VDialog: VDialogStub,
+                DialogToolbar: DialogToolbarStub,
+                EditableEntityTable: EditableEntityTableStub,
+                AttributeConstantCsvImport: CsvImportStub,
+                UnsavedChangesDialog: true,
+                AddNewButton: true
+            }
+        }
+    })
+
+describe('NewAttribute dictionary administration', () => {
+    beforeEach(async () => {
+        vi.clearAllMocks()
+        const api = await import('@/api/config')
+        vi.mocked(api.getAttributeEnums).mockResolvedValue({ data: { items: [], total_count: 0 } } as never)
+        vi.mocked(api.addAttributeEnum).mockResolvedValue({} as never)
+        vi.mocked(api.reloadDictionaries).mockResolvedValue({} as never)
+    })
+
+    it('gates reload by update permission and import by the existing create endpoint permission', async () => {
+        checkPermission.mockReturnValue(true)
+        const wrapper = mountDialog()
+        await flushPromises()
+
+        expect(wrapper.find('.csv-import').exists()).toBe(true)
+        expect(wrapper.text()).toContain('Reload CVE Dictionary')
+
+        checkPermission.mockImplementation((permission: string) => permission === 'CONFIG_ATTRIBUTE_UPDATE')
+        const updateOnly = mountDialog()
+        await flushPromises()
+        expect(updateOnly.find('.csv-import').exists()).toBe(false)
+        expect(updateOnly.text()).toContain('Reload CVE Dictionary')
+
+        checkPermission.mockReturnValue(false)
+        const unauthorized = mountDialog()
+        await flushPromises()
+        expect(unauthorized.text()).not.toContain('Reload CVE Dictionary')
+    })
+
+    it('reloads the selected dictionary and refreshes its constants', async () => {
+        checkPermission.mockReturnValue(true)
+        const api = await import('@/api/config')
+        const wrapper = mountDialog()
+        await flushPromises()
+
+        const reloadButton = wrapper.findAllComponents({ name: 'VBtn' }).find((button) => button.text() === 'Reload CVE Dictionary')
+        if (!reloadButton) throw new Error('Reload button was not rendered')
+        await reloadButton.trigger('click')
+        await flushPromises()
+
+        expect(api.reloadDictionaries).toHaveBeenCalledWith('cve')
+        expect(api.getAttributeEnums).toHaveBeenCalledWith(expect.objectContaining({ attribute_id: 42, offset: 0 }))
+    })
+
+    it('imports constants with replace mode through the existing enum endpoint', async () => {
+        checkPermission.mockReturnValue(true)
+        const api = await import('@/api/config')
+        const wrapper = mountDialog()
+        await flushPromises()
+
+        await wrapper.find('.csv-import').trigger('click')
+        await flushPromises()
+
+        expect(api.addAttributeEnum).toHaveBeenCalledWith(42, {
+            items: [{ value: 'CVE-2026-1', description: 'Example' }],
+            delete_existing: true
+        })
+    })
+
+    it('surfaces backend reload errors in the dialog', async () => {
+        checkPermission.mockImplementation((permission: string) => permission === 'CONFIG_ATTRIBUTE_UPDATE')
+        const api = await import('@/api/config')
+        vi.mocked(api.reloadDictionaries).mockRejectedValue({ response: { data: { error: 'CVE source is unavailable' } } })
+        const wrapper = mountDialog()
+        await flushPromises()
+
+        const reloadButton = wrapper.findAllComponents({ name: 'VBtn' }).find((button) => button.text() === 'Reload CVE Dictionary')
+        if (!reloadButton) throw new Error('Reload button was not rendered')
+        await reloadButton.trigger('click')
+        await flushPromises()
+
+        expect(wrapper.text()).toContain('CVE source is unavailable')
+    })
+})

--- a/src/gui-v3/tests/unit/config.api.spec.ts
+++ b/src/gui-v3/tests/unit/config.api.spec.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { addAttributeEnum, reloadDictionaries } from '@/api/config'
+import ApiService from '@/services/api_service'
+
+vi.mock('@/services/api_service', () => ({
+    default: {
+        get: vi.fn(),
+        post: vi.fn()
+    }
+}))
+
+describe('configuration API', () => {
+    beforeEach(() => vi.clearAllMocks())
+
+    it('reloads the requested vulnerability dictionary through the protected configuration route', () => {
+        reloadDictionaries('cwe')
+        expect(ApiService.get).toHaveBeenCalledWith('/config/reload-enum-dictionaries/cwe')
+    })
+
+    it('sends imported attribute constants and replace mode unchanged', () => {
+        const payload = {
+            items: [{ value: 'CWE-79', description: 'Cross-site scripting' }],
+            delete_existing: true
+        }
+        addAttributeEnum(42, payload)
+        expect(ApiService.post).toHaveBeenCalledWith('/config/attributes/42/enums', payload)
+    })
+})


### PR DESCRIPTION
## Restore Vue 3 attribute dictionary administration

### What changed

- Restored CPE, CVE, and CWE dictionary reload controls for persisted attributes.
- Added CSV import for attribute constants with:
  - Automatic delimiter detection
  - Optional header-row handling
  - Explicit value and description column mapping
  - Import preview
  - Case-insensitive duplicate removal
  - Merge or replace-existing behavior
- Existing attributes import through the established attribute-enum API.
- New attributes retain imported constants locally until the attribute is saved.
- Added visible parsing, file-reading, API, and reload errors.
- Added busy and progress states for imports and dictionary reloads.
- Preserved existing individual constant CRUD.
- Applied the existing permission model:
  - Dictionary reload requires attribute update permission.
  - Importing into an existing attribute requires both update and create permissions.

### Why

The legacy GUI supported vulnerability dictionary reload and bulk constant import, while Vue 3 exposed only individual constant CRUD. This restores the missing administration workflows without changing backend behavior.

### Validation

- Focused import/API tests: 12/12 passed
- Full frontend suite: 751/751 tests passed
- Full ESLint, TypeScript, and Prettier checks passed
- Production build passed
- `git diff --check` passed