### PR TITLE
Persist Analyze editor layout preference

### DIFF
--- a/src/gui-v3/src/components/analyze/NewReportItem.vue
+++ b/src/gui-v3/src/components/analyze/NewReportItem.vue
@@ -426,6 +426,7 @@
     import { ICONS } from '@/config/ui-constants'
     import { useAnalyzeStore } from '@/stores/analyze'
     import { useSettingsStore } from '@/stores/settings'
+    import { useUserStore } from '@/stores/user'
     import { Settings } from '@/types/settings'
 
     import {
@@ -490,6 +491,7 @@
     const { checkPermission, getUserId } = useAuth()
     const analyzeStore = useAnalyzeStore()
     const settingsStore = useSettingsStore()
+    const userStore = useUserStore()
 
     // Refs
     const formRef = ref<FormRef | null>(null)
@@ -501,7 +503,6 @@
     const modify = ref<boolean>(true)
     const overlay = ref<boolean>(false)
     const showCloseConfirmation = ref<boolean>(false)
-    const verticalView = ref<boolean>(false)
     const show_validation_error = ref<boolean>(false)
     const show_error = ref<boolean>(false)
     const key_timeout = ref<any>(null)
@@ -561,6 +562,11 @@
     })
 
     const spellcheck = computed(() => settingsStore.getSettingBoolean(Settings.SPELLCHECK, true))
+
+    const verticalView = computed<boolean>({
+        get: () => userStore.verticalView,
+        set: (value) => userStore.setVerticalView(value)
+    })
 
     // Methods
     const initializeNewReportItem = (newsItemAggregates = []) => {

--- a/src/gui-v3/tests/unit/NewReportItemAttributes.spec.js
+++ b/src/gui-v3/tests/unit/NewReportItemAttributes.spec.js
@@ -129,6 +129,7 @@ describe('NewReportItem — label-only attributes (max_occurrence 0)', () => {
 
     beforeEach(async () => {
         vi.clearAllMocks()
+        localStorage.removeItem('TNGVericalView')
         mockCheckPermission.mockReturnValue(true)
         mockAnalyzeStore.getReportItemTypes = { items: [makeReportType()] }
         mockAnalyzeStore.loadReportItemTypes.mockResolvedValue({ data: mockAnalyzeStore.getReportItemTypes })
@@ -212,5 +213,24 @@ describe('NewReportItem — label-only attributes (max_occurrence 0)', () => {
         expect(tooltip.exists()).toBe(true)
         expect(tooltip.props('text')).toBe(EDITABLE_DESCRIPTION)
         expect(undescribedPanel.findComponent({ name: 'VTooltip' }).exists()).toBe(false)
+    })
+
+    it('restores and immediately persists the side-by-side layout preference', async () => {
+        localStorage.setItem('TNGVericalView', 'true')
+
+        const wrapper = mountWithPlugins(NewReportItem, {
+            props: { showButton: false },
+            global: { stubs: { VDialog: VDialogStub, VOverlay: VOverlayStub } }
+        })
+        await flushPromises()
+
+        const layoutSwitch = wrapper.findComponent({ name: 'VSwitch' })
+        expect(layoutSwitch.props('modelValue')).toBe(true)
+
+        layoutSwitch.vm.$emit('update:modelValue', false)
+        await flushPromises()
+
+        expect(layoutSwitch.props('modelValue')).toBe(false)
+        expect(localStorage.getItem('TNGVericalView')).toBe('false')
     })
 })


### PR DESCRIPTION
## Summary

Persist the analyst’s preferred Analyze report-editor layout.

## What changed

- Connect the report editor’s layout switch to the existing user store.
- Restore the saved layout whenever the editor is reopened or remounted.
- Persist layout changes immediately using the existing `TNGVericalView` local-storage key.
- Preserve compatibility with preferences saved by the legacy GUI.
- Add regression coverage for restoring and changing the preference.

## Why

Vue 3 created an isolated `false` value every time the report editor mounted. This caused the editor to forget whether the analyst preferred the stacked or side-by-side layout, despite the application already having a persistence mechanism for that setting.

## Validation

- Focused component tests: 5/5 passed
- Vue TypeScript check passed
- Scoped ESLint passed
- Scoped Prettier check passed
- `git diff --check` passed