### PR TITLE
Resynchronize Vue 3 data after SSE gaps

### DIFF
--- a/src/gui-v3/src/App.vue
+++ b/src/gui-v3/src/App.vue
@@ -33,7 +33,7 @@
     import { ref, computed, onMounted, onUnmounted, nextTick, watch } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useTheme } from 'vuetify'
-    import { useRoute } from 'vue-router'
+    import { useRouter } from 'vue-router'
     import { useAuthStore } from '@/stores/auth'
     import { useUserStore } from '@/stores/user'
     import { useSettingsStore } from '@/stores/settings'
@@ -45,7 +45,8 @@
 
     const { locale } = useI18n()
     const theme = useTheme()
-    const route = useRoute()
+    const router = useRouter()
+    const route = computed(() => router.currentRoute?.value ?? { name: undefined, path: '' })
     const authStore = useAuthStore()
     const userStore = useUserStore()
     const settingsStore = useSettingsStore()
@@ -53,8 +54,8 @@
 
     const navVisible = ref(true)
     const isAuth = computed(() => authStore.isAuthenticated)
-    const showNavigation = computed(() => isAuth.value && route.name !== 'publish' && route.name !== 'dashboard')
-    const isConfigurationRoute = computed(() => route.path === '/config' || route.path.startsWith('/config/'))
+    const showNavigation = computed(() => isAuth.value && route.value.name !== 'publish' && route.value.name !== 'dashboard')
+    const isConfigurationRoute = computed(() => route.value.path === '/config' || route.value.path.startsWith('/config/'))
 
     // Watch theme changes and apply dark-mode/light-mode classes to HTML element.
     // These override the prefers-color-scheme CSS fallback once the user's preference is known.

--- a/src/gui-v3/src/components/analyze/ContentDataAnalyze.vue
+++ b/src/gui-v3/src/components/analyze/ContentDataAnalyze.vue
@@ -82,6 +82,7 @@
     import { useAnalyzeStore } from '@/stores/analyze'
     import CardAnalyze from './CardAnalyze.vue'
     import CardCompact from '@/components/common/CardCompact.vue'
