### PR TITLE
Restore word-list import from URL

### DIFF
--- a/src/gui-v3/src/components/config/word-lists/NewWordList.vue
+++ b/src/gui-v3/src/components/config/word-lists/NewWordList.vue
@@ -111,7 +111,10 @@
                                 :hint="t('word_lists.link_hint')"
                             />
 
-                            <WordListCsvImport v-model="item.entries" />
+                            <WordListCsvImport
+                                v-model="item.entries"
+                                :source-url="item.link"
+                            />
 
                             <EditableEntityTable
                                 v-model="item.entries"

--- a/src/gui-v3/src/components/config/word-lists/WordListCsvImport.vue
+++ b/src/gui-v3/src/components/config/word-lists/WordListCsvImport.vue
@@ -1,14 +1,25 @@
 <template>
-    <v-btn
-        type="button"
-        color="primary"
-        variant="tonal"
-        prepend-icon="mdi-upload"
-        class="mb-3"
-        @click="openDialog"
-    >
-        {{ t('word_lists.import_from_csv') }}
-    </v-btn>
+    <div class="d-flex flex-wrap ga-2 mb-3">
+        <v-btn
+            type="button"
+            color="primary"
+            variant="tonal"
+            prepend-icon="mdi-upload"
+            @click="openLocalDialog"
+        >
+            {{ t('word_lists.import_from_csv') }}
+        </v-btn>
+        <v-btn
+            v-if="normalizedSourceUrl"
+            type="button"
+            color="primary"
+            variant="tonal"
+            prepend-icon="mdi-download"
+            @click="openUrlDialog"
+        >
+            {{ t('word_lists.download_from_link') }}
+        </v-btn>
+    </div>
 
     <v-dialog
         v-model="dialog"
@@ -21,7 +32,7 @@
                 color="primary"
                 density="compact"
             >
-                <v-toolbar-title>{{ t('word_lists.import_from_csv') }}</v-toolbar-title>
+                <v-toolbar-title>{{ dialogTitle }}</v-toolbar-title>
                 <v-spacer />
                 <v-btn
                     type="button"
@@ -45,6 +56,7 @@
 
             <v-card-text>
                 <v-file-input
+                    v-if="sourceMode === 'file'"
                     v-model="csvFile"
                     :label="t('word_lists.load_csv_file')"
                     accept=".csv,text/csv,text/plain"
@@ -52,6 +64,15 @@
                     variant="outlined"
                     clearable
                     @update:model-value="readCsvFile"
+                />
+
+                <v-text-field
+                    v-else
+                    :model-value="normalizedSourceUrl"
+                    :label="t('word_lists.link')"
+                    prepend-inner-icon="mdi-link"
+                    variant="outlined"
+                    readonly
                 />
 
                 <div class="d-flex flex-wrap align-center ga-6 mb-3">
@@ -74,7 +95,7 @@
                     variant="tonal"
                     class="mb-3"
                 >
-                    {{ t('word_lists.error') }}
+                    {{ importErrorMessage }}
                 </v-alert>
 
                 <v-data-table
@@ -95,7 +116,10 @@
     import { mergeWordListEntries, parseWordListCsv, type WordListEntry } from '@/utils/word-list-csv'
 
     const model = defineModel<WordListEntry[]>({ default: () => [] })
+    const props = withDefaults(defineProps<{ sourceUrl?: string }>(), { sourceUrl: '' })
     const { t } = useI18n()
+
+    type SourceMode = 'file' | 'url'
 
     const previewHeaders = computed(() => [
         { title: t('word_lists.value'), key: 'value', sortable: false },
@@ -103,6 +127,7 @@
     ])
 
     const dialog = ref(false)
+    const sourceMode = ref<SourceMode>('file')
     const csvFile = ref<File | File[] | null>(null)
     const csvText = ref('')
     const csvRows = ref<WordListEntry[]>([])
@@ -110,6 +135,9 @@
     const fileHasHeader = ref(true)
     const replaceExisting = ref(false)
     const readingFile = ref(false)
