### PR TITLE
Apply spellcheck preference consistently

### DIFF
--- a/src/gui-v3/src/components/assess/AddNewsItemDialog.vue
+++ b/src/gui-v3/src/components/assess/AddNewsItemDialog.vue
@@ -45,6 +45,7 @@
                     <!-- Title Field -->
                     <v-text-field
                         v-model="newsItem.title"
+                        :spellcheck="spellcheck"
                         :label="t('enter.title')"
                         :rules="[rules.required]"
                         variant="outlined"
@@ -55,6 +56,7 @@
                     <!-- Review Field -->
                     <v-textarea
                         v-model="newsItem.review"
+                        :spellcheck="spellcheck"
                         :label="t('enter.review')"
                         variant="outlined"
                         density="comfortable"
@@ -65,6 +67,7 @@
                     <!-- Source Field -->
                     <v-text-field
                         v-model="newsItem.source"
+                        :spellcheck="spellcheck"
                         :label="t('enter.source')"
                         variant="outlined"
                         density="comfortable"
@@ -74,6 +77,7 @@
                     <!-- Link Field -->
                     <v-text-field
                         v-model="newsItem.link"
+                        :spellcheck="false"
                         :label="t('enter.link')"
                         variant="outlined"
                         density="comfortable"
@@ -88,6 +92,7 @@
                         </label>
                         <Editor
                             v-model="editorContent"
+                            :pt="editorPassThrough"
                             editor-style="min-height: 250px"
                         />
                     </div>
