### PR TITLE
Validate service node API keys

### DIFF
--- a/src/shared/shared/schema/bots_node.py
+++ b/src/shared/shared/schema/bots_node.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from shared.schema.bots_node import BotsNode
 
-from marshmallow import EXCLUDE, Schema, fields, post_load
+from marshmallow import EXCLUDE, Schema, fields, post_load, validate
 
 from shared.schema.bot import BotSchema
 from shared.schema.presentation import PresentationSchema
@@ -70,7 +70,7 @@ class BotsNodeSchema(Schema):
     name = fields.Str()
     description = fields.Str()
     api_url = fields.Str()
-    api_key = fields.Str()
+    api_key = fields.Str(required=True, validate=validate.Regexp(r".*\S"))
     bots = fields.List(fields.Nested(BotSchema))
     created = fields.DateTime("%d.%m.%Y - %H:%M", dump_only=True)
     last_seen = fields.DateTime("%d.%m.%Y - %H:%M", dump_only=True)

--- a/src/shared/shared/schema/collectors_node.py
+++ b/src/shared/shared/schema/collectors_node.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from shared.schema.collectors_node import CollectorsNode
 
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, validate
 
 from shared.schema.collector import CollectorSchema
 from shared.schema.presentation import PresentationSchema
@@ -60,7 +60,7 @@ class CollectorsNodeSchema(Schema):
     name = fields.Str()
     description = fields.Str()
     api_url = fields.Str()
-    api_key = fields.Str()
+    api_key = fields.Str(required=True, validate=validate.Regexp(r".*\S"))
     collectors = fields.List(fields.Nested(CollectorSchema))
     status = fields.Str(dump_only=True)
     created = fields.DateTime("%d.%m.%Y - %H:%M", dump_only=True)

--- a/src/shared/shared/schema/presenters_node.py
+++ b/src/shared/shared/schema/presenters_node.py
@@ -1,31 +1,33 @@
-from marshmallow import EXCLUDE, Schema, fields, post_load
+"""PresentersNode schema."""
+
+from __future__ import annotations
+
+from marshmallow import EXCLUDE, Schema, fields, post_load, validate
 
 from shared.schema.presentation import PresentationSchema
 from shared.schema.presenter import PresenterSchema
 
 
-class PresentersNodeSchema(Schema):
-    class Meta:
-        unknown = EXCLUDE
-
-    id = fields.Str()
-    name = fields.Str()
-    description = fields.Str()
-    api_url = fields.Str()
-    api_key = fields.Str()
-    presenters = fields.List(fields.Nested(PresenterSchema))
-
-    @post_load
-    def make(self, data, **kwargs):
-        return PresentersNode(**data)
-
-
-class PresentersNodePresentationSchema(PresentersNodeSchema, PresentationSchema):
-    pass
-
-
 class PresentersNode:
-    def __init__(self, id, name, description, api_url, api_key):
+    """Lightweight data container created by `PresentersNodeSchema`."""
+
+    def __init__(
+        self,
+        id: str,  # noqa: A002
+        name: str,
+        description: str,
+        api_url: str,
+        api_key: str,
+    ) -> None:
+        """Initialize a presenters node.
+
+        Args:
+            id (str): GUID for the presenters node.
+            name (str): Human-readable node name.
+            description (str): Short description or notes about the node.
+            api_url (str): Base URL for the node's API endpoint.
+            api_key (str): API key used to authenticate requests to the node.
+        """
         self.id = id
         self.name = name
         self.description = description
@@ -33,6 +35,47 @@ class PresentersNode:
         self.api_key = api_key
 
     @classmethod
-    def create(cls, data):
+    def create(cls, data: dict) -> PresentersNode:
+        """Create a presenters node from raw schema data.
+
+        Args:
+            data (dict): Raw data to validate and deserialize.
+
+        Returns:
+            PresentersNode: Instance created from the validated data.
+        """
         node_schema = PresentersNodeSchema()
         return node_schema.load(data)
+
+
+class PresentersNodeSchema(Schema):
+    """Marshmallow schema for a presenters node."""
+
+    class Meta:
+        """Configure unknown-field handling."""
+
+        unknown = EXCLUDE
+
+    id = fields.Str()
+    name = fields.Str()
+    description = fields.Str()
+    api_url = fields.Str()
+    api_key = fields.Str(required=True, validate=validate.Regexp(r".*\S"))
+    presenters = fields.List(fields.Nested(PresenterSchema))
+
+    @post_load
+    def make(self, data: dict, **kwargs) -> PresentersNode:  # noqa: ANN003, ARG002
+        """Construct a presenters node from deserialized data.
+
+        Args:
+            data (dict): Deserialized schema data.
+            **kwargs: Additional Marshmallow callback arguments.
+
+        Returns:
+            PresentersNode: A populated presenters node.
+        """
+        return PresentersNode(**data)
+
+
+class PresentersNodePresentationSchema(PresentersNodeSchema, PresentationSchema):
+    """Presentation-oriented schema for presenters nodes."""

--- a/src/shared/shared/schema/publishers_node.py
+++ b/src/shared/shared/schema/publishers_node.py
@@ -1,31 +1,33 @@
-from marshmallow import EXCLUDE, Schema, fields, post_load
+"""PublishersNode schema."""
+
+from __future__ import annotations
+
+from marshmallow import EXCLUDE, Schema, fields, post_load, validate
 
 from shared.schema.presentation import PresentationSchema
 from shared.schema.publisher import PublisherSchema
 
 
