### PR TITLE
Restore attribute modification provenance

### DIFF
--- a/src/gui-v3/src/components/analyze/NewReportItem.vue
+++ b/src/gui-v3/src/components/analyze/NewReportItem.vue
@@ -323,12 +323,6 @@
                                                                         </v-icon>
                                                                     </template>
                                                                 </v-tooltip>
-                                                                <span
-                                                                    v-if="getAttributeMeta(attribute_item)"
-                                                                    class="attribute-meta text-medium-emphasis text-no-wrap ml-auto mr-2"
-                                                                >
-                                                                    {{ getAttributeMeta(attribute_item) }}
-                                                                </span>
                                                             </div>
                                                         </v-expansion-panel-title>
                                                         <v-expansion-panel-text v-if="!isLabelOnlyAttribute(attribute_item)">
@@ -1072,37 +1066,6 @@
         return isLabelOnly(attributeItem?.attribute_group_item)
     }
 
-    const getAttributeMeta = (attributeItem) => {
-        const values = Array.isArray(attributeItem?.values) ? attributeItem.values : []
-        let latest: Record<string, unknown> | null = null
-
-        for (const value of values) {
-            const user = value?.user as { name?: string } | undefined
-            const userName = user?.name
-            if (!userName) continue
-
-            if (!latest) {
-                latest = value
-                continue
-            }
-
-            const currentTime = Date.parse(String(value?.['last_updated'] || ''))
-            const latestTime = Date.parse(String(latest?.['last_updated'] || ''))
-
-            if (!Number.isNaN(currentTime) && Number.isNaN(latestTime)) {
-                latest = value
-            } else if (!Number.isNaN(currentTime) && !Number.isNaN(latestTime) && currentTime > latestTime) {
-                latest = value
-            }
-        }
-
-        const latestUserName = (latest?.['user'] as { name?: string } | undefined)?.name
-        if (!latestUserName) return ''
-        if (!latest?.['last_updated']) return latestUserName
-
-        return `${latest['last_updated']} ${latestUserName}`
-    }
-
     // AI generation
     const autoGenerate = async (attribute_group_item_id) => {
         if (!autoGenerateIcon[attribute_group_item_id]) {
@@ -1394,12 +1357,6 @@
     .locked-style :deep(input) {
         color: grey !important;
         font-style: italic;
-    }
-
-    .attribute-meta {
-        font-size: 0.8rem;
-        font-weight: 400;
-        text-transform: none;
     }
 
     /* Let the panel list wrap so compact attributes can pair up two-per-row.

--- a/src/gui-v3/src/components/common/attribute/AttributeValueLayout.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeValueLayout.vue
@@ -19,6 +19,58 @@
             />
         </v-col>
         <v-col
+            v-if="hasProvenance"
+            cols="auto"
+            class="attribute-provenance"
+        >
+            <v-menu location="bottom end">
+                <template #activator="{ props: menuProps }">
+                    <v-btn
+                        v-bind="menuProps"
+                        class="attribute-provenance__activator"
+                        :icon="ICONS.CLOCK"
+                        variant="text"
+                        density="compact"
+                        size="x-small"
+                        :aria-label="provenanceLabel"
+                    />
+                </template>
+                <v-card
+                    class="attribute-provenance__details"
+                    variant="outlined"
+                >
+                    <v-card-text class="pa-3">
+                        <div
+                            v-if="lastUpdated"
+                            class="attribute-provenance__row"
+                        >
+                            <v-icon
+                                :icon="ICONS.CLOCK"
+                                size="small"
+                            />
+                            <span>
+                                <strong>{{ t('drop_zone.last_updated') }}:</strong>
+                                {{ lastUpdated }}
+                            </span>
+                        </div>
+                        <div
+                            v-if="modifiedBy"
+                            class="attribute-provenance__row"
+                        >
+                            <v-icon
+                                :icon="ICONS.ACCOUNT"
+                                size="small"
+                            />
+                            <span>
+                                <strong>{{ t('settings.updated_by') }}:</strong>
+                                {{ modifiedBy }}
+                            </span>
+                        </div>
+                    </v-card-text>
+                </v-card>
+            </v-menu>
+        </v-col>
+        <v-col
             v-if="!embedDelete"
             cols="auto"
         >
@@ -48,7 +100,11 @@
             embedDelete?: boolean
             valIndex: number
             occurrence?: number | null | undefined
-            values: Array<Record<string, unknown>>
+            values: Array<{
+                user?: { name?: unknown } | string | null
+                last_updated?: unknown
+                [key: string]: unknown
+            }>
         }>(),
         {
             delButton: false,
@@ -63,6 +119,28 @@
 
     const { t } = useI18n()
 
+    const currentValue = computed(() => props.values[props.valIndex])
+
+    const lastUpdated = computed(() => {
+        const value = currentValue.value?.last_updated
+        return typeof value === 'string' || typeof value === 'number' ? String(value).trim() : ''
+    })
+
+    const modifiedBy = computed(() => {
+        const user = currentValue.value?.user
+        const name = typeof user === 'string' ? user : user?.name
+        return typeof name === 'string' || typeof name === 'number' ? String(name).trim() : ''
+    })
+
+    const hasProvenance = computed(() => Boolean(lastUpdated.value || modifiedBy.value))
+
+    const provenanceLabel = computed(() => {
+        const details: string[] = []
+        if (lastUpdated.value) details.push(`${t('drop_zone.last_updated')}: ${lastUpdated.value}`)
+        if (modifiedBy.value) details.push(`${t('settings.updated_by')}: ${modifiedBy.value}`)
+        return details.join('; ')
+    })
+
     const delButtonVisible = computed(() => {
         // The attribute group's min_occurrence is the only floor: with a minimum of 0 even
         // the last value can be deleted, leaving the attribute empty.
@@ -76,3 +154,30 @@
         emit('del-value')
     }
 </script>
+
+<style scoped>
+    .attribute-provenance {
+        align-self: center;
+        padding-inline: 0;
+    }
+
+    .attribute-provenance__activator {
+        color: rgb(var(--v-theme-on-surface-variant));
+    }
+
+    .attribute-provenance__details {
+        min-width: 14rem;
+        max-width: min(24rem, calc(100vw - 2rem));
+        background: rgb(var(--v-theme-surface));
+    }
+
+    .attribute-provenance__row {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
+    .attribute-provenance__row + .attribute-provenance__row {
+        margin-top: 0.5rem;
+    }
+</style>

--- a/src/gui-v3/tests/unit/AttributeValueLayout.spec.js
+++ b/src/gui-v3/tests/unit/AttributeValueLayout.spec.js
@@ -43,6 +43,49 @@ describe('AttributeValueLayout', () => {
         expect(wrapper.emitted('del-value')).toBeTruthy()
     })
 
+    // ── Modification provenance ──────────────────────────────────────────────
+    it('exposes modification provenance through a keyboard-focusable control', () => {
+        const wrapper = mountLayout({
+            values: [
+                {
+                    id: 1,
+                    value: 'v1',
+                    last_updated: '05.08.2026 - 03:45',
+                    user: { name: 'Arthur Dent' }
+                }
+            ]
+        })
+        const activator = wrapper.find('.attribute-provenance__activator')
+
+        expect(activator.exists()).toBe(true)
+        expect(activator.element.tagName).toBe('BUTTON')
+        expect(activator.attributes('aria-label')).toBe('Last updated: 05.08.2026 - 03:45; Updated by: Arthur Dent')
+        expect(activator.attributes('tabindex')).not.toBe('-1')
+    })
+
+    it('renders no provenance control when both timestamp and modifier are absent', () => {
+        const wrapper = mountLayout({
+            values: [{ id: 1, value: 'v1', last_updated: null, user: null }]
+        })
+
+        expect(wrapper.find('.attribute-provenance__activator').exists()).toBe(false)
+        expect(wrapper.find('.attribute-provenance__details').exists()).toBe(false)
+    })
+
+    it('uses the selected value provenance rather than another occurrence', () => {
+        const wrapper = mountLayout({
+            valIndex: 1,
+            values: [
+                { id: 1, last_updated: 'old', user: { name: 'First analyst' } },
+                { id: 2, last_updated: 'new', user: { name: 'Second analyst' } }
+            ]
+        })
+
+        expect(wrapper.find('.attribute-provenance__activator').attributes('aria-label')).toBe(
+            'Last updated: new; Updated by: Second analyst'
+        )
+    })
+
     // ── Embed-delete: expose visibility/handler via the col_middle slot ───────
     it('exposes delVisible via the col_middle scoped slot and omits the col_right button', () => {
         const wrapper = mountWithPlugins(AttributeValueLayout, {


### PR DESCRIPTION
## Summary

Restore modification provenance for individual report attribute values.

## What changed

- Add a compact provenance control beside each attribute value.
- Show the value’s last modification time and modifying user.
- Associate provenance with the correct value occurrence rather than showing ambiguous group-level metadata.
- Make the provenance control keyboard-focusable and accessible.
- Provide a descriptive ARIA label containing the available provenance.
- Render no control when neither timestamp nor modifier is available.
- Reuse existing translated `Last updated` and `Updated by` labels across all supported locales.
- Add focused provenance, accessibility, absence, and occurrence-selection tests.

## Why

Vue 2 exposed who last modified an attribute value and when. Vue 3 retained this data but did not present it correctly. A value-level control restores the information without crowding report forms or incorrectly attributing one occurrence’s metadata to the entire attribute group.

## Validation

- Focused attribute/editor tests: 14/14 passed
- Vue TypeScript check passed
- Scoped ESLint passed
- Scoped Prettier check passed
- `git diff --check` passed