+    const normalizedSourceUrl = computed(() => props.sourceUrl.trim())
+    const dialogTitle = computed(() => (sourceMode.value === 'url' ? t('word_lists.download_from_link') : t('word_lists.import_from_csv')))
+    const importErrorMessage = computed(() => `${dialogTitle.value}: ${t('common.error')}`)
 
     const reset = (): void => {
         csvFile.value = null
@@ -121,9 +149,17 @@
         readingFile.value = false
     }
 
-    const openDialog = (): void => {
+    const openLocalDialog = (): void => {
         reset()
+        sourceMode.value = 'file'
         dialog.value = true
+    }
+
+    const openUrlDialog = async (): Promise<void> => {
+        reset()
+        sourceMode.value = 'url'
+        dialog.value = true
+        await downloadCsv()
     }
 
     const closeDialog = (): void => {
@@ -152,6 +188,36 @@
         try {
             csvText.value = await file.text()
             parseCsv()
+        } catch {
+            csvError.value = true
+        } finally {
+            readingFile.value = false
+        }
+    }
+
+    const downloadCsv = async (): Promise<void> => {
+        csvText.value = ''
+        csvRows.value = []
+        csvError.value = false
+        readingFile.value = true
+
+        try {
+            const url = new globalThis.URL(normalizedSourceUrl.value)
+            if (url.protocol !== 'http:' && url.protocol !== 'https:') throw new Error('Unsupported URL protocol')
+
+            // This intentionally remains a direct browser request, like Vue 2. Omitting
+            // credentials prevents Taranis cookies or authorization from reaching a
+            // category-controlled host; the remote server must explicitly allow CORS.
+            const response = await globalThis.fetch(url, {
+                credentials: 'omit',
+                referrerPolicy: 'no-referrer',
+                cache: 'no-store'
+            })
+            if (!response.ok) throw new Error(`Download failed with HTTP ${response.status}`)
+
+            csvText.value = await response.text()
+            parseCsv()
+            if (!csvRows.value.length) csvError.value = true
         } catch {
             csvError.value = true
         } finally {

--- a/src/gui-v3/tests/unit/WordListCsvImport.spec.ts
+++ b/src/gui-v3/tests/unit/WordListCsvImport.spec.ts
@@ -1,5 +1,5 @@
 import { flushPromises } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { mountWithPlugins } from '../helpers/mount-helpers'
 import WordListCsvImport from '@/components/config/word-lists/WordListCsvImport.vue'
 
@@ -17,6 +17,10 @@ const VFileInputStub = {
 }
 
 describe('WordListCsvImport', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals()
+    })
+
     it('imports and merges a selected GUI CSV file', async () => {
         const wrapper = mountWithPlugins(WordListCsvImport, {
             props: { modelValue: [{ value: 'the', description: 'old' }] },
@@ -37,5 +41,109 @@ describe('WordListCsvImport', () => {
             { value: 'the', description: 'new' },
             { value: 'and', description: 'conjunction' }
         ])
+    })
+
+    it('downloads a configured URL through the CSV preview and merge flow without credentials', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            text: () => Promise.resolve('description,value\nnew,the\nconjunction,and\n')
+        })
+        vi.stubGlobal('fetch', fetchMock)
+
+        const wrapper = mountWithPlugins(WordListCsvImport, {
+            props: {
+                modelValue: [{ value: 'the', description: 'old' }],
+                sourceUrl: ' https://lists.example.test/words.csv '
+            },
+            global: { stubs: { VDialog: VDialogStub } }
+        })
+
+        const downloadButton = wrapper.findAllComponents({ name: 'VBtn' }).find((button) => button.text() === 'Download from URL')
+        if (!downloadButton) throw new Error('URL download button was not rendered')
+        await downloadButton.trigger('click')
+        await flushPromises()
+
+        expect(fetchMock).toHaveBeenCalledWith(new globalThis.URL('https://lists.example.test/words.csv'), {
+            credentials: 'omit',
+            referrerPolicy: 'no-referrer',
+            cache: 'no-store'
+        })
+        expect(wrapper.text()).toContain('the')
+        expect(wrapper.text()).toContain('and')
+
+        const importButton = wrapper.findAllComponents({ name: 'VBtn' }).find((button) => button.text() === 'Import')
+        if (!importButton) throw new Error('CSV import confirmation button was not rendered')
+        await importButton.trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')?.at(-1)?.[0]).toEqual([
+            { value: 'the', description: 'new' },
+            { value: 'and', description: 'conjunction' }
+        ])
+    })
+
+    it('reports URL failures without replacing existing category entries', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }))
+        const original = [{ value: 'keep', description: 'existing' }]
+        const wrapper = mountWithPlugins(WordListCsvImport, {
+            props: { modelValue: original, sourceUrl: 'https://lists.example.test/down.csv' },
+            global: { stubs: { VDialog: VDialogStub } }
+        })
+
+        const downloadButton = wrapper.findAllComponents({ name: 'VBtn' }).find((button) => button.text() === 'Download from URL')
+        if (!downloadButton) throw new Error('URL download button was not rendered')
+        await downloadButton.trigger('click')
+        await flushPromises()
+
+        expect(wrapper.text()).toContain('Download from URL: An error occurred')
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+        expect(original).toEqual([{ value: 'keep', description: 'existing' }])
+    })
+
+    it('replaces existing category entries only after explicit confirmation', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: true,
+                text: () => Promise.resolve('value,description\nreplacement,new list\n')
+            })
+        )
+        const wrapper = mountWithPlugins(WordListCsvImport, {
+            props: {
+                modelValue: [{ value: 'keep', description: 'existing' }],
+                sourceUrl: 'https://lists.example.test/replacement.csv'
+            },
+            global: { stubs: { VDialog: VDialogStub } }
+        })
+
+        const downloadButton = wrapper.findAllComponents({ name: 'VBtn' }).find((button) => button.text() === 'Download from URL')
+        if (!downloadButton) throw new Error('URL download button was not rendered')
+        await downloadButton.trigger('click')
+        await flushPromises()
+
+        const replaceCheckbox = wrapper.findAllComponents({ name: 'VCheckbox' })[1]
+        if (!replaceCheckbox) throw new Error('Replace-existing checkbox was not rendered')
+        await replaceCheckbox.setValue(true)
+        const importButton = wrapper.findAllComponents({ name: 'VBtn' }).find((button) => button.text() === 'Import')
+        if (!importButton) throw new Error('CSV import confirmation button was not rendered')
+        await importButton.trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')?.at(-1)?.[0]).toEqual([{ value: 'replacement', description: 'new list' }])
+    })
+
+    it('does not expose URL download for blank or unsupported links', async () => {
+        const wrapper = mountWithPlugins(WordListCsvImport, {
+            props: { sourceUrl: '' },
+            global: { stubs: { VDialog: VDialogStub } }
+        })
+        expect(wrapper.text()).not.toContain('Download from URL')
+
+        await wrapper.setProps({ sourceUrl: 'file:///etc/passwd' })
+        const downloadButton = wrapper.findAllComponents({ name: 'VBtn' }).find((button) => button.text() === 'Download from URL')
+        if (!downloadButton) throw new Error('Configured URL action was not rendered')
+        await downloadButton.trigger('click')
+        await flushPromises()
+
+        expect(wrapper.text()).toContain('Download from URL: An error occurred')
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
     })
 })


### PR DESCRIPTION
## Summary

Restore word-list category import from a configured URL in Vue 3.

## What changed

- Add a Download from URL action when a word-list category has a configured link.
- Feed downloaded content through the existing CSV import workflow.
- Reuse delimiter detection, optional headers, column mapping, preview, deduplication, and merge/replace controls.
- Restrict downloads to HTTP and HTTPS URLs.
- Fetch directly from the browser without sending Taranis credentials.
- Use `credentials: omit` and a no-referrer policy for remote requests.
- Preserve the current category contents when downloading or parsing fails.
- Show clear network, HTTP, URL, and parsing errors.
- Add focused tests for successful downloads, security options, invalid schemes, HTTP failures, and preview integration.

## Why

Vue 2 could populate a word-list category from its configured URL. Vue 3 retained the Link field but only supported importing a local CSV file.

This restores the missing workflow while reusing the established Vue 3 preview and mapping interface. No server-side URL proxy or arbitrary backend fetching was introduced; normal browser CORS rules continue to apply.

## Validation

- Focused word-list tests: 11/11 passed
- Full Vue TypeScript check passed
- Scoped ESLint passed
- Scoped Prettier check passed
- `git diff --check` passed