### PR TITLE
Enforce inherited provider and workflow permissions

### DIFF
--- a/src/gui-v3/src/components/config/data-providers/AiProvidersTab.vue
+++ b/src/gui-v3/src/components/config/data-providers/AiProvidersTab.vue
@@ -61,6 +61,7 @@
                         @click="handleEdit(asAiProviderItem(item))"
                     />
                     <ActionButton
+                        v-if="canDelete"
                         action="delete"
                         :title="t('common.delete')"
                         @click="handleDelete(asAiProviderItem(item))"
@@ -79,7 +80,7 @@
 </template>
 
 <script setup lang="ts">
-    import { ref, onMounted } from 'vue'
+    import { computed, ref, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useConfigStore } from '@/stores/config'
     import { deleteAiProvider } from '@/api/config'
@@ -87,6 +88,7 @@
     import ActionButton from '@/components/common/buttons/ActionButton.vue'
     import SearchField from '@/components/common/SearchField.vue'
     import ConfirmationDialog from '@/components/common/dialogs/ConfirmationDialog.vue'
+    import { useAuth } from '@/composables/useAuth'
 
     type HeaderEntry = {
         title: string
@@ -107,6 +109,8 @@
 
     const { t } = useI18n()
     const configStore = useConfigStore()
+    const { checkPermission } = useAuth()
+    const canDelete = computed(() => checkPermission('CONFIG_AI_DELETE'))
 
     const search = ref('')
     const editItem = ref<AiProviderItem | null>(null)
@@ -139,12 +143,13 @@
     }
 
     const handleDelete = (item: AiProviderItem): void => {
+        if (!canDelete.value) return
         itemToDelete.value = item
         deleteDialog.value = true
     }
 
     const confirmDelete = async (): Promise<void> => {
-        if (!itemToDelete.value) {
+        if (!canDelete.value || !itemToDelete.value) {
             return
         }
         try {

--- a/src/gui-v3/src/components/config/data-providers/DataProvidersTab.vue
+++ b/src/gui-v3/src/components/config/data-providers/DataProvidersTab.vue
@@ -51,6 +51,7 @@
                         @click="handleEdit(asDataProviderItem(item))"
                     />
                     <ActionButton
+                        v-if="canDelete"
                         action="delete"
                         :title="t('common.delete')"
                         @click="handleDelete(asDataProviderItem(item))"
@@ -69,7 +70,7 @@
 </template>
 
 <script setup lang="ts">
-    import { ref, onMounted } from 'vue'
+    import { computed, ref, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useConfigStore } from '@/stores/config'
     import { deleteDataProvider } from '@/api/config'
@@ -77,6 +78,7 @@
     import ActionButton from '@/components/common/buttons/ActionButton.vue'
     import SearchField from '@/components/common/SearchField.vue'
     import ConfirmationDialog from '@/components/common/dialogs/ConfirmationDialog.vue'
+    import { useAuth } from '@/composables/useAuth'
 
     type HeaderEntry = {
         title: string
@@ -99,6 +101,8 @@
 
     const { t } = useI18n()
     const configStore = useConfigStore()
+    const { checkPermission } = useAuth()
+    const canDelete = computed(() => checkPermission('CONFIG_DATA_PROVIDER_DELETE'))
 
     const search = ref('')
     const editItem = ref<DataProviderItem | null>(null)
@@ -133,12 +137,13 @@
     }
 
     const handleDelete = (item: DataProviderItem): void => {
+        if (!canDelete.value) return
         itemToDelete.value = item
         deleteDialog.value = true
     }
 
     const confirmDelete = async (): Promise<void> => {
-        if (!itemToDelete.value) {
+        if (!canDelete.value || !itemToDelete.value) {
             return
         }
         try {

--- a/src/gui-v3/src/components/config/data-providers/NewAiProvider.vue
+++ b/src/gui-v3/src/components/config/data-providers/NewAiProvider.vue
@@ -17,6 +17,7 @@
             <DialogToolbar
                 :title="isEdit ? t('data_providers.ai.edit') : t('data_providers.ai.add_new')"
                 :saving="saving"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -24,6 +25,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-text-field
@@ -171,9 +173,11 @@
 
     const isEdit = computed(() => !!localItem.value.id)
     const canCreate = computed(() => checkPermission('CONFIG_AI_CREATE'))
+    const canSave = computed(() => checkPermission(isEdit.value ? 'CONFIG_AI_UPDATE' : 'CONFIG_AI_CREATE'))
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     async function persist(): Promise<boolean> {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/data-providers/NewDataProvider.vue
+++ b/src/gui-v3/src/components/config/data-providers/NewDataProvider.vue
@@ -17,6 +17,7 @@
             <DialogToolbar
                 :title="isEdit ? t('data_providers.data.edit') : t('data_providers.data.add_new')"
                 :saving="saving"
+                :show-save="canSave"
                 @cancel="requestClose"
                 @save="saveAndClose"
             />
@@ -24,6 +25,7 @@
             <v-card-text>
                 <v-form
                     ref="formRef"
+                    :disabled="!canSave"
                     @submit.prevent="saveAndClose"
                 >
                     <v-text-field
@@ -184,9 +186,11 @@
 
     const canCreate = computed(() => checkPermission('CONFIG_DATA_PROVIDER_CREATE'))
     const isEdit = computed(() => !!localItem.value.id)
+    const canSave = computed(() => checkPermission(isEdit.value ? 'CONFIG_DATA_PROVIDER_UPDATE' : 'CONFIG_DATA_PROVIDER_CREATE'))
 
     // Persists the form. Returns true on success so the guard can decide whether to close.
     async function persist(): Promise<boolean> {
+        if (!canSave.value) return false
         showValidationError.value = false
         showError.value = false
 

--- a/src/gui-v3/src/components/config/workflow/StateWorkflowTab.vue
+++ b/src/gui-v3/src/components/config/workflow/StateWorkflowTab.vue
@@ -88,6 +88,7 @@
                             @click="editItem(item)"
                         />
                         <ActionButton
+                            v-if="canDelete"
                             action="delete"
                             :title="t('common.delete')"
                             @click="deleteItem(item)"
@@ -130,18 +131,21 @@
                             ? t('workflow.state_workflow.add_state_association')
                             : t('workflow.state_workflow.edit_state_association')
                     "
-                    :show-save="isEditable"
+                    :show-save="canSave"
                     :saving="saving"
                     @cancel="requestClose"
                     @save="saveAndClose"
                 />
                 <v-card-text>
-                    <v-form ref="formRef">
+                    <v-form
+                        ref="formRef"
+                        :disabled="!canSave"
+                    >
                         <v-select
                             v-model="editedItem.entity_type"
                             :items="entityTypeFilter"
                             :label="t('workflow.state_workflow.entity_type')"
-                            :disabled="!isEditable"
+                            :disabled="!canSave"
                             variant="outlined"
                             density="comfortable"
                             class="mb-3"
@@ -154,7 +158,7 @@
                             item-title="display_name"
                             item-value="id"
                             :label="t('workflow.state_workflow.state')"
-                            :disabled="!isEditable"
+                            :disabled="!canSave"
                             variant="outlined"
                             density="comfortable"
                             class="mb-3"
@@ -165,7 +169,7 @@
                             v-model="editedItem.state_type"
                             :items="stateTypeOptions"
                             :label="t('workflow.state_workflow.state_type')"
-                            :disabled="!isEditable"
+                            :disabled="!canSave"
                             variant="outlined"
                             density="comfortable"
                             class="mb-3"
@@ -174,7 +178,7 @@
                         <v-text-field
                             v-model.number="editedItem.sort_order"
                             :label="t('workflow.state_workflow.sort_order')"
-                            :disabled="!isEditable"
+                            :disabled="!canSave"
                             variant="outlined"
                             type="number"
                             density="comfortable"
@@ -184,7 +188,7 @@
                         <v-switch
                             v-model="editedItem.is_active"
                             :label="t('workflow.state_workflow.is_active')"
-                            :disabled="!isEditable"
+                            :disabled="!canSave"
                             color="primary"
                         />
                     </v-form>
@@ -296,8 +300,11 @@
     ]
 
     const canCreate = computed(() => checkPermission('CONFIG_WORKFLOW_CREATE'))
+    const canUpdate = computed(() => checkPermission('CONFIG_WORKFLOW_UPDATE'))
+    const canDelete = computed(() => checkPermission('CONFIG_WORKFLOW_DELETE'))
 
     const isEditable = computed(() => editedIndex.value === -1 || editedItem.value.editable)
+    const canSave = computed(() => isEditable.value && (editedIndex.value === -1 ? canCreate.value : canUpdate.value))
 
     const availableStates = computed<StateDefinition[]>(() =>
         Array.isArray(configStore.stateDefinitions.items) ? (configStore.stateDefinitions.items as StateDefinition[]) : []
@@ -347,6 +354,7 @@
     }
 
     function addItem(): void {
+        if (!canCreate.value) return
         editedIndex.value = -1
         editedItem.value = { ...defaultItem }
         dialogEdit.value = true
@@ -360,7 +368,7 @@
     }
 
     function deleteItem(item: StateEntityTypeRecord): void {
-        if (!item.editable) return
+        if (!canDelete.value || !item.editable) return
         const records = filteredRecords.value
         editedIndex.value = records.indexOf(item)
         editedItem.value = { ...item }
@@ -381,6 +389,7 @@
     // Persists the form. Returns true on success so the unsaved-changes guard can
     // decide whether to close the dialog (it closes only on a successful save).
     async function persist(): Promise<boolean> {
+        if (!canSave.value) return false
         const { valid } = (await formRef.value?.validate()) as FormValidationResult
         if (!valid) {
             return false
@@ -441,7 +450,7 @@
     )
 
     async function deleteRecord(): Promise<void> {
-        if (!editedItem.value.editable) {
+        if (!canDelete.value || !editedItem.value.editable) {
             closeDelete()
             return
         }

--- a/src/gui-v3/src/components/config/workflow/StatesTab.vue
+++ b/src/gui-v3/src/components/config/workflow/StatesTab.vue
@@ -59,6 +59,7 @@
                             @click="editItem(item)"
                         />
                         <ActionButton
+                            v-if="canDelete"
                             action="delete"
                             :title="t('common.delete')"
                             @click="deleteItem(item)"
@@ -97,17 +98,20 @@
             <v-card>
                 <DialogToolbar
                     :title="editedIndex === -1 ? t('workflow.states.add_new') : t('workflow.states.edit')"
-                    :show-save="isEditable"
+                    :show-save="canSave"
                     :saving="saving"
                     @cancel="requestClose"
                     @save="saveAndClose"
                 />
                 <v-card-text>
-                    <v-form ref="formRef">
+                    <v-form
+                        ref="formRef"
+                        :disabled="!canSave"
+                    >
                         <v-text-field
                             v-model="editedItem.display_name"
                             :label="t('workflow.states.display_name')"
-                            :disabled="!isEditable"
+                            :disabled="!canSave"
                             variant="outlined"
                             density="comfortable"
                             class="mb-3"
@@ -117,7 +121,7 @@
                         <v-textarea
                             v-model="editedItem.description"
                             :label="t('workflow.states.description')"
-                            :disabled="!isEditable"
+                            :disabled="!canSave"
                             variant="outlined"
                             density="comfortable"
                             rows="3"
@@ -127,7 +131,7 @@
                         <v-text-field
                             v-model="editedItem.color"
                             :label="t('workflow.states.color')"
-                            :disabled="!isEditable"
+                            :disabled="!canSave"
                             variant="outlined"
                             type="color"
                             density="comfortable"
@@ -137,7 +141,7 @@
                         <v-text-field
                             v-model="editedItem.icon"
                             :label="t('workflow.states.icon')"
-                            :disabled="!isEditable"
+                            :disabled="!canSave"
                             variant="outlined"
                             density="comfortable"
                             placeholder="mdi-circle"
@@ -221,8 +225,11 @@
     ]
 
     const canCreate = computed(() => checkPermission('CONFIG_WORKFLOW_CREATE'))
+    const canUpdate = computed(() => checkPermission('CONFIG_WORKFLOW_UPDATE'))
+    const canDelete = computed(() => checkPermission('CONFIG_WORKFLOW_DELETE'))
 
     const isEditable = computed(() => editedIndex.value === -1 || editedItem.value.editable)
+    const canSave = computed(() => isEditable.value && (editedIndex.value === -1 ? canCreate.value : canUpdate.value))
 
     const filteredRecords = computed<StateDefinition[]>(() =>
         Array.isArray(configStore.stateDefinitions.items) ? (configStore.stateDefinitions.items as StateDefinition[]) : []
@@ -238,6 +245,7 @@
     }
 
     function addItem(): void {
+        if (!canCreate.value) return
         editedIndex.value = -1
         editedItem.value = { ...defaultItem }
         dialogEdit.value = true
@@ -251,7 +259,7 @@
     }
 
     function deleteItem(item: StateDefinition): void {
-        if (!item.editable) return
+        if (!canDelete.value || !item.editable) return
         const records = filteredRecords.value
         editedIndex.value = records.indexOf(item)
         editedItem.value = { ...item }
@@ -272,6 +280,7 @@
     // Persists the form. Returns true on success so the unsaved-changes guard can
     // decide whether to close the dialog (it closes only on a successful save).
     async function persist(): Promise<boolean> {
+        if (!canSave.value) return false
         const { valid } = (await formRef.value?.validate()) as FormValidationResult
         if (!valid) {
             return false
@@ -331,7 +340,7 @@
     )
 
     async function deleteRecord(): Promise<void> {
-        if (!editedItem.value.editable) {
+        if (!canDelete.value || !editedItem.value.editable) {
             closeDelete()
             return
         }

--- a/src/gui-v3/tests/unit/InheritedConfigPermissionSemantics.spec.js
+++ b/src/gui-v3/tests/unit/InheritedConfigPermissionSemantics.spec.js
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { readFileSync } from 'node:fs'
+import { mountWithPlugins } from '../helpers/mount-helpers'
+import NewDataProvider from '@/components/config/data-providers/NewDataProvider.vue'
+import NewAiProvider from '@/components/config/data-providers/NewAiProvider.vue'
+import StatesTab from '@/components/config/workflow/StatesTab.vue'
+import StateWorkflowTab from '@/components/config/workflow/StateWorkflowTab.vue'
+
+const { allowedPermissions, api, configStore } = vi.hoisted(() => ({
+    allowedPermissions: new Set(),
+    api: {
+        createNewDataProvider: vi.fn(),
+        updateDataProvider: vi.fn(),
+        createNewAiProvider: vi.fn(),
+        updateAiProvider: vi.fn(),
+        createNewStateDefinition: vi.fn(),
+        updateStateDefinition: vi.fn(),
+        deleteStateDefinition: vi.fn(),
+        createNewStateEntityType: vi.fn(),
+        updateStateEntityType: vi.fn(),
+        deleteStateEntityType: vi.fn()
+    },
+    configStore: {
+        stateDefinitions: { items: [] },
+        stateEntityTypes: { items: [] },
+        loadStateDefinitions: vi.fn().mockResolvedValue(undefined),
+        loadStateEntityTypes: vi.fn().mockResolvedValue(undefined)
+    }
+}))
+
+vi.mock('@/composables/useAuth', () => ({
+    useAuth: () => ({ checkPermission: (permission) => allowedPermissions.has(permission) })
+}))
+
+vi.mock('@/api/config', () => api)
+vi.mock('@/stores/config', () => ({ useConfigStore: () => configStore }))
+
+const VDialogStub = {
+    name: 'VDialog',
+    props: ['modelValue'],
+    template: '<div><slot /><slot name="activator" :props="{}" /></div>'
+}
+
+const VFormStub = {
+    name: 'VForm',
+    props: ['disabled'],
+    methods: { validate: vi.fn().mockResolvedValue({ valid: true }), reset: vi.fn() },
+    template: '<form><slot /></form>'
+}
+
+const DialogToolbarStub = {
+    name: 'DialogToolbar',
+    props: ['showSave'],
+    emits: ['save', 'cancel'],
+    template: '<div class="dialog-toolbar" />'
+}
+
+const AddNewButtonStub = {
+    name: 'AddNewButton',
+    props: { show: { type: Boolean, default: true } },
+    emits: ['click'],
+    template: '<button v-if="show" class="add-new" @click="$emit(\'click\')" />'
+}
+
+const commonStubs = {
+    VDialog: VDialogStub,
+    VForm: VFormStub,
+    DialogToolbar: DialogToolbarStub,
+    AddNewButton: AddNewButtonStub,
+    UnsavedChangesDialog: true,
+    ConfirmationDialog: true,
+    SearchField: true
+}
+
+const dataProvider = {
+    id: 7,
+    name: 'EUVD',
+    api_type: 'EUVD',
+    api_url: 'https://example.test',
+    api_key: '',
+    user_agent: '',
+    web_url: ''
+}
+
+const aiProvider = {
+    id: 8,
+    name: 'AI',
+    api_type: 'openai',
+    api_url: 'https://example.test',
+    api_key: 'secret',
+    model: 'example'
+}
+
+const mountProvider = (component, editItem = null) =>
+    mountWithPlugins(component, {
+        props: { editItem },
+        global: { stubs: commonStubs }
+    })
+
+describe('data and AI provider permission roles', () => {
+    beforeEach(() => {
+        allowedPermissions.clear()
+        vi.clearAllMocks()
+    })
+
+    it.each([
+        [NewDataProvider, dataProvider, 'CONFIG_DATA_PROVIDER_CREATE'],
+        [NewAiProvider, aiProvider, 'CONFIG_AI_CREATE']
+    ])('keeps create-only users out of existing %s editing', async (component, item, createPermission) => {
+        allowedPermissions.add(createPermission)
+        expect(mountProvider(component).find('.add-new').exists()).toBe(true)
+
+        const detail = mountProvider(component, item)
+        await flushPromises()
+        expect(detail.findComponent(DialogToolbarStub).props('showSave')).toBe(false)
+        expect(detail.findComponent(VFormStub).props('disabled')).toBe(true)
+    })
+
+    it.each([
+        [NewDataProvider, dataProvider, 'CONFIG_DATA_PROVIDER_UPDATE'],
+        [NewAiProvider, aiProvider, 'CONFIG_AI_UPDATE']
+    ])('allows update independently for %s', async (component, item, updatePermission) => {
+        allowedPermissions.add(updatePermission)
+        const detail = mountProvider(component, item)
+        await flushPromises()
+
+        expect(detail.find('.add-new').exists()).toBe(false)
+        expect(detail.findComponent(DialogToolbarStub).props('showSave')).toBe(true)
+        expect(detail.findComponent(VFormStub).props('disabled')).toBe(false)
+    })
+
+    it('rejects a direct provider save without update permission', async () => {
+        const detail = mountProvider(NewDataProvider, dataProvider)
+        await flushPromises()
+
+        expect(await detail.vm.persist()).toBe(false)
+        expect(api.updateDataProvider).not.toHaveBeenCalled()
+    })
+})
+
+describe('workflow permission roles', () => {
+    const state = {
+        id: 1,
+        display_name: 'Draft',
+        description: '',
+        color: '#2196F3',
+        icon: 'mdi-circle',
+        editable: true
+    }
+    const association = {
+        id: 2,
+        entity_type: 'report_item',
+        state_id: 1,
+        state_type: 'normal',
+        is_active: true,
+        editable: true,
+        sort_order: 0,
+        state
+    }
+
+    beforeEach(() => {
+        allowedPermissions.clear()
+        vi.clearAllMocks()
+        configStore.stateDefinitions.items = [state]
+        configStore.stateEntityTypes.items = [association]
+    })
+
+    it.each([
+        [StatesTab, state],
+        [StateWorkflowTab, association]
+    ])('opens existing %s records read-only without update', async (component, item) => {
+        allowedPermissions.add('CONFIG_WORKFLOW_ACCESS')
+        const wrapper = mountWithPlugins(component, { global: { stubs: commonStubs } })
+        wrapper.vm.editItem(item)
+        await flushPromises()
+
+        expect(wrapper.vm.canSave).toBe(false)
+        expect(wrapper.findComponent(DialogToolbarStub).props('showSave')).toBe(false)
+        expect(wrapper.findComponent(VFormStub).props('disabled')).toBe(true)
+    })
+
+    it.each([
+        [StatesTab, state],
+        [StateWorkflowTab, association]
+    ])('allows workflow update without implying delete for %s', async (component, item) => {
+        allowedPermissions.add('CONFIG_WORKFLOW_UPDATE')
+        const wrapper = mountWithPlugins(component, { global: { stubs: commonStubs } })
+        wrapper.vm.editItem(item)
+        await flushPromises()
+
+        expect(wrapper.vm.canSave).toBe(true)
+        expect(wrapper.vm.canDelete).toBe(false)
+        wrapper.vm.deleteItem(item)
+        expect(wrapper.vm.dialogDelete).toBe(false)
+    })
+
+    it('enables workflow create, update, and delete for full access', async () => {
+        for (const permission of ['CONFIG_WORKFLOW_CREATE', 'CONFIG_WORKFLOW_UPDATE', 'CONFIG_WORKFLOW_DELETE']) {
+            allowedPermissions.add(permission)
+        }
+        const wrapper = mountWithPlugins(StatesTab, { global: { stubs: commonStubs } })
+
+        expect(wrapper.find('.add-new').exists()).toBe(true)
+        wrapper.vm.editItem(state)
+        await flushPromises()
+        expect(wrapper.vm.canSave).toBe(true)
+        wrapper.vm.deleteItem(state)
+        expect(wrapper.vm.dialogDelete).toBe(true)
+    })
+})
+
+describe('inherited configuration permission coverage', () => {
+    const sourceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../src')
+    const matrix = [
+        ['components/config/data-providers/NewDataProvider.vue', 'CONFIG_DATA_PROVIDER_CREATE', 'CONFIG_DATA_PROVIDER_UPDATE'],
+        ['components/config/data-providers/NewAiProvider.vue', 'CONFIG_AI_CREATE', 'CONFIG_AI_UPDATE'],
+        ['components/config/workflow/StatesTab.vue', 'CONFIG_WORKFLOW_CREATE', 'CONFIG_WORKFLOW_UPDATE'],
+        ['components/config/workflow/StateWorkflowTab.vue', 'CONFIG_WORKFLOW_CREATE', 'CONFIG_WORKFLOW_UPDATE']
+    ]
+
+    it.each(matrix)('%s has independent create/update persistence gates', (relativePath, createPermission, updatePermission) => {
+        const source = readFileSync(resolve(sourceRoot, relativePath), 'utf8')
+        expect(source).toContain(createPermission)
+        expect(source).toContain(updatePermission)
+        expect(source).toContain(':show-save="canSave"')
+        expect(source).toContain('if (!canSave.value) return false')
+    })
+
+    const deletionMatrix = [
+        ['components/config/data-providers/DataProvidersTab.vue', 'CONFIG_DATA_PROVIDER_DELETE'],
+        ['components/config/data-providers/AiProvidersTab.vue', 'CONFIG_AI_DELETE'],
+        ['components/config/workflow/StatesTab.vue', 'CONFIG_WORKFLOW_DELETE'],
+        ['components/config/workflow/StateWorkflowTab.vue', 'CONFIG_WORKFLOW_DELETE']
+    ]
+
+    it.each(deletionMatrix)('%s gates row deletion', (relativePath, deletePermission) => {
+        const source = readFileSync(resolve(sourceRoot, relativePath), 'utf8')
+        expect(source).toContain(deletePermission)
+        expect(source).toContain('v-if="canDelete"')
+        expect(source).toContain('if (!canDelete.value')
+    })
+})


### PR DESCRIPTION
## Enforce inherited provider and workflow permissions

### What changed

- Added independent create, update, and delete permission handling for:
  - Data providers
  - AI providers
  - Workflow states
  - Workflow state associations
- Users with access but without update permission now receive genuine read-only details.
- Save is hidden and mutation handlers reject direct calls without update permission.
- Delete controls are hidden and defensively guarded without delete permission.
- Create permission remains independent from update and delete.
- Backend-protected workflow records remain locked regardless of the user’s role.
- Existing non-mutating Tags and Tag Workflow placeholders remain unchanged.
- Added a role-matrix test suite covering:
  - Create-only users
  - Access-only users
  - Update without delete
  - Full access
  - Direct save/delete guard behavior
  - Locked workflow records

### Why

These provider and workflow screens inherited incomplete authorization UX from the legacy GUI. Users could see editable or destructive controls that the backend would later reject. This applies the permission model already established across the rest of Vue 3 configuration.

### Scope

This is entirely frontend-side. No backend permission, API, database, migration, or schema changes were made.

### Validation

- New role-matrix tests: 18/18 passed
- Combined relevant permission suite: 72/72 passed
- Full frontend suite: 776/776 passed
- TypeScript check passed
- ESLint and Prettier checks passed
- `git diff --check` passed