### PR TITLE
Make product preview popup-safe

### DIFF
--- a/src/gui-v3/src/components/publish/NewProduct.vue
+++ b/src/gui-v3/src/components/publish/NewProduct.vue
@@ -297,7 +297,7 @@
     import { getAllUserProductTypes, getAllUserPublishersPresets } from '@/api/user'
     import { getEntityTypeStates } from '@/api/state'
     import { useAuth } from '@/composables/useAuth'
-    import { openInNewTabWithoutOpener } from '@/utils/window'
+    import { navigateReservedTabOrCurrentWindow, openBlankTabWithoutOpener } from '@/utils/window'
     import StateSelector from '@/components/common/StateSelector.vue'
     import ConfirmationDialog from '@/components/common/dialogs/ConfirmationDialog.vue'
     import ReportItemSelector from '@/components/publish/ReportItemSelector.vue'
@@ -657,20 +657,28 @@
     }
 
     async function handlePreview(event?: MouseEvent): Promise<void> {
-        const { valid } = (await formRef.value?.validate?.()) || { valid: false }
-        if (!valid) return
-
-        prepareProduct()
+        // Reserve the tab before validation or the API request yields. Waiting
+        // until either promise resolves loses browser user activation and may
+        // cause the preview to be blocked as an unsolicited popup.
+        const previewWindow = openBlankTabWithoutOpener()
+        const ctrl = Boolean(event?.ctrlKey)
 
         try {
-            const ctrl = Boolean(event && event.ctrlKey)
+            const { valid } = (await formRef.value?.validate?.()) || { valid: false }
+            if (!valid) {
+                previewWindow?.close()
+                return
+            }
+
+            prepareProduct()
             const response = await previewProduct(product.value, ctrl, authStore.jwt)
             const token = response.data.token
 
             const apiBase = import.meta.env.VITE_APP_TARANIS_NG_CORE_API || '/api/v1'
             const previewUrl = `${apiBase}/publish/products/preview/${token}`
-            openInNewTabWithoutOpener(previewUrl)
+            navigateReservedTabOrCurrentWindow(previewWindow, previewUrl)
         } catch (error: unknown) {
+            previewWindow?.close()
             console.error('Preview failed:', error)
             showError.value = true
         }
@@ -767,7 +775,8 @@
     // Expose methods for parent components
     defineExpose({
         openDialog,
-        openEditDialog
+        openEditDialog,
+        handlePreview
     })
 </script>
 

--- a/src/gui-v3/src/utils/window.ts
+++ b/src/gui-v3/src/utils/window.ts
@@ -3,3 +3,26 @@ export const openInNewTabWithoutOpener = (url: string): Window | null => {
     if (openedWindow) openedWindow.opener = null
     return openedWindow
 }
+
+/**
+ * Reserve a tab while a click still has transient browser user activation.
+ *
+ * `noopener` cannot be passed as a window feature here because browsers may
+ * then deliberately return `null`, leaving us unable to navigate the reserved
+ * tab after an asynchronous preview request. Clear the opener synchronously
+ * instead, before any application code yields back to the browser.
+ */
+export const openBlankTabWithoutOpener = (): Window | null => {
+    const openedWindow = window.open('about:blank', '_blank')
+    if (openedWindow) openedWindow.opener = null
+    return openedWindow
+}
+
+export const navigateReservedTabOrCurrentWindow = (openedWindow: Window | null, url: string): void => {
+    if (openedWindow && !openedWindow.closed) {
+        openedWindow.location.href = url
+        return
+    }
+
+    window.location.assign(url)
+}

--- a/src/gui-v3/tests/unit/NewProductPreview.spec.ts
+++ b/src/gui-v3/tests/unit/NewProductPreview.spec.ts
@@ -1,0 +1,117 @@
+import { defineComponent, h } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mountWithPlugins } from '../helpers/mount-helpers'
+import NewProduct from '@/components/publish/NewProduct.vue'
+import { previewProduct } from '@/api/publish'
+import { navigateReservedTabOrCurrentWindow, openBlankTabWithoutOpener } from '@/utils/window'
+
+const validateForm = vi.fn()
+
+vi.mock('@/api/publish', () => ({
+    createProduct: vi.fn(),
+    updateProduct: vi.fn(),
+    publishProduct: vi.fn(),
+    previewProduct: vi.fn()
+}))
+
+vi.mock('@/api/user', () => ({
+    getAllUserProductTypes: vi.fn().mockResolvedValue({ data: { items: [] } }),
+    getAllUserPublishersPresets: vi.fn().mockResolvedValue({ data: { items: [] } })
+}))
+
+vi.mock('@/api/state', () => ({
+    getEntityTypeStates: vi.fn().mockResolvedValue({ data: { states: [] } })
+}))
+
+vi.mock('@/composables/useAuth', () => ({
+    useAuth: () => ({ checkPermission: vi.fn().mockReturnValue(true) })
+}))
+
+vi.mock('@/utils/window', () => ({
+    openBlankTabWithoutOpener: vi.fn(),
+    navigateReservedTabOrCurrentWindow: vi.fn()
+}))
+
+const VDialogStub = {
+    name: 'VDialog',
+    template: '<div><slot /></div>'
+}
+
+const VFormStub = defineComponent({
+    name: 'VForm',
+    setup(_, { expose, slots }) {
+        expose({ validate: () => validateForm() })
+        return () => h('form', slots['default']?.())
+    }
+})
+
+function mountPreviewEditor() {
+    return mountWithPlugins(NewProduct, {
+        global: {
+            stubs: {
+                VDialog: VDialogStub,
+                VForm: VFormStub,
+                ConfirmationDialog: true,
+                StateSelector: true,
+                ReportItemSelector: true
+            }
+        }
+    })
+}
+
+describe('NewProduct preview', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('reserves the preview tab before asynchronous validation completes and preserves Ctrl-click', async () => {
+        let finishValidation: ((result: { valid: boolean }) => void) | undefined
+        validateForm.mockReturnValue(
+            new Promise((resolve) => {
+                finishValidation = resolve
+            })
+        )
+        const previewWindow = { close: vi.fn() } as unknown as Window
+        vi.mocked(openBlankTabWithoutOpener).mockReturnValue(previewWindow)
+        vi.mocked(previewProduct).mockResolvedValue({ data: { token: 'ticket-123' } } as never)
+        const wrapper = mountPreviewEditor()
+
+        const preview = wrapper.vm.handlePreview({ ctrlKey: true } as MouseEvent)
+
+        expect(openBlankTabWithoutOpener).toHaveBeenCalledOnce()
+        expect(previewProduct).not.toHaveBeenCalled()
+
+        finishValidation?.({ valid: true })
+        await preview
+
+        expect(previewProduct).toHaveBeenCalledWith(expect.any(Object), true, '')
+        expect(navigateReservedTabOrCurrentWindow).toHaveBeenCalledWith(previewWindow, '/api/v1/publish/products/preview/ticket-123')
+    })
+
+    it('closes the reserved tab when validation fails', async () => {
+        validateForm.mockResolvedValue({ valid: false })
+        const previewWindow = { close: vi.fn() } as unknown as Window
+        vi.mocked(openBlankTabWithoutOpener).mockReturnValue(previewWindow)
+        const wrapper = mountPreviewEditor()
+
+        await wrapper.vm.handlePreview()
+
+        expect(previewWindow.close).toHaveBeenCalledOnce()
+        expect(previewProduct).not.toHaveBeenCalled()
+        expect(navigateReservedTabOrCurrentWindow).not.toHaveBeenCalled()
+    })
+
+    it('closes the reserved tab when preview generation fails', async () => {
+        validateForm.mockResolvedValue({ valid: true })
+        const previewWindow = { close: vi.fn() } as unknown as Window
+        vi.mocked(openBlankTabWithoutOpener).mockReturnValue(previewWindow)
+        vi.mocked(previewProduct).mockRejectedValue(new Error('preview failed'))
+        vi.spyOn(console, 'error').mockImplementation(() => undefined)
+        const wrapper = mountPreviewEditor()
+
+        await wrapper.vm.handlePreview()
+
+        expect(previewWindow.close).toHaveBeenCalledOnce()
+        expect(navigateReservedTabOrCurrentWindow).not.toHaveBeenCalled()
+    })
+})

