### PR TITLE
Leave protected UI immediately after auth loss

### DIFF
--- a/src/gui-v3/src/App.vue
+++ b/src/gui-v3/src/App.vue
@@ -21,7 +21,8 @@
         </v-navigation-drawer>
 
         <v-main :class="{ 'configuration-view': isConfigurationRoute }">
-            <router-view />
+            <!-- Never retain a protected view after local credentials disappear. -->
+            <router-view v-if="isAuth || route.path === '/login'" />
         </v-main>
 
         <!-- Notification component -->
@@ -216,6 +217,12 @@
         navVisible.value = !navVisible.value
     }
 
+    const navigateToLogin = (): void => {
+        if (route.value.path !== '/login') {
+            void router.replace('/login')
+        }
+    }
+
     /**
      * Token refresh interval
      */
@@ -238,11 +245,16 @@
                         })
                         .catch((error) => {
                             console.error('[App] Token refresh failed:', error)
+                            navigateToLogin()
                         })
                 }
             } else if (authStore.jwt) {
                 console.log('[App] Token expired, logging out...')
-                authStore.logout()
+                const logoutRequest = authStore.logout()
+                navigateToLogin()
+                logoutRequest.catch((error) => {
+                    console.error('[App] Logout after token expiry failed:', error)
+                })
             }
         }, 5000)
     }

