### PR TITLE
Restore Assess sorting and display preferences

### DIFF
--- a/src/gui-v3/src/components/assess/ToolbarFilterAssess.vue
+++ b/src/gui-v3/src/components/assess/ToolbarFilterAssess.vue
@@ -71,13 +71,13 @@
             <!-- Relevance sort button (Assess-specific) -->
             <v-chip
                 size="small"
-                :color="filter.sort === 'RELEVANCE_DESC' ? 'primary' : 'default'"
-                :variant="filter.sort === 'RELEVANCE_DESC' ? 'flat' : 'outlined'"
-                :title="t('assess.tooltip.sort.relevance.descending')"
+                :color="filter.sort === 'RELEVANCE_DESC' || filter.sort === 'RELEVANCE_ASC' ? 'primary' : 'default'"
+                :variant="filter.sort === 'RELEVANCE_DESC' || filter.sort === 'RELEVANCE_ASC' ? 'flat' : 'outlined'"
+                :title="relevanceSortTooltip"
                 @click="toggleRelevanceSort"
             >
                 <v-icon start>mdi-thumb-up</v-icon>
-                <v-icon>mdi-arrow-down</v-icon>
+                <v-icon>{{ relevanceSortIcon }}</v-icon>
             </v-chip>
         </template>
     </BaseToolbarFilter>
@@ -145,7 +145,7 @@
 </template>
 
 <script setup lang="ts">
-    import { ref, computed, watch } from 'vue'
+    import { ref, computed, watch, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useRoute } from 'vue-router'
     import { useAssessStore } from '@/stores/assess'
@@ -153,6 +153,32 @@
     import ToolbarGroup from '@/components/common/ToolbarGroup.vue'
 
     type ThreeStateFilter = 'ALL' | boolean
+
+    const DISPLAY_PREFERENCE_KEYS = {
+        hideReviews: 'review-hide',
+        hideSourceLinks: 'source-link-hide',
+        hideWordlist: 'word-list-hide',
+        compactMode: 'taranis.assess.compact-mode'
+    } as const
+
+    const readStoredBoolean = (key: string, fallback: boolean): boolean => {
+        try {
+            const value = localStorage.getItem(key)
+            if (value === 'true') return true
+            if (value === 'false') return false
+        } catch {
+            // Storage can be unavailable in privacy-restricted browser contexts.
+        }
+        return fallback
+    }
+
+    const storeBoolean = (key: string, value: boolean): void => {
+        try {
+            localStorage.setItem(key, String(value))
+        } catch {
+            // The display control should remain usable even if persistence is unavailable.
+        }
+    }
 
     type AssessToolbarFilter = {
         search: string
@@ -205,10 +231,11 @@
         sort: 'DATE_DESC'
     })
 
-    const compactMode = ref(false)
-    const hideReviews = ref(false)
-    const hideSourceLinks = ref(false)
-    const highlightWordlist = ref(false)
+    const compactMode = ref(readStoredBoolean(DISPLAY_PREFERENCE_KEYS.compactMode, false))
+    const hideReviews = ref(readStoredBoolean(DISPLAY_PREFERENCE_KEYS.hideReviews, false))
+    const hideSourceLinks = ref(readStoredBoolean(DISPLAY_PREFERENCE_KEYS.hideSourceLinks, false))
+    // Vue 2 stores the inverse (whether highlighting is hidden), so retain that key and meaning.
+    const highlightWordlist = ref(!readStoredBoolean(DISPLAY_PREFERENCE_KEYS.hideWordlist, false))
     const totalCount = ref(0)
     const currentlyShowingCount = ref(0)
     const selectedCount = ref(0)
@@ -253,11 +280,21 @@
     })
 
     const dateSortIcon = computed(() => {
-        return filter.value.sort === 'DATE_DESC' ? 'mdi-arrow-down' : 'mdi-arrow-up'
+        return filter.value.sort === 'DATE_ASC' ? 'mdi-arrow-up' : 'mdi-arrow-down'
     })
 
     const dateSortTooltip = computed(() => {
-        return filter.value.sort === 'DATE_DESC' ? t('assess.tooltip.sort.date.descending') : t('assess.tooltip.sort.date.ascending')
+        return filter.value.sort === 'DATE_ASC' ? t('assess.tooltip.sort.date.ascending') : t('assess.tooltip.sort.date.descending')
+    })
+
+    const relevanceSortIcon = computed(() => {
+        return filter.value.sort === 'RELEVANCE_ASC' ? 'mdi-arrow-up' : 'mdi-arrow-down'
+    })
+
+    const relevanceSortTooltip = computed(() => {
+        return filter.value.sort === 'RELEVANCE_ASC'
+            ? t('assess.tooltip.sort.relevance.ascending')
+            : t('assess.tooltip.sort.relevance.descending')
     })
 
     // Handle filter updates from base component