@@ -141,6 +146,7 @@
     import { addNewsItem } from '@/api/assess'
     import { useUserStore } from '@/stores/user'
     import { useAuth } from '@/composables/useAuth'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import Permissions from '@/services/permissions'
 
     type ManualSource = {
@@ -192,6 +198,8 @@
     const userStore = useUserStore()
     const { checkPermission } = useAuth()
     const canCreateNewsItem = computed(() => checkPermission(Permissions.ASSESS_CREATE))
+    const spellcheck = useSpellcheck()
+    const editorPassThrough = computed(() => ({ content: { spellcheck: spellcheck.value } }))
 
     const isOpen = computed<boolean>({
         get: () => props.modelValue,

--- a/src/gui-v3/src/components/assess/NewsItemDetailDialog.vue
+++ b/src/gui-v3/src/components/assess/NewsItemDetailDialog.vue
@@ -202,6 +202,7 @@
                     <v-form>
                         <v-text-field
                             v-model="editTitle"
+                            :spellcheck="spellcheck"
                             :label="t('assess.title')"
                             density="comfortable"
                             variant="outlined"
@@ -211,6 +212,7 @@
                         />
                         <v-textarea
                             v-model="editDescription"
+                            :spellcheck="spellcheck"
                             :label="t('assess.description')"
                             density="comfortable"
                             variant="outlined"
@@ -231,6 +233,7 @@
                 >
                     <Editor
                         v-model="commentText"
+                        :pt="editorPassThrough"
                         editor-style="height: 250px"
                         :readonly="!canModifyItem"
                         @text-change="debounceAutoSave"
@@ -246,6 +249,7 @@
     import { ref, computed, watch } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useAuth } from '@/composables/useAuth'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import { PERMISSIONS } from '@/services/auth/permissions'
     import Editor from 'primevue/editor'
     import AssessItemActions from '@/components/assess/AssessItemActions.vue'
@@ -326,6 +330,8 @@
 
     const { t } = useI18n()
     const { checkPermission } = useAuth()
+    const spellcheck = useSpellcheck()
+    const editorPassThrough = computed(() => ({ content: { spellcheck: spellcheck.value } }))
 
     const isOpen = ref<boolean>(false)
     const activeTab = ref<'source' | 'attributes' | 'comments' | 'info'>('source')

--- a/src/gui-v3/src/components/assets/AssetDialog.vue
+++ b/src/gui-v3/src/components/assets/AssetDialog.vue
@@ -40,6 +40,7 @@
                         >
                             <v-text-field
                                 v-model="form.name"
+                                :spellcheck="spellcheck"
                                 :label="t('asset.name')"
                                 :rules="[required]"
                                 :disabled="saving || !canModify"
@@ -48,6 +49,7 @@
                             />
                             <v-text-field
                                 v-model="form.serial"
+                                :spellcheck="false"
                                 :label="t('asset.serial')"
                                 :disabled="saving || !canModify"
                                 variant="outlined"
@@ -55,6 +57,7 @@
                             />
                             <v-textarea
                                 v-model="form.description"
+                                :spellcheck="spellcheck"
                                 :label="t('asset.description')"
                                 :disabled="saving || !canModify"
                                 variant="outlined"
@@ -132,6 +135,7 @@
     import { computed, ref, watch } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useAuth } from '@/composables/useAuth'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import { createNewAsset, solveVulnerability, updateAsset } from '@/api/assets'
     import CpeEditor, { type CpeEntry } from './CpeEditor.vue'
@@ -141,6 +145,7 @@
     const props = defineProps<{ modelValue: boolean; asset?: Asset | null; groupId: string }>()
     const emit = defineEmits<{ (e: 'update:modelValue', value: boolean): void; (e: 'saved'): void }>()
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
 
     const open = computed({ get: () => props.modelValue, set: (value) => emit('update:modelValue', value) })

--- a/src/gui-v3/src/components/assets/CpeEditor.vue
+++ b/src/gui-v3/src/components/assets/CpeEditor.vue
@@ -74,6 +74,7 @@
                 <v-combobox
                     v-model="editedCpe.value"
                     v-model:search="cpeSearch"
+                    :spellcheck="false"
                     :items="cpeSuggestions"
                     :label="t('asset.value')"
                     variant="outlined"
@@ -86,6 +87,7 @@
                 />
                 <v-text-field
                     v-model="editedCpe.description"
+                    :spellcheck="spellcheck"
                     :label="t('asset.description')"
                     variant="outlined"
                     @keydown.enter.prevent="save"
@@ -174,6 +176,7 @@
     import { computed, ref } from 'vue'
     import { useI18n } from 'vue-i18n'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import { getCPEAttributeEnums } from '@/api/assets'
     import type { ListResponse } from '@/types/assets'
 
@@ -185,6 +188,7 @@
     const props = withDefaults(defineProps<{ disabled?: boolean }>(), { disabled: false })
     const model = defineModel<CpeEntry[]>({ default: () => [] })
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
 
     const headers = computed(() => {
         const values = [

--- a/src/gui-v3/src/components/common/attribute/AttributeAttachment.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeAttachment.vue
@@ -146,6 +146,7 @@
                 </div>
                 <v-textarea
                     v-model="descriptionDraft"
+                    :spellcheck="spellcheck"
                     :label="t('drop_zone.file_description')"
                     rows="3"
                     auto-grow
@@ -193,6 +194,7 @@
 <script setup lang="ts">
     import { computed, ref } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import { ICONS } from '@/config/ui-constants'
     import AuthService from '@/services/auth_service'
     import Permissions from '@/services/auth/permissions'
@@ -248,6 +250,7 @@
     )
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     // Besides the field-editing helpers, this composable keeps the values synchronized when
     // another analyst uploads, updates, or deletes an attachment over SSE.
     useAttributes(props)

--- a/src/gui-v3/src/components/common/attribute/AttributeCPE.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeCPE.vue
@@ -51,6 +51,7 @@
                     <template #col_middle="{ delVisible, onDelete }">
                         <v-text-field
                             v-model="value.value"
+                            :spellcheck="false"
                             density="compact"
                             variant="outlined"
                             hide-details="auto"

--- a/src/gui-v3/src/components/common/attribute/AttributeCVE.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeCVE.vue
@@ -58,6 +58,7 @@
                     <template #col_middle="{ delVisible, onDelete }">
                         <v-text-field
                             v-model="value.value"
+                            :spellcheck="false"
                             density="compact"
                             variant="outlined"
                             hide-details="auto"

--- a/src/gui-v3/src/components/common/attribute/AttributeCVSS.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeCVSS.vue
@@ -44,6 +44,7 @@
                     <template #col_middle="{ delVisible, onDelete }">
                         <v-text-field
                             v-model="value.value"
+                            :spellcheck="false"
                             density="compact"
                             variant="outlined"
                             hide-details="auto"

--- a/src/gui-v3/src/components/common/attribute/AttributeCWE.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeCWE.vue
@@ -64,6 +64,7 @@
                         <div class="cwe-fields">
                             <v-text-field
                                 v-model="value.value"
+                                :spellcheck="false"
                                 density="compact"
                                 variant="outlined"
                                 hide-details="auto"
@@ -77,6 +78,7 @@
                             />
                             <v-text-field
                                 v-model="value.value_description"
+                                :spellcheck="spellcheck"
                                 density="compact"
                                 variant="outlined"
                                 hide-details="auto"
@@ -105,6 +107,7 @@
 
 <script setup lang="ts">
     import { onMounted } from 'vue'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import { ICONS } from '@/config/ui-constants'
     import AttributeItemLayout from './AttributeItemLayout.vue'
     import AttributeValueLayout from './AttributeValueLayout.vue'
@@ -148,6 +151,8 @@
             modify: false
         }
     )
+
+    const spellcheck = useSpellcheck()
 
     const { canModify, addInitialValues, addButtonVisible, add, del, getLockedStyle, onFocus, onBlur, onKeyUp, enumSelected } =
         useAttributes(props)

--- a/src/gui-v3/src/components/common/attribute/AttributeRichText.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeRichText.vue
@@ -30,6 +30,7 @@
                     <template #col_middle>
                         <Editor
                             v-model="value.value"
+                            :pt="editorPassThrough"
                             :read-only="false"
                             theme="snow"
                             placeholder="Enter rich text..."
@@ -44,12 +45,13 @@
 </template>
 
 <script setup lang="ts">
-    import { onMounted } from 'vue'
+    import { computed, onMounted } from 'vue'
     import Editor from 'primevue/editor'
     import AttributeItemLayout from './AttributeItemLayout.vue'
     import AttributeValueLayout from './AttributeValueLayout.vue'
     import { useAttributes } from './useAttributes'
     import { sanitizeRichTextHtml } from '@/utils/sanitizeRichTextHtml'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
 
     type AttributeValueItem = {
         index?: string | number
@@ -81,6 +83,8 @@
     )
 
     const { canModify, addInitialValues, addButtonVisible, add, del, onBlur } = useAttributes(props)
+    const spellcheck = useSpellcheck()
+    const editorPassThrough = computed(() => ({ content: { spellcheck: spellcheck.value } }))
 
     // Count words in rich text (strips HTML)
     const getWordCount = (html: string | null | undefined): number => {

--- a/src/gui-v3/src/components/common/attribute/AttributeString.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeString.vue
@@ -86,6 +86,7 @@
                     <template #col_middle="{ delVisible, onDelete }">
                         <v-text-field
                             v-model="value.value"
+                            :spellcheck="spellcheck && !isUrl(value.value)"
                             density="compact"
                             variant="outlined"
                             hide-details="auto"
@@ -129,6 +130,7 @@
 <script setup lang="ts">
     import { onMounted, ref } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AttributeItemLayout from './AttributeItemLayout.vue'
     import AttributeValueLayout from './AttributeValueLayout.vue'
     import AttributeFieldDeleteButton from '@/components/common/buttons/AttributeFieldDeleteButton.vue'
@@ -165,6 +167,7 @@
     )
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
 
     const { canModify, addInitialValues, addButtonVisible, add, del, getLockedStyle, onFocus, onBlur, onKeyUp, move, moveUp, moveDown } =
         useAttributes(props)

--- a/src/gui-v3/src/components/common/attribute/AttributeText.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeText.vue
@@ -77,6 +77,7 @@
                     <template #col_middle="{ delVisible, onDelete }">
                         <v-textarea
                             v-model="value.value"
+                            :spellcheck="spellcheck"
                             density="compact"
                             variant="outlined"
                             hide-details="auto"
@@ -106,6 +107,7 @@
 <script setup lang="ts">
     import { onMounted, ref } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AttributeItemLayout from './AttributeItemLayout.vue'
     import AttributeValueLayout from './AttributeValueLayout.vue'
     import AttributeFieldDeleteButton from '@/components/common/buttons/AttributeFieldDeleteButton.vue'
@@ -142,6 +144,7 @@
     )
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
 
     const { canModify, addInitialValues, addButtonVisible, add, del, getLockedStyle, onFocus, onBlur, onKeyUp, move, moveUp, moveDown } =
         useAttributes(props)

--- a/src/gui-v3/src/components/config/access-management/NewACL.vue
+++ b/src/gui-v3/src/components/config/access-management/NewACL.vue
@@ -30,6 +30,7 @@
                 >
                     <v-text-field
                         v-model="localItem.name"
+                        :spellcheck="spellcheck"
                         :label="t('access_management.acls.name')"
                         variant="outlined"
                         density="comfortable"
@@ -40,6 +41,7 @@
 
                     <v-textarea
                         v-model="localItem.description"
+                        :spellcheck="spellcheck"
                         :label="t('access_management.acls.description')"
                         variant="outlined"
                         density="comfortable"