--- a/src/gui-v3/src/components/UserMenu.vue
+++ b/src/gui-v3/src/components/UserMenu.vue
@@ -75,16 +75,19 @@
     }
 
     const handleLogout = async (): Promise<void> => {
-        try {
-            await authStore.logout()
-            if (authStore.hasExternalLogoutUrl) {
-                window.location.href = authStore.getLogoutURL
-            } else {
-                router.push('/login')
-            }
-        } catch (error: unknown) {
+        const logoutRequest = authStore.logout().catch((error: unknown) => {
             console.error('Logout error:', error)
+        })
+
+        // Leave the protected route immediately; reporting a server-side
+        // logout failure must not keep cached application content visible.
+        if (authStore.hasExternalLogoutUrl) {
+            window.location.href = authStore.getLogoutURL
+        } else {
+            await router.replace('/login')
         }
+
+        await logoutRequest
     }
 </script>
 

--- a/src/gui-v3/src/stores/auth.ts
+++ b/src/gui-v3/src/stores/auth.ts
@@ -89,7 +89,14 @@ export const useAuthStore = defineStore('auth', () => {
 
     function clearJwtToken(): void {
         setStoredAccessToken('')
+        ApiService.setHeader()
         jwt.value = ''
+    }
+
+    function clearSession(): void {
+        clearJwtToken()
+        useUserStore().clearUser()
+        window.dispatchEvent(new Event('logged-out'))
     }
 
     async function login(userData: LoginPayload): Promise<ApiResponse<AuthTokenResponse>> {
@@ -110,19 +117,12 @@ export const useAuthStore = defineStore('auth', () => {
     }
 
     async function logout(): Promise<void> {
-        const userStore = useUserStore()
-
-        try {
-            await logoutApi()
-            clearJwtToken()
-            userStore.clearUser()
-            // Dispatch event to trigger SSE closing in App.vue
-            window.dispatchEvent(new Event('logged-out'))
-        } catch (error) {
-            clearJwtToken()
-            userStore.clearUser()
-            throw error
-        }
+        // Start the authenticated request before removing the local token, but
+        // invalidate the browser session immediately. A slow or failed server
+        // logout must never leave protected UI mounted with stale credentials.
+        const logoutRequest = logoutApi()
+        clearSession()
+        await logoutRequest
     }
 
     async function refreshToken(): Promise<ApiResponse<AuthTokenResponse>> {
@@ -135,7 +135,7 @@ export const useAuthStore = defineStore('auth', () => {
 
             return response
         } catch (error) {
-            clearJwtToken()
+            clearSession()
             throw error
         }
     }

--- a/src/gui-v3/tests/unit/App.spec.js
+++ b/src/gui-v3/tests/unit/App.spec.js
@@ -10,6 +10,7 @@ const mockSubscribe = vi.fn()
 const mockOnResync = vi.fn()
 const mockIsAuthenticated = vi.fn()
 const mockNeedTokenRefresh = vi.fn()
+const mockRouterReplace = vi.fn()
 
 const mockAuthStore = {
     jwt: '',
@@ -37,7 +38,7 @@ const mockSettingsStore = {
 }
 
 vi.mock('vue-router', () => ({
-    useRouter: () => ({ push: vi.fn() }),
+    useRouter: () => ({ replace: mockRouterReplace }),
     useRoute: () => ({ name: 'assess', path: '/assess' })
 }))
 
@@ -194,6 +195,47 @@ describe('App SSE boot flow', () => {
             expect(mockAuthStore.refreshToken).toHaveBeenCalledTimes(1)
             expect(mockReconnect).toHaveBeenCalledTimes(1)
         })
+    })
+
+    it('should leave protected content when token refresh fails', async () => {
+        mockNeedTokenRefresh.mockReturnValue(true)
+        mockAuthStore.refreshToken.mockRejectedValue(new Error('Token expired'))
+
+        wrapper = mountWithPlugins(App, {
+            global: {
+                stubs: {
+                    MainMenu: true,
+                    NotificationSnackbar: true
+                }
+            }
+        })
+
+        await flushPromises()
+        vi.advanceTimersByTime(5000)
+        await flushPromises()
+
+        expect(mockRouterReplace).toHaveBeenCalledWith('/login')
+        expect(mockReconnect).not.toHaveBeenCalled()
+    })
+
+    it('should leave protected content immediately when the stored token expires', async () => {
+        mockIsAuthenticated.mockReturnValue(false)
+        mockAuthStore.logout.mockResolvedValue(undefined)
+
+        wrapper = mountWithPlugins(App, {
+            global: {
+                stubs: {
+                    MainMenu: true,
+                    NotificationSnackbar: true
+                }
+            }
+        })
+
+        await flushPromises()
+        vi.advanceTimersByTime(5000)
+
+        expect(mockAuthStore.logout).toHaveBeenCalledTimes(1)
+        expect(mockRouterReplace).toHaveBeenCalledWith('/login')
     })
 
     it('should initialize authenticated session when logged-in event fires', async () => {

--- a/src/gui-v3/tests/unit/UserMenu.spec.js
+++ b/src/gui-v3/tests/unit/UserMenu.spec.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mountWithPlugins } from '../helpers/mount-helpers'
+import UserMenu from '@/components/UserMenu.vue'
+
+const mockRouterReplace = vi.fn()
+const mockLogout = vi.fn()
+
+vi.mock('vue-router', () => ({
+    useRouter: () => ({ replace: mockRouterReplace })
+}))
+
+vi.mock('@/stores/auth', () => ({
+    useAuthStore: () => ({
+        logout: mockLogout,
+        hasExternalLogoutUrl: false,
+        getLogoutURL: '/logout'
+    })
+}))
+
+vi.mock('@/stores/user', () => ({
+    useUserStore: () => ({
+        userName: 'Analyst',
+        organizationName: 'CERT'
+    })
+}))
+
+describe('UserMenu logout', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    })
+
+    it('navigates away before a pending local logout request settles', async () => {
+        let rejectLogout
+        mockLogout.mockReturnValue(
+            new Promise((_, reject) => {
+                rejectLogout = reject
+            })
+        )
+        const wrapper = mountWithPlugins(UserMenu, {
+            global: { stubs: { VMenu: true, UserSettings: true } }
+        })
+
+        const request = wrapper.vm.handleLogout()
+
+        expect(mockRouterReplace).toHaveBeenCalledWith('/login')
+
+        rejectLogout(new Error('Server unavailable'))
+        await request
+    })
+
+    it('still navigates to login when server logout rejects immediately', async () => {
+        mockLogout.mockRejectedValue(new Error('Server unavailable'))
+        const wrapper = mountWithPlugins(UserMenu, {
+            global: { stubs: { VMenu: true, UserSettings: true } }
+        })
+
+        await wrapper.vm.handleLogout()
+
+        expect(mockRouterReplace).toHaveBeenCalledWith('/login')
+    })
+})

--- a/src/gui-v3/tests/unit/auth.store.spec.js
+++ b/src/gui-v3/tests/unit/auth.store.spec.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useAuthStore } from '@/stores/auth'
+import { useUserStore } from '@/stores/user'
 
 // Mock dependencies
 vi.mock('@/api/auth', () => ({
@@ -221,6 +222,24 @@ describe('Auth Store', () => {
 
             expect(store.getUserData).toBe(null)
         })
+
+        it('should invalidate the local session even when server logout fails', async () => {
+            localStorage.ACCESS_TOKEN = makeJwt()
+            vi.mocked(authApi.logout).mockRejectedValue(new Error('Server unavailable'))
+            const store = useAuthStore()
+            const userStore = useUserStore()
+            userStore.setUser({ id: 1, name: 'Admin', permissions: ['ASSESS_ACCESS'] })
+            const loggedOut = vi.fn()
+            window.addEventListener('logged-out', loggedOut)
+
+            const request = store.logout()
+
+            expect(store.jwt).toBe('')
+            expect(userStore.user.id).toBe('')
+            expect(loggedOut).toHaveBeenCalledTimes(1)
+            await expect(request).rejects.toThrow('Server unavailable')
+            window.removeEventListener('logged-out', loggedOut)
+        })
     })
 
     // ── Token Refresh ─────────────────────────────
@@ -246,10 +265,17 @@ describe('Auth Store', () => {
             vi.mocked(authApi.refresh).mockRejectedValue(new Error('Token expired'))
 
             const store = useAuthStore()
+            const userStore = useUserStore()
+            userStore.setUser({ id: 1, name: 'Admin', permissions: ['ASSESS_ACCESS'] })
+            const loggedOut = vi.fn()
+            window.addEventListener('logged-out', loggedOut)
             await expect(store.refreshToken()).rejects.toThrow('Token expired')
 
             expect(store.jwt).toBe('')
             expect(store.isAuthenticated).toBe(false)
+            expect(userStore.user.id).toBe('')
+            expect(loggedOut).toHaveBeenCalledTimes(1)
+            window.removeEventListener('logged-out', loggedOut)
         })
     })
 


### PR DESCRIPTION
## Summary

Immediately remove protected Vue 3 content when authentication is lost.

## What changed

- Clear the JWT, user data, and authorization header synchronously during logout.
- Start the authenticated server logout request before removing the local token.
- Navigate to the login screen without waiting for the server logout response.
- Continue reporting server logout failures without retaining protected content.
- Redirect immediately through the configured external logout URL when applicable.
- Clear the complete local session after token-refresh failure.
- Navigate away immediately when an expired token is detected.
- Prevent protected router content from remaining mounted after authentication disappears.
- Add focused auth-store, application, and user-menu regression tests.

## Why

Previously, a failed or slow logout request could leave the current protected view mounted even though local authentication had already been cleared. Token-refresh failure had a similar path, allowing cached sensitive content to remain visible until another navigation occurred.

The UI now treats local authentication loss as immediate and authoritative, independently of whether server-side logout succeeds.

## Validation

- Focused authentication tests: 46 passed
- Vue TypeScript check passed
- Scoped ESLint passed
- Scoped Prettier check passed
- `git diff --check` passed