@@ -280,9 +317,8 @@
     }
 
     const toggleRelevanceSort = (): void => {
-        // Toggle between RELEVANCE_DESC and default DATE_DESC
         if (filter.value.sort === 'RELEVANCE_DESC') {
-            filter.value.sort = 'DATE_DESC'
+            filter.value.sort = 'RELEVANCE_ASC'
         } else {
             filter.value.sort = 'RELEVANCE_DESC'
         }
@@ -291,21 +327,25 @@
 
     const toggleCompactMode = (): void => {
         compactMode.value = !compactMode.value
+        storeBoolean(DISPLAY_PREFERENCE_KEYS.compactMode, compactMode.value)
         emitFilter()
     }
 
     const toggleHideReviews = (): void => {
         hideReviews.value = !hideReviews.value
+        storeBoolean(DISPLAY_PREFERENCE_KEYS.hideReviews, hideReviews.value)
         emitFilter()
     }
 
     const toggleHideSourceLinks = (): void => {
         hideSourceLinks.value = !hideSourceLinks.value
+        storeBoolean(DISPLAY_PREFERENCE_KEYS.hideSourceLinks, hideSourceLinks.value)
         emitFilter()
     }
 
     const toggleHighlightWordlist = (): void => {
         highlightWordlist.value = !highlightWordlist.value
+        storeBoolean(DISPLAY_PREFERENCE_KEYS.hideWordlist, !highlightWordlist.value)
         emitFilter()
     }
 
@@ -343,6 +383,9 @@
         },
         { deep: true }
     )