+    import { useSseResync } from '@/composables/useSseResync'
 
     type ReportItem = {
         id: string | number
@@ -309,6 +310,8 @@
     const handleReportItemsUpdate = (): void => {
         updateData(false, true)
     }
+
+    useSseResync(() => updateData(false, true))
 
     onMounted(() => {
         updateData(false, false)

--- a/src/gui-v3/src/components/assess/ContentDataAssess.vue
+++ b/src/gui-v3/src/components/assess/ContentDataAssess.vue
@@ -136,6 +136,7 @@
     import NewReportItem from '@/components/analyze/NewReportItem.vue'
     import ReportsListDialog from './ReportsListDialog.vue'
     import { Action, type ActionKey } from '@/types/actions'
+    import { useSseResync } from '@/composables/useSseResync'
 
     type NewsItem = {
         id: string | number
@@ -814,6 +815,7 @@
 
     /** Silent reload after a card action or a server event: the window must not move. */
     const refreshData = (): Promise<void> => loadData('refresh')
+    useSseResync(refreshData)
 
     /** Kept for the toolbar and the analyze selector, which drive this component by ref. */
     const updateData = (append = false, reload_all = false): Promise<void> => loadData(append ? 'append' : reload_all ? 'reload' : 'reset')

--- a/src/gui-v3/src/components/assess/ContentDataAssess.vue
+++ b/src/gui-v3/src/components/assess/ContentDataAssess.vue
@@ -192,7 +192,8 @@
     const { t } = useI18n()
     const route = useRoute()
     const assessStore = useAssessStore()
-    const searchQuery = Array.isArray(route.query['search']) ? route.query['search'][0] : route.query['search']
+    const routeQuery = route.query ?? {}
+    const searchQuery = Array.isArray(routeQuery['search']) ? routeQuery['search'][0] : routeQuery['search']
 
     const news_items_data = ref<NewsItem[]>([])
 

--- a/src/gui-v3/src/components/assets/ContentDataAssets.vue
+++ b/src/gui-v3/src/components/assets/ContentDataAssets.vue
@@ -47,6 +47,7 @@
     import { useAssetsStore } from '@/stores/assets'
     import CardAsset from './CardAsset.vue'
     import type { Asset, AssetFilter } from '@/types/assets'
+    import { useSseResync } from '@/composables/useSseResync'
 
     const emit = defineEmits<{ (e: 'edit', asset: Asset): void }>()
     const { t } = useI18n()
@@ -61,22 +62,28 @@
         window.dispatchEvent(new CustomEvent('notification', { detail: { type, loc } }))
     }
 
-    const reload = async (): Promise<void> => {
+    const reloadData = async (silent = false): Promise<void> => {
         if (!groupId.value) {
             store.clearAssets()
             return
         }
-        loading.value = true
-        loadError.value = false
+        if (!silent) {
+            loading.value = true
+            loadError.value = false
+        }
         try {
             await store.loadAssets({ group_id: groupId.value, filter: filter.value })
         } catch {
-            loadError.value = true
-            notify('error', 'asset.load_error')
+            if (!silent) {
+                loadError.value = true
+                notify('error', 'asset.load_error')
+            }
         } finally {
-            loading.value = false
+            if (!silent) loading.value = false
         }
     }
+
+    const reload = (): Promise<void> => reloadData(false)
 
     const remove = async (asset: Asset): Promise<void> => {
         try {
@@ -95,6 +102,7 @@
 
     watch(groupId, reload)
     onMounted(reload)
+    useSseResync(() => reloadData(true))
     defineExpose({ reload, updateFilter })
 </script>
 

--- a/src/gui-v3/src/components/publish/ContentDataPublish.vue
+++ b/src/gui-v3/src/components/publish/ContentDataPublish.vue
@@ -79,6 +79,7 @@
     import { getAllUserProductTypes } from '@/api/user'
     import CardProduct from './CardProduct.vue'
     import CardCompact from '@/components/common/CardCompact.vue'
+    import { useSseResync } from '@/composables/useSseResync'
 
     type ProductItem = {
         id: string | number
@@ -277,6 +278,8 @@
         // The animation will trigger when the deleted item is missing from the new data
         updateData(false, true)
     }
+
+    useSseResync(() => updateData(false, true))
 
     onMounted(() => {
         updateData(false, false)

--- a/src/gui-v3/src/composables/useSseResync.ts
+++ b/src/gui-v3/src/composables/useSseResync.ts
@@ -1,0 +1,68 @@
+import { onMounted, onUnmounted } from 'vue'
+
+type ResyncHandler = () => void | Promise<void>
+
+const RESYNC_COALESCE_MS = 100
+
+/**
+ * Refresh a mounted SSE consumer after the stream reports a missed-event window.
+ * Bursts are coalesced and a signal received during a refresh becomes one trailing
+ * refresh, so recovery cannot create parallel request storms or lose the newest signal.
+ */
+export function useSseResync(handler: ResyncHandler): void {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let running = false
+    let pending = false
+    let mounted = false
+
+    const run = async (): Promise<void> => {
+        if (!mounted) return
+        if (running) {
+            pending = true
+            return
+        }
+
+        running = true
+        try {
+            do {
+                pending = false
+                try {
+                    await handler()
+                } catch (error) {
+                    console.error('[SSE] Data resynchronization failed:', error)
+                }
+            } while (mounted && pending)
+        } finally {
+            running = false
+        }
+    }
+
+    const requestResync = (): void => {
+        if (!mounted) return
+        if (running) {
+            pending = true
+            return
+        }
+        if (timer) return
+
+        timer = setTimeout(() => {
+            timer = undefined
+            void run()
+        }, RESYNC_COALESCE_MS)
+    }
+
+    onMounted(() => {
+        mounted = true
+        window.addEventListener('sse-resync', requestResync)
+    })
+
+    onUnmounted(() => {
+        mounted = false
+        pending = false
+        if (timer) {
+            clearTimeout(timer)
+            timer = undefined
+        }
+        window.removeEventListener('sse-resync', requestResync)
+    })
+}

--- a/src/gui-v3/src/stores/assets.ts
+++ b/src/gui-v3/src/stores/assets.ts
@@ -10,6 +10,7 @@ export const useAssetsStore = defineStore('assets', () => {
     const assetGroups = ref<ListResponse<AssetGroup>>(empty())
     const notificationTemplates = ref<ListResponse<NotificationTemplate>>(empty())
     const assets = ref<ListResponse<Asset>>(empty())
+    let assetLoadSequence = 0
 
     async function loadAssetGroups(filter: { search?: string } = {}): Promise<ApiResponse<ListResponse<AssetGroup>>> {
         const response = (await getAllAssetGroups(filter)) as ApiResponse<ListResponse<AssetGroup>>
@@ -24,8 +25,9 @@ export const useAssetsStore = defineStore('assets', () => {
     }
 
     async function loadAssets(data: { group_id: string; filter: AssetFilter }): Promise<ApiResponse<ListResponse<Asset>>> {
+        const requestId = ++assetLoadSequence
         const response = (await getAllAssets(data)) as ApiResponse<ListResponse<Asset>>
-        assets.value = response.data || empty()
+        if (requestId === assetLoadSequence) assets.value = response.data || empty()
         return response
     }
 

--- a/src/gui-v3/src/views/nav/MyAssetsNav.vue
+++ b/src/gui-v3/src/views/nav/MyAssetsNav.vue
@@ -48,6 +48,7 @@
     import { useRoute, useRouter } from 'vue-router'
     import GroupNavList from '@/components/common/GroupNavList.vue'
     import { useAssetsStore } from '@/stores/assets'
+    import { useSseResync } from '@/composables/useSseResync'
 
     const store = useAssetsStore()
     const route = useRoute()
@@ -82,20 +83,22 @@
         if (!hasActiveGroup) await router.replace(firstGroup.route)
     }
 
-    const loadGroups = (): Promise<void> => {
+    const fetchGroups = (silent: boolean): Promise<void> => {
         if (loadPromise) return loadPromise
 
         loadPromise = (async () => {
-            loading.value = true
-            loadError.value = false
-            groupsLoaded.value = false
+            if (!silent) {
+                loading.value = true
+                loadError.value = false
+                groupsLoaded.value = false
+            }
             try {
                 await store.loadAssetGroups({ search: '' })
                 groupsLoaded.value = true
             } catch {
-                loadError.value = true
+                if (!silent) loadError.value = true
             } finally {
-                loading.value = false
+                if (!silent) loading.value = false
                 loadPromise = null
             }
 
@@ -104,6 +107,10 @@
 
         return loadPromise
     }
+
+    const loadGroups = (): Promise<void> => fetchGroups(false)
+
+    useSseResync(() => fetchGroups(true))
 
     watch(activeGroupId, () => void reconcileRoute())
     onMounted(() => void loadGroups())

--- a/src/gui-v3/src/views/users/DashboardView.vue
+++ b/src/gui-v3/src/views/users/DashboardView.vue
@@ -266,6 +266,7 @@
     import { format } from 'date-fns'
     import gitMeta from '../../../git-info.json'
     import packageJson from '../../../package.json'
+    import { useSseResync } from '@/composables/useSseResync'
 
     const dashboardStore = useDashboardStore()
     const { t, te, locale } = useI18n()
@@ -404,6 +405,7 @@
     })
 
     let refreshInterval: ReturnType<typeof setInterval> | null = null
+    let refreshPromise: Promise<void> | null = null
 
     /**
      * Get translated state display name
@@ -423,17 +425,29 @@
     /**
      * Refresh dashboard data
      */
-    const refreshDashboard = async (): Promise<void> => {
-        if (refreshing.value) return
-        refreshing.value = true
-        try {
-            await dashboardStore.loadDashboardData()
-        } catch (error) {
-            console.error('[Dashboard] Error refreshing data:', error)
-        } finally {
-            refreshing.value = false
-        }
+    const refreshDashboard = (): Promise<void> => {
+        if (refreshPromise) return refreshPromise
+
+        refreshPromise = (async () => {
+            refreshing.value = true
+            try {
+                await dashboardStore.loadDashboardData()
+            } catch (error) {
+                console.error('[Dashboard] Error refreshing data:', error)
+            } finally {
+                refreshing.value = false
+                refreshPromise = null
+            }
+        })()
+        return refreshPromise
     }
+
+    const resyncDashboard = async (): Promise<void> => {
+        if (refreshPromise) await refreshPromise
+        await refreshDashboard()
+    }
+
+    useSseResync(resyncDashboard)
 
     /**
      * Component mount

--- a/src/gui-v3/tests/unit/AssetsStoreConcurrency.spec.ts
+++ b/src/gui-v3/tests/unit/AssetsStoreConcurrency.spec.ts
@@ -1,0 +1,44 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getAllAssets } from '@/api/assets'
+import { useAssetsStore } from '@/stores/assets'
+
+vi.mock('@/api/assets', () => ({
+    getAllAssetGroups: vi.fn(),
+    getAllAssets: vi.fn(),
+    getAllNotificationTemplates: vi.fn()
+}))
+
+const deferred = <T>() => {
+    let resolve!: (value: T) => void
+    const promise = new Promise<T>((done) => {
+        resolve = done
+    })
+    return { promise, resolve }
+}
+
+describe('assets store request ordering', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+        vi.clearAllMocks()
+    })
+
+    it('does not let a stale group request overwrite a newer route request', async () => {
+        const first = deferred<{ data: { total_count: number; items: Array<{ id: number; name: string }> } }>()
+        const second = deferred<{ data: { total_count: number; items: Array<{ id: number; name: string }> } }>()
+        vi.mocked(getAllAssets)
+            .mockReturnValueOnce(first.promise as unknown as ReturnType<typeof getAllAssets>)
+            .mockReturnValueOnce(second.promise as unknown as ReturnType<typeof getAllAssets>)
+        const store = useAssetsStore()
+
+        const oldGroup = store.loadAssets({ group_id: 'old', filter: { search: '', vulnerable: false, sort: 'ALPHABETICAL' } })
+        const currentGroup = store.loadAssets({ group_id: 'current', filter: { search: '', vulnerable: false, sort: 'ALPHABETICAL' } })
+
+        second.resolve({ data: { total_count: 1, items: [{ id: 2, name: 'current asset' }] } })
+        await currentGroup
+        first.resolve({ data: { total_count: 1, items: [{ id: 1, name: 'stale asset' }] } })
+        await oldGroup
+
+        expect(store.assets.items).toEqual([{ id: 2, name: 'current asset' }])
+    })
+})

--- a/src/gui-v3/tests/unit/ContentDataSSE.spec.js
+++ b/src/gui-v3/tests/unit/ContentDataSSE.spec.js
@@ -250,4 +250,46 @@ describe('SSE consumer components', () => {
             wrapper?.unmount()
         }
     })
+
+    it('coalesces full resynchronization for active Assess, Analyze, and Publish lists without changing selections', async () => {
+        vi.useFakeTimers()
+        const wrappers = [
+            mountWithPlugins(ContentDataAssess, {
+                props: { analyze_selector: false },
+                global: { stubs: commonStubs }
+            }),
+            mountWithPlugins(ContentDataAnalyze, {
+                props: { remoteReports: false },
+                global: { stubs: commonStubs }
+            }),
+            mountWithPlugins(ContentDataPublish, {
+                props: { selection: [] },
+                global: { stubs: commonStubs }
+            })
+        ]
+
+        try {
+            await flushPromises()
+            vi.clearAllMocks()
+
+            for (let i = 0; i < 8; i++) window.dispatchEvent(new CustomEvent('sse-resync'))
+            await vi.advanceTimersByTimeAsync(100)
+            await flushPromises()
+
+            expect(mockAssessStore.loadNewsItemsByGroup).toHaveBeenCalledTimes(1)
+            expect(mockAnalyzeStore.loadReportItems).toHaveBeenCalledTimes(1)
+            expect(mockAnalyzeStore.loadReportItemTypes).toHaveBeenCalledTimes(1)
+            expect(mockPublishStore.loadProducts).toHaveBeenCalledTimes(1)
+            expect(mockGetAllUserProductTypes).toHaveBeenCalledTimes(1)
+            expect(mockAssessStore.select).not.toHaveBeenCalled()
+            expect(mockAssessStore.deselect).not.toHaveBeenCalled()
+            expect(mockAnalyzeStore.selectReport).not.toHaveBeenCalled()
+            expect(mockAnalyzeStore.deselectReport).not.toHaveBeenCalled()
+            expect(mockPublishStore.select).not.toHaveBeenCalled()
+            expect(mockPublishStore.deselect).not.toHaveBeenCalled()
+        } finally {
+            wrappers.forEach((wrapper) => wrapper.unmount())
+            vi.useRealTimers()
+        }
+    })
 })

--- a/src/gui-v3/tests/unit/SseResyncAssetsDashboard.spec.js
+++ b/src/gui-v3/tests/unit/SseResyncAssetsDashboard.spec.js
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { mountWithPlugins } from '../helpers/mount-helpers'
+import ContentDataAssets from '@/components/assets/ContentDataAssets.vue'
+import MyAssetsNav from '@/views/nav/MyAssetsNav.vue'
+import DashboardView from '@/views/users/DashboardView.vue'
+
+const mocks = vi.hoisted(() => ({
+    route: { path: '/myassets/group/3', params: { groupId: '3' } },
+    router: { push: vi.fn(), replace: vi.fn() },
+    assetsStore: {
+        assetGroups: { total_count: 1, items: [{ id: 3, name: 'Servers' }] },
+        assets: { total_count: 1, items: [{ id: 8, name: 'host.example' }] },
+        loadAssetGroups: vi.fn().mockResolvedValue({}),
+        loadAssets: vi.fn().mockResolvedValue({}),
+        clearAssets: vi.fn()
+    },
+    dashboardStore: {
+        dashboard_data: {
+            total_news_items: 1,
+            total_products: 2,
+            total_report_items: 3,
+            total_database_items: 4,
+            latest_collected: '',
+            news_items_by_day: [],
+            tag_cloud: [],
+            report_item_states: {},
+            product_states: {}
+        },
+        loadDashboardData: vi.fn().mockResolvedValue(undefined)
+    }
+}))
+
+vi.mock('vue-router', () => ({
+    useRoute: () => mocks.route,
+    useRouter: () => mocks.router
+}))
+
+vi.mock('@/stores/assets', () => ({ useAssetsStore: () => mocks.assetsStore }))
+vi.mock('@/stores/dashboard', () => ({ useDashboardStore: () => mocks.dashboardStore }))
+vi.mock('@/api/assets', () => ({ deleteAsset: vi.fn() }))
+vi.mock('@/composables/useAuth', () => ({ useAuth: () => ({ checkPermission: () => true }) }))
+
+const stubs = {
+    CardAsset: { template: '<div class="asset-card-stub" />' },
+    GroupNavList: { template: '<div class="group-nav-stub" />' },
+    WordCloud: { template: '<div class="word-cloud-stub" />' }
+}
+
+describe('SSE resynchronization for Assets and Dashboard', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+        vi.clearAllMocks()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it('refreshes the active asset group and asset-group navigation once per signal burst', async () => {
+        const content = mountWithPlugins(ContentDataAssets, { global: { stubs } })
+        const navigation = mountWithPlugins(MyAssetsNav, { global: { stubs } })
+
+        try {
+            await flushPromises()
+            vi.clearAllMocks()
+
+            for (let i = 0; i < 6; i++) window.dispatchEvent(new CustomEvent('sse-resync'))
+            await vi.advanceTimersByTimeAsync(100)
+            await flushPromises()
+
+            expect(mocks.assetsStore.loadAssets).toHaveBeenCalledTimes(1)
+            expect(mocks.assetsStore.loadAssets).toHaveBeenCalledWith({
+                group_id: '3',
+                filter: { search: '', vulnerable: false, sort: 'ALPHABETICAL' }
+            })
+            expect(mocks.assetsStore.loadAssetGroups).toHaveBeenCalledTimes(1)
+            expect(mocks.assetsStore.clearAssets).not.toHaveBeenCalled()
+        } finally {
+            content.unmount()
+            navigation.unmount()
+        }
+    })
+
+    it('refreshes Dashboard after a missed-event signal and coalesces bursts', async () => {
+        const wrapper = mountWithPlugins(DashboardView, { global: { stubs } })
+
+        try {
+            await flushPromises()
+            mocks.dashboardStore.loadDashboardData.mockClear()
+
+            window.dispatchEvent(new CustomEvent('sse-resync'))
+            window.dispatchEvent(new CustomEvent('sse-resync'))
+            await vi.advanceTimersByTimeAsync(100)
+            await flushPromises()
+
+            expect(mocks.dashboardStore.loadDashboardData).toHaveBeenCalledTimes(1)
+        } finally {
+            wrapper.unmount()
+        }
+    })
+})

--- a/src/gui-v3/tests/unit/useSseResync.spec.ts
+++ b/src/gui-v3/tests/unit/useSseResync.spec.ts
@@ -1,0 +1,83 @@
+import { defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useSseResync } from '@/composables/useSseResync'
+
+const deferred = () => {
+    let resolve!: () => void
+    const promise = new Promise<void>((done) => {
+        resolve = done
+    })
+    return { promise, resolve }
+}
+
+const mountConsumer = (handler: () => void | Promise<void>) =>
+    mount(
+        defineComponent({
+            setup() {
+                useSseResync(handler)
+                return () => h('div')
+            }
+        })
+    )
+
+describe('useSseResync', () => {
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it('coalesces a burst and removes its listener on unmount', async () => {
+        vi.useFakeTimers()
+        const handler = vi.fn()
+        const wrapper = mountConsumer(handler)
+
+        window.dispatchEvent(new CustomEvent('sse-resync'))
+        window.dispatchEvent(new CustomEvent('sse-resync'))
+        window.dispatchEvent(new CustomEvent('sse-resync'))
+        await vi.advanceTimersByTimeAsync(100)
+
+        expect(handler).toHaveBeenCalledTimes(1)
+
+        wrapper.unmount()
+        window.dispatchEvent(new CustomEvent('sse-resync'))
+        await vi.advanceTimersByTimeAsync(100)
+        expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('serializes refreshes and collapses signals received while one is running', async () => {
+        vi.useFakeTimers()
+        const first = deferred()
+        const handler = vi.fn().mockReturnValueOnce(first.promise).mockResolvedValue(undefined)
+        const wrapper = mountConsumer(handler)
+
+        window.dispatchEvent(new CustomEvent('sse-resync'))
+        await vi.advanceTimersByTimeAsync(100)
+        expect(handler).toHaveBeenCalledTimes(1)
+
+        window.dispatchEvent(new CustomEvent('sse-resync'))
+        window.dispatchEvent(new CustomEvent('sse-resync'))
+        first.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(handler).toHaveBeenCalledTimes(2)
+        wrapper.unmount()
+    })
+
+    it('does not run a trailing refresh after its consumer unmounts', async () => {
+        vi.useFakeTimers()
+        const first = deferred()
+        const handler = vi.fn().mockReturnValue(first.promise)
+        const wrapper = mountConsumer(handler)
+
+        window.dispatchEvent(new CustomEvent('sse-resync'))
+        await vi.advanceTimersByTimeAsync(100)
+        window.dispatchEvent(new CustomEvent('sse-resync'))
+        wrapper.unmount()
+        first.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(handler).toHaveBeenCalledTimes(1)
+    })
+})


### PR DESCRIPTION
## Resynchronize Vue 3 data after SSE gaps

### What changed

- Added frontend resynchronization after the existing `sse-resync` signal for:
  - Assess
  - Analyze
  - Publish
  - My Assets
  - Dashboard
- Added a shared resynchronization composable that:
  - Coalesces event bursts
  - Prevents parallel refresh storms
  - Allows one trailing refresh when another signal arrives during a request
  - Handles refresh failures safely
  - Removes timers and listeners when components unmount
- Preserved active selections, open editors, and list viewport position.
- Added request sequencing to My Assets so a slow response from a previous group cannot overwrite the current group.
- Made Dashboard refresh single-flight while guaranteeing a fresh recovery pass.

### Why

Vue 3 reconnects its SSE stream after connection gaps or long background periods, but most screens did not reload data that may have changed while disconnected. They could therefore remain stale until another event or manual refresh.

### Scope

This is entirely frontend-side. No backend, API, database, migration, or protocol changes were required.

### Validation

- Full frontend unit suite: 776/776 tests passed
- Focused SSE and concurrency tests: 11/11 passed
- Full ESLint passed
- Full TypeScript check passed
- Full Prettier check passed
- `git diff --check` passed