-class PublishersNodeSchema(Schema):
-    class Meta:
-        unknown = EXCLUDE
-
-    id = fields.Str()
-    name = fields.Str()
-    description = fields.Str()
-    api_url = fields.Str()
-    api_key = fields.Str()
-    publishers = fields.List(fields.Nested(PublisherSchema))
-
-    @post_load
-    def make(self, data, **kwargs):
-        return PublishersNode(**data)
-
-
-class PublishersNodePresentationSchema(PublishersNodeSchema, PresentationSchema):
-    pass
-
-
 class PublishersNode:
-    def __init__(self, id, name, description, api_url, api_key):
+    """Lightweight data container created by `PublishersNodeSchema`."""
+
+    def __init__(
+        self,
+        id: str,  # noqa: A002
+        name: str,
+        description: str,
+        api_url: str,
+        api_key: str,
+    ) -> None:
+        """Initialize a publishers node.
+
+        Args:
+            id (str): GUID for the publishers node.
+            name (str): Human-readable node name.
+            description (str): Short description or notes about the node.
+            api_url (str): Base URL for the node's API endpoint.
+            api_key (str): API key used to authenticate requests to the node.
+        """
         self.id = id
         self.name = name
         self.description = description
@@ -33,6 +35,47 @@ class PublishersNode:
         self.api_key = api_key
 
     @classmethod
-    def create(cls, data):
+    def create(cls, data: dict) -> PublishersNode:
+        """Create a publishers node from raw schema data.
+
+        Args:
+            data (dict): Raw data to validate and deserialize.
+
+        Returns:
+            PublishersNode: Instance created from the validated data.
+        """
         node_schema = PublishersNodeSchema()
         return node_schema.load(data)
+
+
+class PublishersNodeSchema(Schema):
+    """Marshmallow schema for a publishers node."""
+
+    class Meta:
+        """Configure unknown-field handling."""
+
+        unknown = EXCLUDE
+
+    id = fields.Str()
+    name = fields.Str()
+    description = fields.Str()
+    api_url = fields.Str()
+    api_key = fields.Str(required=True, validate=validate.Regexp(r".*\S"))
+    publishers = fields.List(fields.Nested(PublisherSchema))
+
+    @post_load
+    def make(self, data: dict, **kwargs) -> PublishersNode:  # noqa: ANN003, ARG002
+        """Construct a publishers node from deserialized data.
+
+        Args:
+            data (dict): Deserialized schema data.
+            **kwargs: Additional Marshmallow callback arguments.
+
+        Returns:
+            PublishersNode: A populated publishers node.
+        """
+        return PublishersNode(**data)
+
+
+class PublishersNodePresentationSchema(PublishersNodeSchema, PresentationSchema):
+    """Presentation-oriented schema for publishers nodes."""

--- a/src/shared/tests/test_node_api_key_schema.py
+++ b/src/shared/tests/test_node_api_key_schema.py
@@ -1,0 +1,37 @@
+"""Validate the API-key contract shared by service-node schemas."""
+
+import pytest
+from marshmallow import ValidationError
+from shared.schema.bots_node import BotsNodeSchema
+from shared.schema.collectors_node import CollectorsNodeSchema
+from shared.schema.presenters_node import PresentersNodeSchema
+from shared.schema.publishers_node import PublishersNodeSchema
+
+SCHEMAS = (CollectorsNodeSchema, PresentersNodeSchema, PublishersNodeSchema, BotsNodeSchema)
+
+
+def _payload(api_key: str | None) -> dict[str, str]:
+    payload = {
+        "id": "node-id",
+        "name": "Node",
+        "description": "Description",
+        "api_url": "https://service.invalid",
+    }
+    if api_key is not None:
+        payload["api_key"] = api_key
+    return payload
+
+
+@pytest.mark.parametrize("schema_type", SCHEMAS)
+@pytest.mark.parametrize("invalid_key", [None, "", "   "])
+def test_missing_empty_and_whitespace_api_keys_are_rejected(schema_type: type, invalid_key: str | None) -> None:
+    """Reject keys that cannot authenticate a service request."""
+    with pytest.raises(ValidationError):
+        schema_type().load(_payload(invalid_key))
+
+
+@pytest.mark.parametrize("schema_type", SCHEMAS)
+def test_non_empty_api_key_is_accepted(schema_type: type) -> None:
+    """Continue accepting ordinary service-node payloads."""
+    node = schema_type().load(_payload("secret"))
+    assert node.api_key == "secret"  # noqa: S101


### PR DESCRIPTION
## Summary

Require the existence of API-key in shared service-node schemas.

## What changed

- Require `api_key` in collector, presenter, publisher, and bot node schemas.
- Reject missing, empty, and whitespace-only API keys.
- Continue accepting existing nonblank keys.
- Add focused contract tests covering all four node types.
- Bring the touched legacy presenter and publisher schema modules into Ruff compliance with documentation and type annotations.

## Runtime scope

The only functional change is schema validation of the existing API-key requirement.

This PR does not change:

- Database models or migrations
- API endpoints
- Managers or remote clients
- Authentication or authorization
- Permission handling
- Node constructor fields or serialized names
- Marshmallow post-load behavior

The presenter and publisher cleanup is behavior-neutral. The `id` constructor keyword is deliberately preserved for Marshmallow compatibility, using only a narrow Ruff suppression for the built-in-name warning.

## Why

All four service-node types already rely on API-key authentication:

- Their database columns are non-null.
- Remote clients send `Authorization: ApiKey <key>`.
- Service endpoints require API-key authentication.
- The CLI and legacy GUI require keys.

The shared schemas previously accepted missing or unusable keys, allowing invalid configuration to progress further into the request workflow.

## Validation

- Focused schema tests: 16/16 passed
- Ruff 0.16 lint passed on all five changed files
- Ruff formatting passed on all five changed files
- `git diff --check` passed