### PR TITLE
Restore Vue 3 parity for create-only Assess users and enforce per-item modification restrictions.

### DIFF
--- a/src/gui-v3/src/components/analyze/CardAnalyze.vue
+++ b/src/gui-v3/src/components/analyze/CardAnalyze.vue
@@ -133,6 +133,7 @@
     import BaseCard from '@/components/common/BaseCard.vue'
     import ActionButton from '@/components/common/buttons/ActionButton.vue'
     import ConfirmationDialog from '@/components/common/dialogs/ConfirmationDialog.vue'
+    import { isRemoteAnalyzeRoute } from '@/utils/analyze-routing'
 
     type AnalyzeCard = {
         id: number | string
@@ -196,7 +197,7 @@
     })
 
     const canCreateProduct = computed(() => {
-        return !isRemote.value && checkPermission(PERMISSIONS.PUBLISH_CREATE) && !route.path.includes('/group/')
+        return !isRemote.value && checkPermission(PERMISSIONS.PUBLISH_CREATE) && !isRemoteAnalyzeRoute(route)
     })
 
     const multiSelectActive = computed(() => {

--- a/src/gui-v3/src/components/analyze/ContentDataAnalyze.vue
+++ b/src/gui-v3/src/components/analyze/ContentDataAnalyze.vue
@@ -83,6 +83,7 @@
     import CardAnalyze from './CardAnalyze.vue'
     import CardCompact from '@/components/common/CardCompact.vue'
     import { useSseResync } from '@/composables/useSseResync'
+    import { getAnalyzeGroupName } from '@/utils/analyze-routing'
 
     type ReportItem = {
         id: string | number
@@ -154,17 +155,6 @@
         emit('show-report-item-detail', item)
     }
 
-    const getNormalizedScope = (): string => {
-        const scope = route.params['scope']
-        if (typeof scope === 'string') {
-            return scope
-        }
-        if (Array.isArray(scope)) {
-            return scope[0] || 'local'
-        }
-        return 'local'
-    }
-
     const infiniteScrolling = (isIntersecting: boolean): void => {
         const totalCount = analyzeStore.getReportItems.total_count || 0
         // Don't attempt to load more when there are no items to load
@@ -197,21 +187,11 @@
             offset = 0
         }
 
-        let group = ''
-        if (props.remoteReports) {
-            group = typeof analyzeStore.getCurrentReportItemGroup === 'string' ? analyzeStore.getCurrentReportItemGroup : ''
-        } else {
-            // Extract scope from route params
-            const scope = getNormalizedScope()
-            if (scope !== 'local') {
-                // If scope starts with 'group-', extract the group name
-                if (scope.startsWith('group-')) {
-                    group = scope.substring(6).replaceAll('-', ' ')
-                } else {
-                    group = scope.replaceAll('-', ' ')
-                }
-            }
-        }
+        const group = props.remoteReports
+            ? typeof analyzeStore.getCurrentReportItemGroup === 'string'
+                ? analyzeStore.getCurrentReportItemGroup
+                : ''
+            : getAnalyzeGroupName(route)
 
         try {
             // Load the report items list and the report-item-type catalog in

--- a/src/gui-v3/src/components/analyze/NewReportItem.vue
+++ b/src/gui-v3/src/components/analyze/NewReportItem.vue
@@ -446,6 +446,7 @@
     import NewsItemSelector from '@/components/analyze/NewsItemSelector.vue'
     import RemoteReportItemSelector from '@/components/analyze/RemoteReportItemSelector.vue'
     import StateSelector from '@/components/common/StateSelector.vue'
+    import { isRemoteAnalyzeRoute } from '@/utils/analyze-routing'
 
     type FormRef = {
         resetValidation?: () => void
@@ -517,7 +518,6 @@
     const expand_group_items = ref<any[]>([])
     const autoGenerateIcon = reactive<Record<string | number, string>>({})
     const autoGenerateIconTimer = reactive<Record<string | number, ReturnType<typeof setTimeout> | null>>({})
-    const local_reports = ref<boolean>(true)
 
     const field_locks = reactive({
         title_prefix: false,
@@ -549,7 +549,7 @@
 
     // Computed
     const canCreate = computed<boolean>(() => {
-        return checkPermission('ANALYZE_CREATE') && local_reports.value === true
+        return checkPermission('ANALYZE_CREATE') && !isRemoteAnalyzeRoute(route)
     })
 
     const canModify = computed<boolean>(() => {
@@ -1346,17 +1346,9 @@
         }
     })
 
-    watch(
-        () => route.path,
-        () => {
-            local_reports.value = !window.location.pathname.includes('/group/')
-        }
-    )
-
     // Lifecycle
     onMounted(async () => {
         loadAvailableStates()
-        local_reports.value = !window.location.pathname.includes('/group/')
         await loadReportTypes()
 
         window.addEventListener('report-item-locked', reportItemLockedEvent)

--- a/src/gui-v3/src/components/assess/AssessItemActions.vue
+++ b/src/gui-v3/src/components/assess/AssessItemActions.vue
@@ -183,6 +183,8 @@
         dislikes?: number
         important?: boolean
         read?: boolean
+        modify?: boolean
+        entityType?: 'news_item' | 'news_item_aggregate'
         link?: string
         news_items?: Array<{
             news_item_data?: {
@@ -278,11 +280,13 @@
     }
 
     const canModify = computed(() => {
-        return checkPermission(PERMISSIONS.ASSESS_UPDATE)
+        const itemAllowsModification = props.item.entityType !== 'news_item' || props.item.modify === true
+        return checkPermission(PERMISSIONS.ASSESS_UPDATE) && itemAllowsModification
     })
 
     const canDelete = computed(() => {
-        return checkPermission(PERMISSIONS.ASSESS_DELETE)
+        const itemAllowsDeletion = props.item.entityType !== 'news_item' || props.item.modify === true
+        return checkPermission(PERMISSIONS.ASSESS_DELETE) && itemAllowsDeletion
     })
 
     const canCreateReport = computed(() => {

--- a/src/gui-v3/src/components/assess/CardAssess.vue
+++ b/src/gui-v3/src/components/assess/CardAssess.vue
@@ -337,6 +337,10 @@
     }
 
     const handleDelete = async (): Promise<void> => {
+        if (!checkPermission('ASSESS_DELETE')) {
+            return
+        }
+
         try {
             await deleteNewsItemAggregate('', props.card.id)
             emit('delete-item', props.card)

--- a/src/gui-v3/src/components/assess/ContentDataAssess.vue
+++ b/src/gui-v3/src/components/assess/ContentDataAssess.vue
@@ -137,6 +137,8 @@
     import ReportsListDialog from './ReportsListDialog.vue'
     import { Action, type ActionKey } from '@/types/actions'
     import { useSseResync } from '@/composables/useSseResync'
+    import { useAuth } from '@/composables/useAuth'
+    import Permissions from '@/services/permissions'
 
     type NewsItem = {
         id: string | number
@@ -145,6 +147,7 @@
         title?: string
         description?: string
         comments?: string
+        modify?: boolean
         [key: string]: unknown
     }
 
@@ -190,6 +193,7 @@
     const emit = defineEmits(['new-data-loaded', 'card-items-reindex', 'update-showing-count'])
 
     const { t } = useI18n()
+    const { checkPermission } = useAuth()
     const route = useRoute()
     const assessStore = useAssessStore()
     const routeQuery = route.query ?? {}
@@ -410,6 +414,10 @@
      */
     const applyItemAction = async (action: ActionKey, item: NewsItem, group_id: string): Promise<boolean> => {
         const isChildNewsItem = item.entityType === 'news_item'
+        const mutatingActions: readonly ActionKey[] = [Action.LIKE, Action.DISLIKE, Action.IMPORTANT, Action.READ, Action.UNGROUP]
+        if (mutatingActions.includes(action) && (!checkPermission(Permissions.ASSESS_UPDATE) || (isChildNewsItem && item.modify !== true))) {
+            return false
+        }
         switch (action) {
             case Action.LIKE:
                 await (isChildNewsItem ? voteNewsItem(group_id, item.id, 1) : assessStore.voteNewsItemAggregate(group_id, item.id, 1))
@@ -443,6 +451,12 @@
         const { action, newsItem } = payload
         const group_id = current_group_id.value || getNormalizedGroupId()
         const isChildNewsItem = newsItem.entityType === 'news_item'
+        if (
+            (action === Action.COMMENT || action === Action.UPDATE_AGGREGATE) &&
+            (!checkPermission(Permissions.ASSESS_UPDATE) || (isChildNewsItem && newsItem.modify !== true))
+        ) {
+            return
+        }
         const toolbarActions: readonly ActionKey[] = [Action.LIKE, Action.DISLIKE, Action.IMPORTANT, Action.READ, Action.UNGROUP]
         const isToolbarAction = toolbarActions.includes(action)
         if (isToolbarAction && detailActionPending.value) {
@@ -514,9 +528,13 @@
     }
 
     const handleDetailDelete = async (newsItem: NewsItem) => {
+        const isChildNewsItem = newsItem.entityType === 'news_item'
+        if (!checkPermission(Permissions.ASSESS_DELETE) || (isChildNewsItem && newsItem.modify !== true)) {
+            return
+        }
         try {
             const group_id = current_group_id.value || getNormalizedGroupId()
-            if (newsItem.entityType === 'news_item') {
+            if (isChildNewsItem) {
                 await deleteNewsItem(group_id, newsItem.id)
             } else {
                 await assessStore.deleteNewsItemAggregate(group_id, newsItem.id)
@@ -549,7 +567,24 @@
         }
     }
 
-    const handleDelete = async (): Promise<void> => {
+    const handleDelete = async (newsItem?: NewsItem): Promise<void> => {
+        // Aggregate cards delete themselves before notifying us. Child cards hand us the item,
+        // so perform that request here and repeat the permission/ACL check at the handler edge.
+        if (newsItem?.entityType === 'news_item') {
+            if (newsItem.modify !== true || !checkPermission(Permissions.ASSESS_DELETE)) {
+                return
+            }
+
+            try {
+                const groupId = current_group_id.value || getNormalizedGroupId()
+                await deleteNewsItem(groupId, newsItem.id)
+                notify({ type: 'success', loc: 'assess.item_deleted' })
+            } catch (error) {
+                notifyActionError(error, 'Error deleting item:', 'assess.error_deleting')
+                return
+            }
+        }
+
         // Reload current view after successful deletion
         // The animation will trigger when the deleted item is missing from the new data
         await refreshData()

--- a/src/gui-v3/src/components/assess/NewsItemDetailDialog.vue
+++ b/src/gui-v3/src/components/assess/NewsItemDetailDialog.vue
@@ -59,9 +59,6 @@
                     <v-tab value="attributes">
                         {{ t('assess.attributes') }}
                     </v-tab>
-                    <v-tab value="comments">
-                        {{ t('assess.comments') }}
-                    </v-tab>
                 </template>
 
                 <!-- Aggregate Tabs: Info, Comments -->
@@ -209,6 +206,7 @@
                             density="comfortable"
                             variant="outlined"
                             class="mb-4"
+                            :readonly="!canModifyItem"
                             @blur="autoSaveAggregateInfo"
                         />
                         <v-textarea
@@ -218,6 +216,7 @@
                             variant="outlined"
                             rows="6"
                             class="mb-4"
+                            :readonly="!canModifyItem"
                             @blur="autoSaveAggregateInfo"
                         />
                         <div class="text-caption text-grey">{{ t('assess.auto_save_blur') }}</div>
@@ -226,12 +225,14 @@
 
                 <!-- Comments Tab -->
                 <div
+                    v-if="isAggregate"
                     class="pane tab-pane"
                     :class="{ 'pane--active': activeTab === 'comments' }"
                 >
                     <Editor
                         v-model="commentText"
                         editor-style="height: 250px"
+                        :readonly="!canModifyItem"
                         @text-change="debounceAutoSave"
                     />
                     <div class="text-caption text-grey mt-2">{{ t('assess.auto_save_changes') }}</div>
@@ -283,9 +284,11 @@
 
     type NewsItemModel = {
         id?: number | string
+        entityType?: 'news_item' | 'news_item_aggregate'
         title?: string
         description?: string
         comments?: string
+        modify?: boolean
         news_items?: NestedNewsItem[]
         [key: string]: any
     }
@@ -404,12 +407,9 @@
         return attributes
     })
 
-    const canCreateReport = computed(() => {
-        return checkPermission(PERMISSIONS.ANALYZE_CREATE)
-    })
-
-    const canDelete = computed(() => {
-        return checkPermission(PERMISSIONS.ASSESS_DELETE)
+    const canModifyItem = computed(() => {
+        const itemAllowsModification = newsItem.value.entityType !== 'news_item' || newsItem.value.modify === true
+        return checkPermission(PERMISSIONS.ASSESS_UPDATE) && itemAllowsModification
     })
 
     const handleClose = (): void => {
@@ -437,6 +437,9 @@
     let saveTimeout: ReturnType<typeof setTimeout> | null = null
 
     const debounceAutoSave = (): void => {
+        if (!canModifyItem.value || !isAggregate.value) {
+            return
+        }
         if (saveTimeout) {
             clearTimeout(saveTimeout)
         }
@@ -446,6 +449,9 @@
     }
 
     const saveComment = (): void => {
+        if (!canModifyItem.value || !isAggregate.value) {
+            return
+        }
         emit('action', {
             action: Action.COMMENT,
             newsItem: newsItem.value,
@@ -458,6 +464,9 @@
     }
 
     const autoSaveAggregateInfo = (): void => {
+        if (!canModifyItem.value || !isAggregate.value) {
+            return
+        }
         // Only save if content has changed
         if (editTitle.value !== newsItem.value.title || editDescription.value !== newsItem.value.description) {
             saveAggregateInfo()

--- a/src/gui-v3/src/router.ts
+++ b/src/gui-v3/src/router.ts
@@ -45,6 +45,14 @@ const routes: RouteRecordRaw[] = [
         })
     },
     {
+        path: '/enter',
+        redirect: {
+            name: 'assess',
+            params: { groupId: 'all' },
+            query: { manualEntry: 'true' }
+        }
+    },
+    {
         path: '/analyze',
         redirect: '/analyze/local'
     },
@@ -337,6 +345,9 @@ router.beforeEach((to) => {
             if (AuthService.hasPermission(Permissions.ASSESS_ACCESS)) {
                 return { path: '/dashboard' }
             }
+            if (AuthService.hasPermission(Permissions.ASSESS_CREATE)) {
+                return { path: '/enter' }
+            }
             if (AuthService.hasPermission(Permissions.CONFIG_ACCESS)) {
                 return { path: '/config' }
             }
@@ -350,6 +361,15 @@ router.beforeEach((to) => {
         const requiredPermissions = (to.meta as RouteMetaAuth).requiresPerm
         if (requiredPermissions && requiredPermissions.length > 0) {
             if (AuthService.hasAnyPermission(requiredPermissions)) {
+                return true
+            }
+
+            // Manual entry deliberately reuses the Assess view, but creating an item has
+            // always required ASSESS_CREATE rather than ASSESS_ACCESS. Restrict the exception
+            // to the two handoff query parameters so /assess itself remains inaccessible.
+            const isManualEntryHandoff =
+                to.name === 'assess' && (to.query['manualSource'] !== undefined || to.query['manualEntry'] === 'true')
+            if (isManualEntryHandoff && AuthService.hasPermission(Permissions.ASSESS_CREATE)) {
                 return true
             }
             return { path: '/' }

--- a/src/gui-v3/src/router.ts
+++ b/src/gui-v3/src/router.ts
@@ -6,6 +6,7 @@ import AuthService from '@/services/auth_service'
 import Permissions from '@/services/permissions'
 import { getFirstConfigRoute } from '@/config/config-nav-links'
 import type { PermissionKey } from '@/types/permissions'
+import { createLegacyAnalyzeRedirect } from '@/utils/analyze-routing'
 
 interface RouteMetaAuth {
     requiresAuth?: boolean
@@ -46,6 +47,10 @@ const routes: RouteRecordRaw[] = [
     {
         path: '/analyze',
         redirect: '/analyze/local'
+    },
+    {
+        path: '/analyze/group/:groupName',
+        redirect: createLegacyAnalyzeRedirect
     },
     {
         path: '/analyze/:scope',

--- a/src/gui-v3/src/utils/analyze-routing.ts
+++ b/src/gui-v3/src/utils/analyze-routing.ts
@@ -1,0 +1,40 @@
+import type { RouteLocationNormalized, RouteLocationNormalizedLoaded, RouteLocationRaw } from 'vue-router'
+
+const LOCAL_SCOPE = 'local'
+const REMOTE_SCOPE_PREFIX = 'group-'
+
+type AnalyzeRoute = Pick<RouteLocationNormalizedLoaded, 'params'>
+
+const routeScope = (route: AnalyzeRoute): string => {
+    const scope = route.params['scope']
+    if (typeof scope === 'string') return scope
+    if (Array.isArray(scope)) return scope[0] || LOCAL_SCOPE
+    return LOCAL_SCOPE
+}
+
+export const createRemoteAnalyzeScope = (groupName: string): string => `${REMOTE_SCOPE_PREFIX}${groupName}`
+
+export const createRemoteAnalyzePath = (groupName: string): string => {
+    return `/analyze/${encodeURIComponent(createRemoteAnalyzeScope(groupName))}`
+}
+
+export const isRemoteAnalyzeRoute = (route: AnalyzeRoute): boolean => routeScope(route) !== LOCAL_SCOPE
+
+export const getAnalyzeGroupName = (route: AnalyzeRoute): string => {
+    const scope = routeScope(route)
+    if (scope === LOCAL_SCOPE) return ''
+    return scope.startsWith(REMOTE_SCOPE_PREFIX) ? scope.slice(REMOTE_SCOPE_PREFIX.length) : scope
+}
+
+// Vue 2 replaced spaces with dashes when it generated these bookmarks. Preserve
+// that historical interpretation while new links retain the exact group name.
+export const getLegacyAnalyzeGroupName = (groupName: string): string => groupName.replaceAll('-', ' ')
+
+export const createLegacyAnalyzeRedirect = (route: Pick<RouteLocationNormalized, 'params' | 'query' | 'hash'>): RouteLocationRaw => ({
+    name: 'analyze',
+    params: {
+        scope: createRemoteAnalyzeScope(getLegacyAnalyzeGroupName(String(route.params['groupName'])))
+    },
+    query: route.query,
+    hash: route.hash
+})

--- a/src/gui-v3/src/views/nav/AnalyzeNav.vue
+++ b/src/gui-v3/src/views/nav/AnalyzeNav.vue
@@ -34,6 +34,7 @@
     import { useTheme } from 'vuetify'
     import { useAnalyzeStore } from '@/stores/analyze'
     import { type GroupNavItem } from '@/types/routing'
+    import { createRemoteAnalyzePath } from '@/utils/analyze-routing'
 
     const router = useRouter()
     const route = useRoute()
@@ -70,13 +71,13 @@
                 if (group === undefined || group === null) {
                     continue
                 }
-                const groupId = String(group).replaceAll(' ', '-')
+                const groupName = String(group)
                 links.value.push({
-                    id: groupId,
+                    id: groupName,
                     icon: 'mdi-arrow-down-bold-circle-outline',
-                    title: String(group),
+                    title: groupName,
                     translate: false,
-                    route: '/analyze/group-' + groupId
+                    route: createRemoteAnalyzePath(groupName)
                 })
             }
 

--- a/src/gui-v3/src/views/users/AnalyzeView.vue
+++ b/src/gui-v3/src/views/users/AnalyzeView.vue
@@ -45,6 +45,7 @@
     import ContentDataAnalyze from '@/components/analyze/ContentDataAnalyze.vue'
     import NewReportItem from '@/components/analyze/NewReportItem.vue'
     import RemoteReportItem from '@/components/analyze/RemoteReportItem.vue'
+    import { isRemoteAnalyzeRoute } from '@/utils/analyze-routing'
 
     const route = useRoute()
     const analyzeStore = useAnalyzeStore()
@@ -54,10 +55,7 @@
     const newReportItemRef = ref<any>(null)
     const remoteReportItemRef = ref<any>(null)
 
-    const isRemoteScope = computed(() => {
-        const scope = route.params['scope']
-        return typeof scope === 'string' && scope !== 'local'
-    })
+    const isRemoteScope = computed(() => isRemoteAnalyzeRoute(route))
 
     watch(
         isRemoteScope,

--- a/src/gui-v3/src/views/users/AssessView.vue
+++ b/src/gui-v3/src/views/users/AssessView.vue
@@ -32,6 +32,7 @@
 
         <template #content>
             <ContentDataAssess
+                v-if="canAccessAssess"
                 ref="contentData"
                 :analyze_selector="analyze_selector"
                 :selection="assessStore.getSelection"
@@ -82,6 +83,7 @@
     const requestedManualSourceId = ref<string | null>(null)
     const newReportItem = ref<any>(null)
     const canCreateNewsItem = computed(() => checkPermission(Permissions.ASSESS_CREATE))
+    const canAccessAssess = computed(() => checkPermission(Permissions.ASSESS_ACCESS))
     const hasManualSources = computed(() => assessStore.getManualOSINTSourcesList && assessStore.getManualOSINTSourcesList.length > 0)
 
     const newDataLoaded = (count: number): void => {
@@ -148,10 +150,14 @@
         const manualSourceQuery = route.query['manualSource']
         const sourceId = Array.isArray(manualSourceQuery) ? manualSourceQuery[0] : manualSourceQuery
         requestedManualSourceId.value = sourceId ?? null
+        const manualEntryRequested = route.query['manualEntry'] === 'true'
 
-        if (manualSourceQuery !== undefined) {
+        // Keep the handoff marker in the URL for create-only users: without it a refresh would
+        // correctly fail the ASSESS_ACCESS route guard. Full Assess users get the canonical URL.
+        if ((manualSourceQuery !== undefined || manualEntryRequested) && (canAccessAssess.value || !canCreateNewsItem.value)) {
             const query = { ...route.query }
             delete query['manualSource']
+            delete query['manualEntry']
             await router.replace({ name: 'assess', params: { groupId: route.params['groupId'] }, query })
         }
 
@@ -160,14 +166,15 @@
             try {
                 await assessStore.loadManualOSINTSources()
                 if (
-                    requestedManualSourceId.value &&
-                    assessStore.getManualOSINTSourcesList.some(
-                        (source) =>
-                            typeof source === 'object' &&
-                            source !== null &&
-                            'id' in source &&
-                            String(source.id) === requestedManualSourceId.value
-                    )
+                    manualEntryRequested ||
+                    (requestedManualSourceId.value &&
+                        assessStore.getManualOSINTSourcesList.some(
+                            (source) =>
+                                typeof source === 'object' &&
+                                source !== null &&
+                                'id' in source &&
+                                String(source.id) === requestedManualSourceId.value
+                        ))
                 ) {
                     showAddNewsItemDialog.value = true
                 }

--- a/src/gui-v3/tests/unit/AnalyzeRemoteRouting.spec.js
+++ b/src/gui-v3/tests/unit/AnalyzeRemoteRouting.spec.js
@@ -2,8 +2,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { flushPromises } from '@vue/test-utils'
 import { mountWithPlugins } from '../helpers/mount-helpers'
 import ContentDataAnalyze from '@/components/analyze/ContentDataAnalyze.vue'
+import AnalyzeView from '@/views/users/AnalyzeView.vue'
 
-const mockRoute = { params: { scope: 'group-upstream-node' } }
+const mockRoute = { params: { scope: 'group-upstream node' } }
 const mockStore = {
     getMultiSelectReport: false,
     getCurrentReportItemGroup: '',
@@ -12,11 +13,13 @@ const mockStore = {
     loadReportItems: vi.fn(),
     loadReportItemTypes: vi.fn(),
     selectReport: vi.fn(),
-    deselectReport: vi.fn()
+    deselectReport: vi.fn(),
+    multiSelectReport: vi.fn()
 }
 
-vi.mock('vue-router', () => ({ useRoute: () => mockRoute }))
+vi.mock('vue-router', () => ({ useRoute: () => mockRoute, onBeforeRouteLeave: vi.fn() }))
 vi.mock('@/stores/analyze', () => ({ useAnalyzeStore: () => mockStore }))
+vi.mock('@/composables/useAuth', () => ({ useAuth: () => ({ checkPermission: () => true }) }))
 
 const CardAnalyzeStub = {
     name: 'CardAnalyze',
@@ -24,9 +27,22 @@ const CardAnalyzeStub = {
     template: '<button class="report-card-stub" />'
 }
 
+const ToolbarStub = {
+    name: 'ToolbarFilterAnalyze',
+    props: ['showAddButton', 'multiSelect'],
+    template: '<div />'
+}
+
+const ContentStub = {
+    name: 'ContentDataAnalyze',
+    props: ['disableActions'],
+    template: '<div />'
+}
+
 describe('Analyze remote report routing', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        mockRoute.params.scope = 'group-upstream node'
         mockStore.getReportItems = {
             total_count: 1,
             items: [{ id: 7, title: 'Remote report', report_item_type_id: 2, remote_user: 'upstream node', access: true }]
@@ -47,5 +63,41 @@ describe('Analyze remote report routing', () => {
         expect(wrapper.emitted('show-remote-report-item-detail')?.[0]?.[0]).toMatchObject({ id: 7 })
         expect(wrapper.emitted('show-report-item-detail')).toBeUndefined()
         expect(mockStore.loadReportItems).toHaveBeenCalledWith(expect.objectContaining({ group: 'upstream node' }))
+    })
+
+    it('hides local creation actions throughout a remote scope', () => {
+        const wrapper = mountWithPlugins(AnalyzeView, {
+            global: {
+                stubs: {
+                    ViewLayout: { template: '<div><slot name="panel"/><slot name="content"/></div>' },
+                    ToolbarFilterAnalyze: ToolbarStub,
+                    ContentDataAnalyze: ContentStub,
+                    NewReportItem: true,
+                    RemoteReportItem: true
+                }
+            }
+        })
+
+        expect(wrapper.findComponent(ToolbarStub).props('showAddButton')).toBe(false)
+        expect(wrapper.findComponent(ContentStub).props('disableActions')).toBe(true)
+    })
+
+    it('retains local creation actions in the local scope', () => {
+        mockRoute.params.scope = 'local'
+
+        const wrapper = mountWithPlugins(AnalyzeView, {
+            global: {
+                stubs: {
+                    ViewLayout: { template: '<div><slot name="panel"/><slot name="content"/></div>' },
+                    ToolbarFilterAnalyze: ToolbarStub,
+                    ContentDataAnalyze: ContentStub,
+                    NewReportItem: true,
+                    RemoteReportItem: true
+                }
+            }
+        })
+
+        expect(wrapper.findComponent(ToolbarStub).props('showAddButton')).toBe(true)
+        expect(wrapper.findComponent(ContentStub).props('disableActions')).toBe(false)
     })
 })

--- a/src/gui-v3/tests/unit/AssessItemActions.spec.js
+++ b/src/gui-v3/tests/unit/AssessItemActions.spec.js
@@ -15,7 +15,7 @@ vi.mock('@/composables/useAuth', () => ({
 
 const mountActions = (item) =>
     mountWithPlugins(AssessItemActions, {
-        props: { item, showCounts: true },
+        props: { item: { modify: true, ...item }, showCounts: true },
         global: { stubs: { ConfirmationDialog: true, ActionButton: true } }
     })
 
@@ -108,6 +108,48 @@ describe('AssessItemActions delete confirmation', () => {
 
         try {
             expect(confirmationMessage(wrapper)).toBe('')
+        } finally {
+            wrapper.unmount()
+        }
+    })
+})
+
+describe('AssessItemActions item restrictions', () => {
+    it('keeps read-only child items viewable without showing mutating actions', () => {
+        const wrapper = mountWithPlugins(AssessItemActions, {
+            props: {
+                item: {
+                    id: 1,
+                    entityType: 'news_item',
+                    title: 'Read only',
+                    modify: false,
+                    link: 'https://example.test/item'
+                },
+                showCreateReport: true
+            },
+            global: { stubs: { ConfirmationDialog: true, ActionButton: true } }
+        })
+
+        try {
+            expect(wrapper.find(`[data-action="OPEN"]`).exists()).toBe(true)
+            expect(wrapper.find(`[data-action="CREATE-REPORT"]`).exists()).toBe(true)
+            expect(wrapper.find(`[data-action="LIKE"]`).exists()).toBe(false)
+            expect(wrapper.find(`[data-action="READ"]`).exists()).toBe(false)
+            expect(wrapper.findComponent({ name: 'ActionButton' }).exists()).toBe(false)
+        } finally {
+            wrapper.unmount()
+        }
+    })
+
+    it('does not require a child ACL flag on aggregate actions', () => {
+        const wrapper = mountWithPlugins(AssessItemActions, {
+            props: { item: { id: 2, title: 'Aggregate' } },
+            global: { stubs: { ConfirmationDialog: true, ActionButton: true } }
+        })
+
+        try {
+            expect(wrapper.find(`[data-action="LIKE"]`).exists()).toBe(true)
+            expect(wrapper.findComponent({ name: 'ActionButton' }).exists()).toBe(true)
         } finally {
             wrapper.unmount()
         }

--- a/src/gui-v3/tests/unit/AssessItemModifyRestrictions.spec.js
+++ b/src/gui-v3/tests/unit/AssessItemModifyRestrictions.spec.js
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mountWithPlugins } from '../helpers/mount-helpers'
+import NewsItemDetailDialog from '@/components/assess/NewsItemDetailDialog.vue'
+
+vi.mock('@/composables/useAuth', () => ({
+    useAuth: () => ({ checkPermission: () => true })
+}))
+
+const VDialogStub = {
+    name: 'VDialog',
+    template: '<div><slot /></div>'
+}
+
+const EditorStub = {
+    name: 'Editor',
+    props: ['modelValue', 'readonly'],
+    emits: ['text-change'],
+    template: '<button class="editor" @click="$emit(\'text-change\')" />'
+}
+
+const mountDialog = (newsItem) =>
+    mountWithPlugins(NewsItemDetailDialog, {
+        props: { newsItem },
+        global: {
+            stubs: {
+                VDialog: VDialogStub,
+                Editor: EditorStub,
+                AssessItemActions: true,
+                NewsItemAttribute: true
+            }
+        }
+    })
+
+describe('Assess item modify restrictions', () => {
+    it('does not advertise aggregate-only comments for a child news item', () => {
+        const wrapper = mountDialog({
+            id: 7,
+            entityType: 'news_item',
+            modify: false,
+            news_items: [{ news_item_data: { title: 'Read-only child' } }]
+        })
+
+        try {
+            const tabValues = wrapper.findAllComponents({ name: 'VTab' }).map((tab) => tab.props('value'))
+            expect(tabValues).toEqual(['source', 'attributes'])
+            expect(wrapper.findComponent({ name: 'Editor' }).exists()).toBe(false)
+        } finally {
+            wrapper.unmount()
+        }
+    })
+
+    it('does not apply child ACL flags to aggregate editing', async () => {
+        const wrapper = mountDialog({
+            id: 8,
+            title: 'Locked aggregate',
+            description: 'Locked description',
+            news_items: [{ id: 1 }, { id: 2 }]
+        })
+
+        try {
+            expect(wrapper.findComponent({ name: 'VTextField' }).props('readonly')).toBe(false)
+            expect(wrapper.findComponent({ name: 'VTextarea' }).props('readonly')).toBe(false)
+            expect(wrapper.findComponent({ name: 'Editor' }).props('readonly')).toBe(false)
+        } finally {
+            wrapper.unmount()
+        }
+    })
+})

--- a/src/gui-v3/tests/unit/ContentDataAssessReload.spec.js
+++ b/src/gui-v3/tests/unit/ContentDataAssessReload.spec.js
@@ -3,6 +3,18 @@ import { flushPromises } from '@vue/test-utils'
 import { mountWithPlugins } from '../helpers/mount-helpers'
 import ContentDataAssess from '@/components/assess/ContentDataAssess.vue'
 
+const permissionState = vi.hoisted(() => ({ allowed: true }))
+const assessApiMocks = vi.hoisted(() => ({ deleteNewsItem: vi.fn() }))
+
+vi.mock('@/composables/useAuth', () => ({
+    useAuth: () => ({ checkPermission: () => permissionState.allowed })
+}))
+
+vi.mock('@/api/assess', async () => {
+    const actual = await vi.importActual('@/api/assess')
+    return { ...actual, deleteNewsItem: assessApiMocks.deleteNewsItem }
+})
+
 /**
  * Acting on a card (star, like, read, ...) reloads the whole list from offset 0, and the
  * server echoes an SSE event back that reloads it again. If those loads apply each other's
@@ -54,7 +66,7 @@ vi.mock('@/stores/assess', () => ({
 }))
 
 const commonStubs = {
-    CardAssess: { template: '<div class="card-assess-stub" />', props: ['card'] },
+    CardAssess: { name: 'CardAssess', template: '<div class="card-assess-stub" />', props: ['card'] },
     CardCompact: { template: '<div class="card-compact-stub" />', props: ['card'] },
     NewsItemDetailDialog: true,
     ReportsListDialog: true,
@@ -98,6 +110,8 @@ const deferredPage = (items, total_count = 60) => {
 describe('ContentDataAssess list reloads', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        permissionState.allowed = true
+        assessApiMocks.deleteNewsItem.mockResolvedValue({})
 
         mockRoute.params.groupId = 'all'
         // The old code read the list off this shared store ref after awaiting, rather than off
@@ -135,6 +149,26 @@ describe('ContentDataAssess list reloads', () => {
             // is marked read - instead of sliding the whole list down the viewport.
             expect(idsOf(wrapper.vm.news_items_data)).toEqual(idsOf(makeItems(20)))
             expect(wrapper.findAll('.card-assess-stub')).toHaveLength(before)
+        } finally {
+            wrapper.unmount()
+        }
+    })
+
+    it('deletes only child items that carry modify access', async () => {
+        const wrapper = mountAssess()
+
+        try {
+            await flushPromises()
+            const card = wrapper.findComponent({ name: 'CardAssess' })
+
+            card.vm.$emit('delete-item', { id: 41, entityType: 'news_item', modify: false })
+            await flushPromises()
+            expect(assessApiMocks.deleteNewsItem).not.toHaveBeenCalled()
+
+            card.vm.$emit('delete-item', { id: 42, entityType: 'news_item', modify: true })
+            await flushPromises()
+            expect(assessApiMocks.deleteNewsItem).toHaveBeenCalledOnce()
+            expect(assessApiMocks.deleteNewsItem).toHaveBeenCalledWith('all', 42)
         } finally {
             wrapper.unmount()
         }

--- a/src/gui-v3/tests/unit/ManualEntryPermissions.spec.js
+++ b/src/gui-v3/tests/unit/ManualEntryPermissions.spec.js
@@ -6,7 +6,7 @@ import AssessView from '@/views/users/AssessView.vue'
 import AddNewsItemDialog from '@/components/assess/AddNewsItemDialog.vue'
 
 const authState = vi.hoisted(() => ({
-    allowed: true,
+    permissions: new Set(),
     checkPermission: vi.fn()
 }))
 
@@ -117,12 +117,12 @@ function mountManualEntryDialog() {
 describe('manual news entry permissions', () => {
     beforeEach(() => {
         vi.clearAllMocks()
-        authState.allowed = true
-        authState.checkPermission.mockImplementation(() => authState.allowed)
+        authState.permissions = new Set(['ASSESS_ACCESS', 'ASSESS_CREATE'])
+        authState.checkPermission.mockImplementation((permission) => authState.permissions.has(permission))
     })
 
     it('does not expose manual entry or load its sources without ASSESS_CREATE', async () => {
-        authState.allowed = false
+        authState.permissions.clear()
         const assessApi = await import('@/api/assess')
         const wrapper = await mountAssessView()
 
@@ -141,7 +141,7 @@ describe('manual news entry permissions', () => {
     })
 
     it('does not render the dialog without ASSESS_CREATE', () => {
-        authState.allowed = false
+        authState.permissions.clear()
         const wrapper = mountManualEntryDialog()
 
         expect(wrapper.findComponent({ name: 'VDialog' }).exists()).toBe(false)
@@ -152,11 +152,20 @@ describe('manual news entry permissions', () => {
         const wrapper = mountManualEntryDialog()
         const toolbar = wrapper.findComponent({ name: 'DialogToolbar' })
 
-        authState.allowed = false
+        authState.permissions.clear()
         toolbar.vm.$emit('save')
         await flushPromises()
 
         expect(assessApi.addNewsItem).not.toHaveBeenCalled()
         expect(wrapper.emitted('update:modelValue')).toContainEqual([false])
+    })
+
+    it('keeps the manual-entry dialog available without rendering Assess data for create-only users', async () => {
+        authState.permissions = new Set(['ASSESS_CREATE'])
+        const wrapper = await mountAssessView()
+
+        expect(wrapper.findComponent({ name: 'AddNewsItemDialog' }).exists()).toBe(true)
+        expect(wrapper.find('.add-news-item-button').exists()).toBe(true)
+        expect(wrapper.findComponent({ name: 'ContentDataAssess' }).exists()).toBe(false)
     })
 })

--- a/src/gui-v3/tests/unit/analyze-routing.spec.ts
+++ b/src/gui-v3/tests/unit/analyze-routing.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import {
+    createRemoteAnalyzePath,
+    createRemoteAnalyzeScope,
+    createLegacyAnalyzeRedirect,
+    getAnalyzeGroupName,
+    getLegacyAnalyzeGroupName,
+    isRemoteAnalyzeRoute
+} from '@/utils/analyze-routing'
+
+describe('Analyze routing', () => {
+    it('preserves the exact remote group name and encodes URL-sensitive characters', async () => {
+        const groupName = 'Threat Research / EU?#'
+        const router = createRouter({
+            history: createMemoryHistory(),
+            routes: [{ path: '/analyze/:scope', name: 'analyze', component: { template: '<div />' } }]
+        })
+
+        await router.push(createRemoteAnalyzePath(groupName))
+
+        expect(router.currentRoute.value.params['scope']).toBe(createRemoteAnalyzeScope(groupName))
+        expect(getAnalyzeGroupName(router.currentRoute.value)).toBe(groupName)
+        expect(isRemoteAnalyzeRoute(router.currentRoute.value)).toBe(true)
+        expect(router.currentRoute.value.path).toContain('%2F')
+        expect(router.currentRoute.value.path).toContain('%3F%23')
+    })
+
+    it('recognizes local scope from route parameters', () => {
+        const route = { params: { scope: 'local' } }
+
+        expect(isRemoteAnalyzeRoute(route)).toBe(false)
+        expect(getAnalyzeGroupName(route)).toBe('')
+    })
+
+    it('retains the legacy dash-for-space bookmark interpretation', () => {
+        expect(getLegacyAnalyzeGroupName('upstream-node')).toBe('upstream node')
+    })
+
+    it('redirects a legacy bookmark to the canonical route without losing query or hash', async () => {
+        const router = createRouter({
+            history: createMemoryHistory(),
+            routes: [
+                { path: '/analyze/group/:groupName', redirect: createLegacyAnalyzeRedirect },
+                { path: '/analyze/:scope', name: 'analyze', component: { template: '<div />' } }
+            ]
+        })
+
+        await router.push('/analyze/group/upstream-node?search=urgent#results')
+
+        expect(router.currentRoute.value.name).toBe('analyze')
+        expect(router.currentRoute.value.params['scope']).toBe('group-upstream node')
+        expect(router.currentRoute.value.query).toEqual({ search: 'urgent' })
+        expect(router.currentRoute.value.hash).toBe('#results')
+    })
+})

--- a/src/gui-v3/tests/unit/legacy-route-manual-entry.spec.js
+++ b/src/gui-v3/tests/unit/legacy-route-manual-entry.spec.js
@@ -5,7 +5,7 @@ import { mountWithPlugins } from '../helpers/mount-helpers'
 import AssessView from '@/views/users/AssessView.vue'
 
 const authState = vi.hoisted(() => ({
-    allowed: true,
+    permissions: new Set(),
     checkPermission: vi.fn()
 }))
 
@@ -77,8 +77,8 @@ async function mountLegacyEntry() {
 describe('legacy manual-entry route', () => {
     beforeEach(() => {
         vi.clearAllMocks()
-        authState.allowed = true
-        authState.checkPermission.mockImplementation(() => authState.allowed)
+        authState.permissions = new Set(['ASSESS_ACCESS', 'ASSESS_CREATE'])
+        authState.checkPermission.mockImplementation((permission) => authState.permissions.has(permission))
     })
 
     it('opens manual entry with the requested source and canonicalizes the URL', async () => {
@@ -91,12 +91,21 @@ describe('legacy manual-entry route', () => {
     })
 
     it('does not load sources or open manual entry without ASSESS_CREATE', async () => {
-        authState.allowed = false
+        authState.permissions.clear()
         const assessApi = await import('@/api/assess')
         const { router, wrapper } = await mountLegacyEntry()
 
         expect(assessApi.getManualOSINTSources).not.toHaveBeenCalled()
         expect(wrapper.findComponent({ name: 'AddNewsItemDialog' }).exists()).toBe(false)
         expect(router.currentRoute.value.fullPath).toBe('/assess/group/all')
+    })
+
+    it('retains the guarded handoff URL for create-only users so refresh remains authorized', async () => {
+        authState.permissions = new Set(['ASSESS_CREATE'])
+        const { router, wrapper } = await mountLegacyEntry()
+
+        expect(wrapper.findComponent({ name: 'AddNewsItemDialog' }).props('modelValue')).toBe(true)
+        expect(wrapper.findComponent({ name: 'ContentDataAssess' }).exists()).toBe(false)
+        expect(router.currentRoute.value.fullPath).toBe('/assess/group/all?manualSource=manual-42')
     })
 })

--- a/src/gui-v3/tests/unit/legacy-route-redirects.spec.js
+++ b/src/gui-v3/tests/unit/legacy-route-redirects.spec.js
@@ -43,4 +43,14 @@ describe('legacy route redirects', () => {
             query: { from: 'bookmark', manualSource: 'manual-42' }
         })
     })
+
+    it('maps the legacy manual-entry root to an explicit Assess dialog handoff', () => {
+        const route = router.getRoutes().find((candidate) => candidate.path === '/enter')
+
+        expect(route?.redirect).toEqual({
+            name: 'assess',
+            params: { groupId: 'all' },
+            query: { manualEntry: 'true' }
+        })
+    })
 })


### PR DESCRIPTION
## Summary

- Normalize remote Analyze routing and restore compatibility with legacy remote-group URLs.
- Restore Vue 3 parity for create-only Assess users and enforce per-item modification restrictions.

## What changed

- Centralized local/remote Analyze route detection.
- Preserve exact remote group names instead of converting spaces into dashes.
- Safely encode group names containing spaces and URL-sensitive characters.
- Redirect legacy `/analyze/group/<name>` bookmarks to the canonical Vue 3 route.
- Preserve query parameters and URL fragments during legacy redirects.
- Use route parameters consistently instead of inspecting `window.location.pathname`.
- Hide local-only actions such as **Add New** and **Create Product** in remote Analyze scopes.
- Added focused routing and UI regression tests.

- Allow users with `ASSESS_CREATE` to reach manual entry without requiring `ASSESS_ACCESS`.
- Add a guarded `/enter` handoff to the Vue 3 Assess dialog.
- Preserve manual-entry URLs across refreshes.
- Keep the ordinary Assess list inaccessible to create-only users.
- Enforce each child news item’s `modify` restriction.
- Hide update and delete controls for read-only child items.
- Make aggregate editors read-only when modification is forbidden.
- Reject forged update and delete events in their handlers.
- Preserve permitted read-only actions, including source viewing and report creation.
- Make child-card deletion call the actual deletion API.
- Remove unsupported child Comments controls.
- Add permission, routing, mutation, and deletion regression tests.


## Why

The previous Vue 3 routing inferred group names from lossy URL transformations and mixed route parameters with pathname inspection. Group names containing spaces, slashes, question marks, or other reserved characters could therefore be corrupted or misclassified. Remote views could also expose actions intended only for local reports.

This makes routing deterministic, URL-safe, and compatible with existing Vue 2 bookmarks.

Vue 2 allowed analysts who could create news items to use manual entry without granting them access to the full Assess workspace. Vue 3 unintentionally required broader access.

Vue 3 also relied too heavily on hidden controls for child-item restrictions. Mutation handlers now independently enforce the item-level permission so read-only records cannot be changed through emitted or forged UI events.