@@ -157,6 +159,7 @@
 <script setup lang="ts">
     import { ref, computed, watch, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
@@ -242,6 +245,7 @@
     }>()
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
 
     const formRef = ref<any>(null)

--- a/src/gui-v3/src/components/config/access-management/NewOrganization.vue
+++ b/src/gui-v3/src/components/config/access-management/NewOrganization.vue
@@ -30,6 +30,7 @@
                 >
                     <v-text-field
                         v-model="localItem.name"
+                        :spellcheck="spellcheck"
                         :label="t('access_management.organizations.name')"
                         variant="outlined"
                         density="comfortable"
@@ -40,6 +41,7 @@
 
                     <v-textarea
                         v-model="localItem.description"
+                        :spellcheck="spellcheck"
                         :label="t('access_management.organizations.description')"
                         variant="outlined"
                         density="comfortable"
@@ -49,6 +51,7 @@
 
                     <v-text-field
                         v-model="localItem.street"
+                        :spellcheck="spellcheck"
                         :label="t('access_management.organizations.street')"
                         variant="outlined"
                         density="comfortable"
@@ -58,6 +61,7 @@
 
                     <v-text-field
                         v-model="localItem.city"
+                        :spellcheck="spellcheck"
                         :label="t('access_management.organizations.city')"
                         variant="outlined"
                         density="comfortable"
@@ -67,6 +71,7 @@
 
                     <v-text-field
                         v-model="localItem.zip"
+                        :spellcheck="false"
                         :label="t('access_management.organizations.zip')"
                         variant="outlined"
                         density="comfortable"
@@ -76,6 +81,7 @@
 
                     <v-text-field
                         v-model="localItem.country"
+                        :spellcheck="spellcheck"
                         :label="t('access_management.organizations.country')"
                         variant="outlined"
                         density="comfortable"
@@ -119,6 +125,7 @@
 <script setup lang="ts">
     import { ref, computed, watch } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import { useAuth } from '@/composables/useAuth'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
@@ -155,6 +162,7 @@
     const emit = defineEmits(['update:modelValue', 'saved'])
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
 
     const formRef = ref<any>(null)

--- a/src/gui-v3/src/components/config/access-management/NewRole.vue
+++ b/src/gui-v3/src/components/config/access-management/NewRole.vue
@@ -30,6 +30,7 @@
                 >
                     <v-text-field
                         v-model="localItem.name"
+                        :spellcheck="spellcheck"
                         :label="t('access_management.roles.title')"
                         variant="outlined"
                         density="comfortable"
@@ -40,6 +41,7 @@
 
                     <v-textarea
                         v-model="localItem.description"
+                        :spellcheck="spellcheck"
                         :label="t('access_management.roles.description')"
                         variant="outlined"
                         density="comfortable"