--- a/src/gui-v3/tests/unit/window.spec.ts
+++ b/src/gui-v3/tests/unit/window.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { openInNewTabWithoutOpener } from '@/utils/window'
+import { navigateReservedTabOrCurrentWindow, openBlankTabWithoutOpener, openInNewTabWithoutOpener } from '@/utils/window'
 
 describe('openInNewTabWithoutOpener', () => {
     afterEach(() => {
@@ -20,5 +20,36 @@ describe('openInNewTabWithoutOpener', () => {
 
         expect(openInNewTabWithoutOpener('/preview/blocked')).toBeNull()
         expect(open).toHaveBeenCalledWith('/preview/blocked', '_blank', 'noopener,noreferrer')
+    })
+})
+
+describe('reserved popup helpers', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('reserves a blank tab and removes its opener synchronously', () => {
+        const openedWindow = { opener: window }
+        const open = vi.spyOn(window, 'open').mockReturnValue(openedWindow as Window)
+
+        expect(openBlankTabWithoutOpener()).toBe(openedWindow)
+        expect(open).toHaveBeenCalledWith('about:blank', '_blank')
+        expect(openedWindow.opener).toBeNull()
+    })
+
+    it('navigates the reserved tab when it is available', () => {
+        const openedWindow = { closed: false, location: { href: 'about:blank' } }
+
+        navigateReservedTabOrCurrentWindow(openedWindow as Window, '/preview/123')
+
+        expect(openedWindow.location.href).toBe('/preview/123')
+    })
+
+    it('falls back to the current window when the popup was blocked', () => {
+        const assign = vi.spyOn(window.location, 'assign').mockImplementation(() => undefined)
+
+        navigateReservedTabOrCurrentWindow(null, '/preview/blocked')
+
+        expect(assign).toHaveBeenCalledWith('/preview/blocked')
     })
 })


### PR DESCRIPTION
## Summary

Make Vue 3 product previews resistant to browser popup blocking.

## What changed

- Reserve a blank preview tab synchronously while the Preview click still has browser user activation.
- Remove the reserved tab’s opener access immediately.
- Run form validation and preview generation after reserving the tab.
- Navigate the reserved tab to the generated preview when ready.
- Close the temporary tab if validation or preview generation fails.
- Fall back to opening the preview in the current tab when popup creation was blocked or the reserved tab was closed.
- Preserve Ctrl-click preview semantics.
- Add focused component and window-helper regression tests.

## Why

Vue 3 waited for validation and the preview API before calling `window.open()`. Browsers can treat that delayed call as an unsolicited popup because the original click activation has expired.

This ports the established Vue 2 solution while retaining the newer opener-isolation protection.

## Validation

- Focused preview tests: 8/8 passed
- Vue TypeScript check passed
- Scoped ESLint passed
- Scoped Prettier check passed
- `git diff --check` passed