+
+    // Apply restored preferences before the user interacts with any filter control.
+    onMounted(() => emitFilter())
 
     // Expose methods for parent component
     defineExpose({

--- a/src/gui-v3/tests/unit/ToolbarFilterAssessPreferences.spec.ts
+++ b/src/gui-v3/tests/unit/ToolbarFilterAssessPreferences.spec.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { VueWrapper } from '@vue/test-utils'
+import { mountWithPlugins } from '../helpers/mount-helpers'
+import ToolbarFilterAssess from '@/components/assess/ToolbarFilterAssess.vue'
+
+vi.mock('vue-router', () => ({
+    useRoute: () => ({ query: {} })
+}))
+
+const BaseToolbarFilterStub = {
+    name: 'BaseToolbarFilter',
+    props: ['initialFilter'],
+    emits: ['update-filter', 'add-new'],
+    template: `
+        <div>
+            <slot name="custom-filters" :filter="initialFilter" />
+            <slot name="sort-buttons" :filter="initialFilter" :toggle-date-sort="() => {}" />
+            <slot name="addbutton" />
+        </div>
+    `
+}
+
+const mountToolbar = (): VueWrapper =>
+    mountWithPlugins(ToolbarFilterAssess, {
+        global: {
+            stubs: {
+                BaseToolbarFilter: BaseToolbarFilterStub,
+                ToolbarGroup: true
+            }
+        }
+    })
+
+const latestFilter = (wrapper: VueWrapper): Record<string, unknown> => {
+    const filters = wrapper.emitted('update-filter')
+    expect(filters).toBeDefined()
+    return filters!.at(-1)![0] as Record<string, unknown>
+}
+
+const clickPreference = async (wrapper: VueWrapper, title: string): Promise<void> => {
+    const button = wrapper.find(`[title="${title}"]`)
+    expect(button.exists()).toBe(true)
+    await button.trigger('click')
+}
+
+describe('ToolbarFilterAssess display preferences', () => {
+    beforeEach(() => {
+        localStorage.clear()
+    })
+
+    it('restores legacy visibility keys and the Vue 3 compact preference on mount', () => {
+        localStorage.setItem('review-hide', 'true')
+        localStorage.setItem('source-link-hide', 'true')
+        localStorage.setItem('word-list-hide', 'true')
+        localStorage.setItem('taranis.assess.compact-mode', 'true')
+
+        const filter = latestFilter(mountToolbar())
+
+        expect(filter).toMatchObject({
+            hide_reviews: true,
+            hide_source_links: true,
+            highlight_wordlist: false,
+            compact_mode: true
+        })
+    })
+
+    it('retains the legacy default of visible word-list highlighting', () => {
+        const filter = latestFilter(mountToolbar())
+
+        expect(filter).toMatchObject({
+            hide_reviews: false,
+            hide_source_links: false,
+            highlight_wordlist: true,
+            compact_mode: false
+        })
+    })
+
+    it('persists each change immediately using backward-compatible keys', async () => {
+        const wrapper = mountToolbar()
+
+        await clickPreference(wrapper, 'Hide reviews on news items')
+        await clickPreference(wrapper, 'Hide source links on news items')
+        await clickPreference(wrapper, 'Highlight words using word lists')
+        await clickPreference(wrapper, 'Toggle compact mode')
+
+        expect(localStorage.getItem('review-hide')).toBe('true')
+        expect(localStorage.getItem('source-link-hide')).toBe('true')
+        expect(localStorage.getItem('word-list-hide')).toBe('true')
+        expect(localStorage.getItem('taranis.assess.compact-mode')).toBe('true')
+        expect(latestFilter(wrapper)).toMatchObject({
+            hide_reviews: true,
+            hide_source_links: true,
+            highlight_wordlist: false,
+            compact_mode: true
+        })
+    })
+
+    it('restores changes after the toolbar is remounted', async () => {
+        const firstMount = mountToolbar()
+        await clickPreference(firstMount, 'Hide reviews on news items')
+        await clickPreference(firstMount, 'Toggle compact mode')
+        firstMount.unmount()
+
+        expect(latestFilter(mountToolbar())).toMatchObject({
+            hide_reviews: true,
+            compact_mode: true
+        })
+    })
+
+    it('falls back safely when stored values are malformed', () => {
+        localStorage.setItem('review-hide', 'yes')
+        localStorage.setItem('source-link-hide', '1')
+        localStorage.setItem('word-list-hide', 'hidden')
+        localStorage.setItem('taranis.assess.compact-mode', '{bad json')
+
+        expect(latestFilter(mountToolbar())).toMatchObject({
+            hide_reviews: false,
+            hide_source_links: false,
+            highlight_wordlist: true,
+            compact_mode: false
+        })
+    })
+})

--- a/src/gui-v3/tests/unit/ToolbarFilterAssessSort.spec.ts
+++ b/src/gui-v3/tests/unit/ToolbarFilterAssessSort.spec.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import ApiService from '@/services/api_service'
+import { getNewsItemsByGroup } from '@/api/assess'
+import ToolbarFilterAssess from '@/components/assess/ToolbarFilterAssess.vue'
+import { mountWithPlugins } from '../helpers/mount-helpers'
+
+vi.mock('vue-router', () => ({
+    useRoute: () => ({ query: {} })
+}))
+
+vi.mock('@/services/api_service', () => ({
+    default: { getWithCancel: vi.fn() }
+}))
+
+const latestSort = (wrapper: ReturnType<typeof mountWithPlugins>): string => {
+    const updates = wrapper.emitted('update-filter') ?? []
+    return (updates.at(-1)?.[0] as { sort: string }).sort
+}
+
+const sortChip = (wrapper: ReturnType<typeof mountWithPlugins>, title: string) => {
+    const chip = wrapper.find(`[title="${title}"]`)
+    expect(chip.exists()).toBe(true)
+    return chip
+}
+
+describe('ToolbarFilterAssess sorting', () => {
+    beforeEach(() => vi.clearAllMocks())
+
+    it('allows relevance descending, relevance ascending, and date ordering to be selected distinctly', async () => {
+        const wrapper = mountWithPlugins(ToolbarFilterAssess, {
+            props: { analyze_selector: true },
+            global: { stubs: { ToolbarGroup: true } }
+        })
+
+        await sortChip(wrapper, 'Sort news items by relevance descending').trigger('click')
+        expect(latestSort(wrapper)).toBe('RELEVANCE_DESC')
+        await nextTick()
+
+        await sortChip(wrapper, 'Sort news items by relevance descending').trigger('click')
+        expect(latestSort(wrapper)).toBe('RELEVANCE_ASC')
+        await nextTick()
+
+        await sortChip(wrapper, 'Sort news items by collected date descending').trigger('click')
+        expect(latestSort(wrapper)).toBe('DATE_DESC')
+
+        await sortChip(wrapper, 'Sort news items by collected date descending').trigger('click')
+        expect(latestSort(wrapper)).toBe('DATE_ASC')
+    })
+
+    it.each(['RELEVANCE_DESC', 'RELEVANCE_ASC'])('passes %s through the Assess API query', (sort) => {
+        getNewsItemsByGroup('group-a', {
+            offset: 0,
+            limit: 20,
+            filter: { search: '', read: 'ALL', important: 'ALL', relevant: 'ALL', range: 'ALL', sort }
+        })
+
+        expect(ApiService.getWithCancel).toHaveBeenCalledWith(
+            'screenData',
+            `/assess/news-item-aggregates-by-group/group-a?offset=0&limit=20&sort=${sort}`
+        )
+    })
+})


### PR DESCRIPTION
## Summary

Restore complete Assess sorting and persistent display preferences in Vue 3.

## What changed

- Restore separate relevance-descending and relevance-ascending sorting.
- Make the relevance control toggle its direction with matching arrow and tooltip.
- Keep date sorting independently selectable and direction-toggleable.
- Pass both relevance directions through the existing API contract.
- Restore and persist review visibility.
- Restore and persist source-link visibility.
- Restore legacy word-list highlighting preference semantics.
- Persist compact mode across navigation and reloads.
- Apply restored preferences immediately when Assess mounts.
- Fall back safely when browser storage is malformed or unavailable.

## Why

Vue 3 could only select relevance-descending or date-descending, losing the legacy ascending relevance option.

Assess display controls also reset whenever the view remounted, forcing analysts to repeatedly restore their preferred high-throughput review layout.

## Validation

- Focused sorting and preference tests: 8/8 passed
- Full Vue TypeScript check passed
- Scoped ESLint passed
- Scoped Prettier check passed
- `git diff --check` passed