@@ -94,6 +96,7 @@
 <script setup lang="ts">
     import { ref, computed, watch, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import { useAuth } from '@/composables/useAuth'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
@@ -149,6 +152,7 @@
     const emit = defineEmits(['update:modelValue', 'saved'])
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
 
     const formRef = ref<any>(null)

--- a/src/gui-v3/src/components/config/access-management/NewUser.vue
+++ b/src/gui-v3/src/components/config/access-management/NewUser.vue
@@ -32,6 +32,7 @@
                         <v-col cols="6">
                             <v-text-field
                                 v-model="localItem.username"
+                                :spellcheck="false"
                                 :label="t('access_management.users.username')"
                                 variant="outlined"
                                 density="comfortable"
@@ -42,6 +43,7 @@
                         <v-col cols="6">
                             <v-text-field
                                 v-model="localItem.name"
+                                :spellcheck="spellcheck"
                                 :label="t('access_management.users.name')"
                                 variant="outlined"
                                 density="comfortable"
@@ -54,6 +56,7 @@
                         <v-col cols="6">
                             <v-text-field
                                 v-model="password"
+                                :spellcheck="false"
                                 :label="t('access_management.users.password')"
                                 :type="showPassword ? 'text' : 'password'"
                                 variant="outlined"
@@ -67,6 +70,7 @@
                         <v-col cols="6">
                             <v-text-field
                                 v-model="passwordConfirm"
+                                :spellcheck="false"
                                 :label="t('access_management.users.password_check')"
                                 :type="showPassword ? 'text' : 'password'"
                                 variant="outlined"
@@ -146,6 +150,7 @@
 <script setup lang="ts">
     import { ref, computed, watch, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import { useAuth } from '@/composables/useAuth'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
@@ -204,6 +209,7 @@
     const emit = defineEmits(['update:modelValue', 'saved'])
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
 
     const dialog = ref(false)

--- a/src/gui-v3/src/components/config/assets/AssetGroupDialog.vue
+++ b/src/gui-v3/src/components/config/assets/AssetGroupDialog.vue
@@ -19,12 +19,14 @@
                 >
                     <v-text-field
                         v-model="form.name"
+                        :spellcheck="spellcheck"
                         :label="t('asset_group.name')"
                         :rules="[required]"
                         variant="outlined"
                     />
                     <v-textarea
                         v-model="form.description"
+                        :spellcheck="spellcheck"
                         :label="t('asset_group.description')"
                         variant="outlined"
                         rows="3"
@@ -70,6 +72,7 @@
 <script setup lang="ts">
     import { computed, ref, watch } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import { createNewAssetGroup, getAllNotificationTemplates, updateAssetGroup } from '@/api/assets'
     import { getAllExternalUsers } from '@/api/config'
@@ -78,6 +81,7 @@
     const props = defineProps<{ modelValue: boolean; group?: AssetGroup | null }>()
     const emit = defineEmits<{ (e: 'update:modelValue', value: boolean): void; (e: 'saved'): void }>()
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const open = computed({ get: () => props.modelValue, set: (value) => emit('update:modelValue', value) })
     const editing = computed(() => Boolean(props.group?.id))
     const formRef = ref<{ validate?: () => Promise<{ valid: boolean }> } | null>(null)

--- a/src/gui-v3/src/components/config/bots/NewBotPreset.vue
+++ b/src/gui-v3/src/components/config/bots/NewBotPreset.vue
@@ -63,6 +63,7 @@
                     <v-text-field
                         v-if="selectedBot"
                         v-model="localItem.name"
+                        :spellcheck="spellcheck"
                         :label="t('bots.presets.name')"
                         variant="outlined"
                         density="comfortable"
@@ -74,6 +75,7 @@
                     <v-textarea
                         v-if="selectedBot"
                         v-model="localItem.description"
+                        :spellcheck="spellcheck"
                         :label="t('bots.presets.description')"
                         variant="outlined"
                         density="comfortable"
@@ -96,6 +98,7 @@
                         >
                             <v-text-field
                                 v-model="parameterValues[index]"
+                                :spellcheck="false"
                                 :label="param.name"
                                 :type="param.key && param.key.includes('PASSWORD') ? 'password' : 'text'"
                                 variant="outlined"
@@ -151,6 +154,7 @@
 <script setup lang="ts">
     import { ref, computed, watch, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
@@ -219,6 +223,7 @@
     }>()
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
 
     const dialog = ref(false)

--- a/src/gui-v3/src/components/config/collectors/NewOSINTSource.vue
+++ b/src/gui-v3/src/components/config/collectors/NewOSINTSource.vue
@@ -63,6 +63,7 @@
                     <v-text-field
                         v-if="selectedCollector"
                         v-model="localItem.name"
+                        :spellcheck="spellcheck"
                         :label="t('collectors.sources.name')"
                         variant="outlined"
                         density="comfortable"
@@ -74,6 +75,7 @@
                     <v-textarea
                         v-if="selectedCollector"
                         v-model="localItem.description"
+                        :spellcheck="spellcheck"
                         :label="t('collectors.sources.description')"
                         variant="outlined"
                         density="comfortable"
@@ -93,6 +95,7 @@
                         >
                             <v-text-field
                                 v-model="parameterValues[index]"
+                                :spellcheck="false"
                                 :label="String(param.name || param.key || '')"
                                 :type="typeof param.key === 'string' && param.key.includes('PASSWORD') ? 'password' : 'text'"
                                 variant="outlined"
@@ -179,6 +182,7 @@
 <script setup lang="ts">
     import { ref, computed, watch, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
@@ -272,6 +276,7 @@
     }>()
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
     const configStore = useConfigStore()
 

--- a/src/gui-v3/src/components/config/collectors/NewOSINTSourceGroup.vue
+++ b/src/gui-v3/src/components/config/collectors/NewOSINTSourceGroup.vue
@@ -30,6 +30,7 @@
                 >
                     <v-text-field
                         v-model="localItem.name"
+                        :spellcheck="spellcheck"
                         :label="t('collectors.groups.name')"
                         variant="outlined"
                         density="comfortable"
@@ -40,6 +41,7 @@
 
                     <v-textarea
                         v-model="localItem.description"
+                        :spellcheck="spellcheck"
                         :label="t('collectors.groups.description')"
                         variant="outlined"
                         density="comfortable"
@@ -95,6 +97,7 @@
 <script setup lang="ts">
     import { ref, computed, watch, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
@@ -131,6 +134,7 @@
     }>()
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
     const configStore = useConfigStore()
 

--- a/src/gui-v3/src/components/config/data-providers/NewAiProvider.vue
+++ b/src/gui-v3/src/components/config/data-providers/NewAiProvider.vue
@@ -30,6 +30,7 @@
                 >
                     <v-text-field
                         v-model="localItem.name"
+                        :spellcheck="spellcheck"
                         :label="t('data_providers.ai.name')"
                         variant="outlined"
                         density="comfortable"
@@ -51,6 +52,7 @@
 
                     <v-text-field
                         v-model="localItem.api_url"
+                        :spellcheck="false"
                         :label="t('data_providers.ai.api_url')"
                         variant="outlined"
                         density="comfortable"
@@ -61,6 +63,7 @@
 
                     <v-text-field
                         v-model="localItem.api_key"
+                        :spellcheck="false"
                         :label="t('settings.api_key')"
                         variant="outlined"
                         density="comfortable"
@@ -74,6 +77,7 @@
 
                     <v-text-field
                         v-model="localItem.model"
+                        :spellcheck="false"
                         :label="t('data_providers.ai.model')"
                         variant="outlined"
                         density="comfortable"
@@ -118,6 +122,7 @@
 <script setup lang="ts">
     import { ref, computed, watch } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
@@ -151,6 +156,7 @@
     const emit = defineEmits(['update:modelValue', 'saved'])
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
 
     const formRef = ref<any>(null)

--- a/src/gui-v3/src/components/config/data-providers/NewDataProvider.vue
+++ b/src/gui-v3/src/components/config/data-providers/NewDataProvider.vue
@@ -30,6 +30,7 @@
                 >
                     <v-text-field
                         v-model="localItem.name"
+                        :spellcheck="spellcheck"
                         :label="t('data_providers.data.name')"
                         variant="outlined"
                         density="comfortable"
@@ -51,6 +52,7 @@
 
                     <v-text-field
                         v-model="localItem.api_url"
+                        :spellcheck="false"
                         :label="t('data_providers.data.api_url')"
                         variant="outlined"
                         density="comfortable"
@@ -63,6 +65,7 @@
                         <v-col cols="6">
                             <v-text-field
                                 v-model="localItem.api_key"
+                                :spellcheck="false"
                                 :label="t('settings.api_key')"
                                 variant="outlined"
                                 density="comfortable"
@@ -75,6 +78,7 @@
                         <v-col cols="6">
                             <v-text-field
                                 v-model="localItem.user_agent"
+                                :spellcheck="false"
                                 :label="t('data_providers.data.user_agent')"
                                 variant="outlined"
                                 density="comfortable"
@@ -85,6 +89,7 @@
 
                     <v-text-field
                         v-model="localItem.web_url"
+                        :spellcheck="false"
                         :label="t('data_providers.data.web_url')"
                         variant="outlined"
                         density="comfortable"
@@ -129,6 +134,7 @@
 <script setup lang="ts">
     import { ref, computed, watch } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
@@ -163,6 +169,7 @@
     const emit = defineEmits(['update:modelValue', 'saved'])
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
 
     const formRef = ref<any>(null)

--- a/src/gui-v3/src/components/config/external/NewExternalUser.vue
+++ b/src/gui-v3/src/components/config/external/NewExternalUser.vue
@@ -23,6 +23,7 @@
                             md="6"
                             ><v-text-field
                                 v-model="form.username"
+                                :spellcheck="false"
                                 :label="t('external_user.username')"
                                 :rules="[required]"
                                 variant="outlined"
@@ -32,6 +33,7 @@
                             md="6"
                             ><v-text-field
                                 v-model="form.name"
+                                :spellcheck="spellcheck"
                                 :label="t('external_user.name')"
                                 variant="outlined"
                         /></v-col>
@@ -40,6 +42,7 @@
                             md="6"
                             ><v-text-field
                                 v-model="password"
+                                :spellcheck="false"
                                 :label="t('external_user.password')"
                                 type="password"
                                 :rules="editing && !password ? [] : [required]"
@@ -50,6 +53,7 @@
                             md="6"
                             ><v-text-field
                                 v-model="passwordAgain"
+                                :spellcheck="false"
                                 :label="t('external_user.password_check')"
                                 type="password"
                                 :rules="[passwordMatches]"
@@ -85,6 +89,7 @@
 <script setup lang="ts">
     import { computed, ref, watch } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import { createNewExternalUser, getAllExternalPermissions, updateExternalUser } from '@/api/config'
 
@@ -93,6 +98,7 @@
     const props = defineProps<{ modelValue: boolean; user?: ExternalUser | null }>()
     const emit = defineEmits<{ (e: 'update:modelValue', value: boolean): void; (e: 'saved'): void }>()
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const open = computed({ get: () => props.modelValue, set: (value) => emit('update:modelValue', value) })
     const editing = computed(() => Boolean(props.user?.id))
     const formRef = ref<{ validate?: () => Promise<{ valid: boolean }> } | null>(null)

--- a/src/gui-v3/src/components/config/notifications/NotificationTemplateDialog.vue
+++ b/src/gui-v3/src/components/config/notifications/NotificationTemplateDialog.vue
@@ -19,24 +19,28 @@
                 >
                     <v-text-field
                         v-model="form.name"
+                        :spellcheck="spellcheck"
                         :label="t('notification_template.name')"
                         :rules="[required]"
                         variant="outlined"
                     />
                     <v-textarea
                         v-model="form.description"
+                        :spellcheck="spellcheck"
                         :label="t('notification_template.description')"
                         variant="outlined"
                         rows="2"
                     />
                     <v-text-field
                         v-model="form.message_title"
+                        :spellcheck="spellcheck"
                         :label="t('notification_template.message_title')"
                         variant="outlined"
                     />
                     <label class="text-subtitle-2 d-block mb-2">{{ t('notification_template.message_body') }}</label>
                     <Editor
                         v-model="form.message_body"
+                        :pt="editorPassThrough"
                         editor-style="min-height: 220px"
                         class="mb-4"
                     />
@@ -57,6 +61,7 @@
 <script setup lang="ts">
     import { computed, ref, watch } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import Editor from 'primevue/editor'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import RecipientTable from './RecipientTable.vue'
@@ -65,6 +70,8 @@
     const props = defineProps<{ modelValue: boolean; template?: NotificationTemplate | null }>()
     const emit = defineEmits<{ (e: 'update:modelValue', value: boolean): void; (e: 'saved'): void }>()
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
+    const editorPassThrough = computed(() => ({ content: { spellcheck: spellcheck.value } }))
     const open = computed({ get: () => props.modelValue, set: (value) => emit('update:modelValue', value) })
     const editing = computed(() => Boolean(props.template?.id))
     const formRef = ref<{ validate?: () => Promise<{ valid: boolean }> } | null>(null)

--- a/src/gui-v3/src/components/config/notifications/RecipientTable.vue
+++ b/src/gui-v3/src/components/config/notifications/RecipientTable.vue
@@ -39,12 +39,14 @@
             <v-card-text>
                 <v-text-field
                     v-model="working.email"
+                    :spellcheck="false"
                     :label="t('notification_template.email')"
                     type="email"
                     variant="outlined"
                 />
                 <v-text-field
                     v-model="working.name"
+                    :spellcheck="spellcheck"
                     :label="t('notification_template.recipient_name')"
                     variant="outlined"
                 />
@@ -56,12 +58,14 @@
 <script setup lang="ts">
     import { computed, ref } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import ActionButton from '@/components/common/buttons/ActionButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import type { NotificationRecipient } from '@/types/assets'
     const model = defineModel<NotificationRecipient[]>({ default: () => [] })
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const dialog = ref(false)
     const index = ref(-1)
     const working = ref<NotificationRecipient>({ email: '', name: '' })

--- a/src/gui-v3/src/components/config/presenters/NewProductType.vue
+++ b/src/gui-v3/src/components/config/presenters/NewProductType.vue
@@ -63,6 +63,7 @@
                     <v-text-field
                         v-if="selectedPresenter"
                         v-model="localItem.title"
+                        :spellcheck="spellcheck"
                         :label="t('presenters.types.name')"
                         variant="outlined"
                         density="comfortable"
@@ -74,6 +75,7 @@
                     <v-textarea
                         v-if="selectedPresenter"
                         v-model="localItem.description"
+                        :spellcheck="spellcheck"
                         :label="t('presenters.types.description')"
                         variant="outlined"
                         density="comfortable"
@@ -105,6 +107,7 @@
                         >
                             <v-text-field
                                 v-model="parameterValues[index]"
+                                :spellcheck="false"
                                 :label="String(param.name || param.key || '')"
                                 variant="outlined"
                                 density="comfortable"
@@ -259,6 +262,7 @@
 <script setup lang="ts">
     import { ref, computed, watch, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
@@ -346,6 +350,7 @@
     }>()
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
     const configStore = useConfigStore()
 

--- a/src/gui-v3/src/components/config/publishers/NewPublisherPreset.vue
+++ b/src/gui-v3/src/components/config/publishers/NewPublisherPreset.vue
@@ -63,6 +63,7 @@
                     <v-text-field
                         v-if="selectedPublisher"
                         v-model="localItem.name"
+                        :spellcheck="spellcheck"
                         :label="t('publishers.presets.name')"
                         variant="outlined"
                         density="comfortable"
@@ -74,6 +75,7 @@
                     <v-textarea
                         v-if="selectedPublisher"
                         v-model="localItem.description"
+                        :spellcheck="spellcheck"
                         :label="t('publishers.presets.description')"
                         variant="outlined"
                         density="comfortable"
@@ -106,6 +108,7 @@
                         >
                             <v-text-field
                                 v-model="parameterValues[index]"
+                                :spellcheck="false"
                                 :label="param.name"
                                 :type="param.key && param.key.includes('PASSWORD') ? 'password' : 'text'"
                                 variant="outlined"
@@ -161,6 +164,7 @@
 <script setup lang="ts">
     import { ref, computed, watch, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
@@ -230,6 +234,7 @@
     }>()
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
 
     const dialog = ref(false)

--- a/src/gui-v3/src/components/config/remote/NewRemoteAccess.vue
+++ b/src/gui-v3/src/components/config/remote/NewRemoteAccess.vue
@@ -30,6 +30,7 @@
                 >
                     <v-text-field
                         v-model="localItem.name"
+                        :spellcheck="spellcheck"
                         :label="t('remote.access.name')"
                         variant="outlined"
                         density="comfortable"
@@ -40,6 +41,7 @@
 
                     <v-textarea
                         v-model="localItem.description"
+                        :spellcheck="spellcheck"
                         :label="t('remote.access.description')"
                         variant="outlined"
                         density="comfortable"
@@ -50,6 +52,7 @@
 
                     <v-text-field
                         v-model="localItem.api_key"
+                        :spellcheck="false"
                         :label="t('settings.api_key')"
                         :type="showApiKey ? 'text' : 'password'"
                         :append-inner-icon="showApiKey ? 'mdi-eye-off' : 'mdi-eye'"
@@ -138,6 +141,7 @@
 <script setup lang="ts">
     import { ref, computed, watch, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
@@ -179,6 +183,7 @@
     }>()
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
 
     const formRef = ref<any>(null)

--- a/src/gui-v3/src/components/config/remote/NewRemoteNode.vue
+++ b/src/gui-v3/src/components/config/remote/NewRemoteNode.vue
@@ -30,6 +30,7 @@
                 >
                     <v-text-field
                         v-model="localItem.name"
+                        :spellcheck="spellcheck"
                         :label="t('remote.nodes.name')"
                         variant="outlined"
                         density="comfortable"
@@ -40,6 +41,7 @@
 
                     <v-textarea
                         v-model="localItem.description"
+                        :spellcheck="spellcheck"
                         :label="t('remote.nodes.description')"
                         variant="outlined"
                         density="comfortable"
@@ -50,6 +52,7 @@
 
                     <v-text-field
                         v-model="localItem.remote_url"
+                        :spellcheck="false"
                         :label="t('remote.nodes.remote_url')"
                         variant="outlined"
                         density="comfortable"
@@ -60,6 +63,7 @@
 
                     <v-text-field
                         v-model="localItem.events_url"
+                        :spellcheck="false"
                         :label="t('remote.nodes.event_url')"
                         variant="outlined"
                         density="comfortable"
@@ -69,6 +73,7 @@
 
                     <v-text-field
                         v-model="localItem.api_key"
+                        :spellcheck="false"
                         :label="t('settings.api_key')"
                         :type="showApiKey ? 'text' : 'password'"
                         :append-inner-icon="showApiKey ? 'mdi-eye-off' : 'mdi-eye'"
@@ -202,6 +207,7 @@
 <script setup lang="ts">
     import { ref, computed, watch, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
@@ -247,6 +253,7 @@
     }>()
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
 
     const formRef = ref<any>(null)

--- a/src/gui-v3/src/components/config/reports/AttributeTable.vue
+++ b/src/gui-v3/src/components/config/reports/AttributeTable.vue
@@ -24,6 +24,7 @@
             />
             <v-text-field
                 v-model="item.title"
+                :spellcheck="spellcheck"
                 :label="t('reports.types.name')"
                 variant="outlined"
                 density="comfortable"
@@ -31,6 +32,7 @@
             />
             <v-text-field
                 v-model="item.description"
+                :spellcheck="spellcheck"
                 :label="t('reports.types.description')"
                 variant="outlined"
                 density="comfortable"
@@ -40,6 +42,7 @@
                 <v-col cols="6">
                     <v-text-field
                         v-model.number="item.min_occurrence"
+                        :spellcheck="false"
                         :label="t('attribute.min_occurrence')"
                         type="number"
                         variant="outlined"
@@ -49,6 +52,7 @@
                 <v-col cols="6">
                     <v-text-field
                         v-model.number="item.max_occurrence"
+                        :spellcheck="false"
                         :label="t('attribute.max_occurrence')"
                         type="number"
                         variant="outlined"
@@ -70,6 +74,7 @@
             <v-textarea
                 v-if="item.ai_provider_id != null"
                 v-model="item.ai_prompt"
+                :spellcheck="spellcheck"
                 :label="t('attribute.ai_prompt')"
                 variant="outlined"
                 density="comfortable"
@@ -83,6 +88,7 @@
 <script setup lang="ts">
     import { computed } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import EditableEntityTable from '@/components/common/EditableEntityTable.vue'
 
     export type AttributeGroupItem = {
@@ -128,6 +134,7 @@
     const items = defineModel<AttributeGroupItem[]>({ required: true })
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
 
     const defaultItem = (): AttributeGroupItem => ({
         id: -1,

--- a/src/gui-v3/src/components/config/reports/NewAttribute.vue
+++ b/src/gui-v3/src/components/config/reports/NewAttribute.vue
@@ -30,6 +30,7 @@
                 >
                     <v-text-field
                         v-model="localItem.name"
+                        :spellcheck="spellcheck"
                         :label="t('reports.attributes.name')"
                         variant="outlined"
                         density="comfortable"
@@ -40,6 +41,7 @@
 
                     <v-textarea
                         v-model="localItem.description"
+                        :spellcheck="spellcheck"
                         :label="t('reports.attributes.description')"
                         variant="outlined"
                         density="comfortable"
@@ -69,6 +71,7 @@
                         >
                             <v-text-field
                                 v-model="localItem.default_value"
+                                :spellcheck="false"
                                 :label="t('reports.attributes.default_value')"
                                 variant="outlined"
                                 density="comfortable"
@@ -94,6 +97,7 @@
                         >
                             <v-text-field
                                 v-model="localItem.validator_parameter"
+                                :spellcheck="false"
                                 :label="t('reports.attributes.validator_parameter')"
                                 variant="outlined"
                                 density="comfortable"
@@ -173,6 +177,7 @@
                         <template #form="{ item }">
                             <v-text-field
                                 v-model="item.value"
+                                :spellcheck="false"
                                 :label="t('reports.attributes.value')"
                                 variant="outlined"
                                 density="comfortable"
@@ -181,6 +186,7 @@
                             />
                             <v-text-field
                                 v-model="item.description"
+                                :spellcheck="spellcheck"
                                 :label="t('reports.attributes.description')"
                                 variant="outlined"
                                 density="comfortable"
@@ -226,6 +232,7 @@
 <script setup lang="ts">
     import { ref, computed, watch } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import { useAuth } from '@/composables/useAuth'
     import {
         createNewAttribute,
@@ -306,6 +313,7 @@
     }>()
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
 
     const formRef = ref<any>(null)

--- a/src/gui-v3/src/components/config/reports/NewReportType.vue
+++ b/src/gui-v3/src/components/config/reports/NewReportType.vue
@@ -30,6 +30,7 @@
                 >
                     <v-text-field
                         v-model="localItem.title"
+                        :spellcheck="spellcheck"
                         :label="t('reports.types.name')"
                         variant="outlined"
                         density="comfortable"
@@ -40,6 +41,7 @@
 
                     <v-textarea
                         v-model="localItem.description"
+                        :spellcheck="spellcheck"
                         :label="t('reports.types.description')"
                         variant="outlined"
                         density="comfortable"
@@ -94,6 +96,7 @@
                         <v-card-text>
                             <v-text-field
                                 v-model="group.title"
+                                :spellcheck="spellcheck"
                                 :label="t('reports.types.name')"
                                 variant="outlined"
                                 density="comfortable"
@@ -102,6 +105,7 @@
                             />
                             <v-textarea
                                 v-model="group.description"
+                                :spellcheck="spellcheck"
                                 :label="t('reports.types.description')"
                                 variant="outlined"
                                 density="comfortable"
@@ -111,6 +115,7 @@
                             />
                             <v-text-field
                                 v-model="group.section_title"
+                                :spellcheck="spellcheck"
                                 :label="t('reports.types.section_title')"
                                 variant="outlined"
                                 density="comfortable"
@@ -164,6 +169,7 @@
 <script setup lang="ts">
     import { ref, computed, watch, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
@@ -232,6 +238,7 @@
     }>()
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
 
     const formRef = ref<any>(null)

--- a/src/gui-v3/src/components/config/word-lists/NewWordList.vue
+++ b/src/gui-v3/src/components/config/word-lists/NewWordList.vue
@@ -32,6 +32,7 @@
                         <v-col cols="12">
                             <v-text-field
                                 v-model="localItem.name"
+                                :spellcheck="spellcheck"
                                 :label="t('word_lists.name')"
                                 variant="outlined"
                                 density="comfortable"
@@ -42,6 +43,7 @@
                         <v-col cols="12">
                             <v-textarea
                                 v-model="localItem.description"
+                                :spellcheck="spellcheck"
                                 :label="t('word_lists.description')"
                                 variant="outlined"
                                 density="comfortable"
@@ -88,6 +90,7 @@
                         <template #form="{ item }">
                             <v-text-field
                                 v-model="item.name"
+                                :spellcheck="spellcheck"
                                 :label="t('word_lists.name')"
                                 variant="outlined"
                                 density="comfortable"
@@ -96,6 +99,7 @@
                             />
                             <v-textarea
                                 v-model="item.description"
+                                :spellcheck="spellcheck"
                                 :label="t('word_lists.description')"
                                 variant="outlined"
                                 density="comfortable"
@@ -104,6 +108,7 @@
                             />
                             <v-text-field
                                 v-model="item.link"
+                                :spellcheck="false"
                                 :label="t('word_lists.link')"
                                 variant="outlined"
                                 density="comfortable"
@@ -129,6 +134,7 @@
                                 <template #form="{ item: word }">
                                     <v-text-field
                                         v-model="word.value"
+                                        :spellcheck="false"
                                         :label="t('word_lists.value')"
                                         variant="outlined"
                                         density="comfortable"
@@ -137,6 +143,7 @@
                                     />
                                     <v-text-field
                                         v-model="word.description"
+                                        :spellcheck="spellcheck"
                                         :label="t('word_lists.description')"
                                         variant="outlined"
                                         density="comfortable"
@@ -179,6 +186,7 @@
 <script setup lang="ts">
     import { ref, computed, watch } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
     import UnsavedChangesDialog from '@/components/common/dialogs/UnsavedChangesDialog.vue'
@@ -240,6 +248,7 @@
     }>()
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
 
     const dialog = ref(false)

--- a/src/gui-v3/src/components/config/word-lists/WordListCsvImport.vue
+++ b/src/gui-v3/src/components/config/word-lists/WordListCsvImport.vue
@@ -69,6 +69,7 @@
                 <v-text-field
                     v-else
                     :model-value="normalizedSourceUrl"
+                    :spellcheck="false"
                     :label="t('word_lists.link')"
                     prepend-inner-icon="mdi-link"
                     variant="outlined"

--- a/src/gui-v3/src/components/config/workflow/StatesTab.vue
+++ b/src/gui-v3/src/components/config/workflow/StatesTab.vue
@@ -110,6 +110,7 @@
                     >
                         <v-text-field
                             v-model="editedItem.display_name"
+                            :spellcheck="spellcheck"
                             :label="t('workflow.states.display_name')"
                             :disabled="!canSave"
                             variant="outlined"
@@ -120,6 +121,7 @@
 
                         <v-textarea
                             v-model="editedItem.description"
+                            :spellcheck="spellcheck"
                             :label="t('workflow.states.description')"
                             :disabled="!canSave"
                             variant="outlined"
@@ -130,6 +132,7 @@
 
                         <v-text-field
                             v-model="editedItem.color"
+                            :spellcheck="false"
                             :label="t('workflow.states.color')"
                             :disabled="!canSave"
                             variant="outlined"
@@ -140,6 +143,7 @@
 
                         <v-text-field
                             v-model="editedItem.icon"
+                            :spellcheck="false"
                             :label="t('workflow.states.icon')"
                             :disabled="!canSave"
                             variant="outlined"
@@ -163,6 +167,7 @@
 <script setup lang="ts">
     import { ref, computed, onMounted, watch } from 'vue'
     import { useI18n } from 'vue-i18n'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import AddNewButton from '@/components/common/buttons/AddNewButton.vue'
     import ActionButton from '@/components/common/buttons/ActionButton.vue'
     import DialogToolbar from '@/components/common/dialogs/DialogToolbar.vue'
@@ -195,6 +200,7 @@
     }
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const configStore = useConfigStore()
     const { checkPermission } = useAuth()
 

--- a/src/gui-v3/src/components/publish/NewProduct.vue
+++ b/src/gui-v3/src/components/publish/NewProduct.vue
@@ -172,6 +172,7 @@
                         >
                             <v-text-field
                                 v-model="product.title"
+                                :spellcheck="spellcheck"
                                 :label="$t('product.title')"
                                 :rules="[requiredRule]"
                                 :disabled="!canModify"
@@ -181,6 +182,7 @@
                         <v-col cols="12">
                             <v-textarea
                                 v-model="product.description"
+                                :spellcheck="spellcheck"
                                 :label="$t('product.description')"
                                 :disabled="!canModify"
                                 rows="3"
@@ -297,6 +299,7 @@
     import { getAllUserProductTypes, getAllUserPublishersPresets } from '@/api/user'
     import { getEntityTypeStates } from '@/api/state'
     import { useAuth } from '@/composables/useAuth'
+    import { useSpellcheck } from '@/composables/useSpellcheck'
     import { navigateReservedTabOrCurrentWindow, openBlankTabWithoutOpener } from '@/utils/window'
     import StateSelector from '@/components/common/StateSelector.vue'
     import ConfirmationDialog from '@/components/common/dialogs/ConfirmationDialog.vue'
@@ -354,6 +357,7 @@
     }
 
     const { t } = useI18n()
+    const spellcheck = useSpellcheck()
     const { checkPermission } = useAuth()
     const authStore = useAuthStore()
 

--- a/src/gui-v3/src/composables/useSpellcheck.ts
+++ b/src/gui-v3/src/composables/useSpellcheck.ts
@@ -1,0 +1,8 @@
+import { computed, type ComputedRef } from 'vue'
+import { useSettingsStore } from '@/stores/settings'
+
+/** Browser spellchecking for natural-language inputs, controlled by the user setting. */
+export function useSpellcheck(): ComputedRef<boolean> {
+    const settingsStore = useSettingsStore()
+    return computed(() => settingsStore.spellcheck)
+}

--- a/src/gui-v3/tests/unit/SpellcheckPreference.spec.ts
+++ b/src/gui-v3/tests/unit/SpellcheckPreference.spec.ts
@@ -1,0 +1,133 @@
+/* eslint-disable vue/one-component-per-file */
+import { computed, defineComponent, h } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSettingsStore } from '@/stores/settings'
+import { useSpellcheck } from '@/composables/useSpellcheck'
+import AssetDialog from '@/components/assets/AssetDialog.vue'
+import CpeEditor from '@/components/assets/CpeEditor.vue'
+import { mountWithPlugins } from '../helpers/mount-helpers'
+
+vi.mock('@/composables/useAuth', () => ({
+    useAuth: () => ({ checkPermission: () => true })
+}))
+
+const VTextField = defineComponent({
+    name: 'VTextField',
+    inheritAttrs: false,
+    props: {
+        modelValue: { type: String, default: '' },
+        label: { type: String, default: '' },
+        spellcheck: Boolean
+    },
+    setup(props) {
+        return () => h('input', { 'data-label': props.label, 'spellcheck': String(props.spellcheck) })
+    }
+})
+
+const VTextarea = defineComponent({
+    name: 'VTextarea',
+    inheritAttrs: false,
+    props: {
+        modelValue: { type: String, default: '' },
+        label: { type: String, default: '' },
+        spellcheck: Boolean
+    },
+    setup(props) {
+        return () => h('textarea', { 'data-label': props.label, 'spellcheck': String(props.spellcheck) })
+    }
+})
+
+const passThrough = { template: '<div><slot /></div>' }
+
+function mountAssetDialog() {
+    return mountWithPlugins(AssetDialog, {
+        props: { modelValue: true, groupId: 'group-1' },
+        global: {
+            stubs: {
+                VDialog: passThrough,
+                VCard: passThrough,
+                VCardText: passThrough,
+                VWindow: passThrough,
+                VWindowItem: passThrough,
+                VForm: passThrough,
+                VTextField,
+                VTextarea,
+                VTabs: true,
+                DialogToolbar: true,
+                CpeEditor: true
+            }
+        }
+    })
+}
+
+describe('spellcheck preference', () => {
+    beforeEach(() => setActivePinia(createPinia()))
+
+    it('is reactive and enabled by default', async () => {
+        const Consumer = defineComponent({
+            setup() {
+                const spellcheck = useSpellcheck()
+                return { enabled: computed(() => String(spellcheck.value)) }
+            },
+            template: '<span>{{ enabled }}</span>'
+        })
+        const wrapper = mount(Consumer)
+        const settingsStore = useSettingsStore()
+
+        expect(wrapper.text()).toBe('true')
+        settingsStore.spellcheck = false
+        await wrapper.vm.$nextTick()
+        expect(wrapper.text()).toBe('false')
+    })
+
+    it('applies the preference to prose while excluding asset identifiers', async () => {
+        const wrapper = mountAssetDialog()
+        const settingsStore = useSettingsStore()
+        settingsStore.spellcheck = false
+        await wrapper.vm.$nextTick()
+
+        const inputs = wrapper.findAll('input')
+        const [name, serial] = inputs
+        const description = wrapper.find('textarea')
+
+        expect(name?.attributes('spellcheck')).toBe('false')
+        expect(description.attributes('spellcheck')).toBe('false')
+        expect(serial?.attributes('spellcheck')).toBe('false')
+
+        settingsStore.spellcheck = true
+        await wrapper.vm.$nextTick()
+        expect(name?.attributes('spellcheck')).toBe('true')
+        expect(description.attributes('spellcheck')).toBe('true')
+        expect(serial?.attributes('spellcheck')).toBe('false')
+    })
+
+    it('keeps CPE codes excluded while applying the preference to their descriptions', () => {
+        const wrapper = mountWithPlugins(CpeEditor, {
+            global: {
+                stubs: {
+                    VCard: passThrough,
+                    VCardTitle: passThrough,
+                    VSpacer: true,
+                    VBtn: true,
+                    VDataTable: true,
+                    VDialog: passThrough,
+                    VCardText: passThrough,
+                    VToolbar: passThrough,
+                    VToolbarTitle: passThrough,
+                    VCombobox: VTextField,
+                    VTextField,
+                    DialogToolbar: true
+                }
+            }
+        })
+        const settingsStore = useSettingsStore()
+        settingsStore.spellcheck = true
+
+        const fields = wrapper.findAll('input[data-label]')
+        expect(fields).toHaveLength(2)
+        expect(fields[0]?.attributes('spellcheck')).toBe('false')
+        expect(fields[1]?.attributes('spellcheck')).toBe('true')
+    })
+})


### PR DESCRIPTION
## Summary

Apply the user’s spellcheck preference consistently across Vue 3 natural-language fields.

## What changed

- Add a shared reactive spellcheck-preference composable.
- Apply the preference to natural-language fields across:
  - Assess manual entry and detail editing
  - Analyze report attributes
  - Publish products
  - Assets and CPE descriptions
  - Access-management dialogs
  - Collectors, presenters, publishers, and bots
  - Data-provider and AI-provider configuration
  - Notifications
  - Remote access and nodes
  - Report, word-list, workflow, and asset configuration
- Update fields reactively when the user changes the preference.
- Keep browser spellchecking disabled for machine-oriented values.

## Deliberate exclusions

Spellcheck is not applied to:

- URLs
- Passwords, credentials, and API keys
- Usernames
- Identifiers, serial numbers, and ZIP codes
- CPE, CVE, CVSS, and CWE codes
- Numeric fields
- Enum, default, validator, and word-list values
- Models and user-agent strings
- Colors and icons
- Dynamic module parameters
- Generic machine settings

Generic report string values use spellcheck unless their current value is an HTTP(S) URL.

## Why

Vue 3 loaded the SPELLCHECK preference but applied it only to a small subset of report fields. Disabling spellcheck therefore had little effect across the rest of the application.

This restores consistent behavior without using global DOM inheritance that could accidentally enable spellchecking on credentials, URLs, codes, or other machine-oriented inputs.

## Validation

- Focused spellcheck and attribute tests: 120 passed
- Full Vue TypeScript check passed
- Scoped ESLint passed with no warnings or errors
- Scoped Prettier check passed
- `git diff --check` passed