### PR TITLE
Extend dashboard tag cloud date filtering

### DIFF
--- a/src/core/api/dashboard.py
+++ b/src/core/api/dashboard.py
@@ -1,5 +1,14 @@
 """Dashboard API."""
 
+from __future__ import annotations
+
+import datetime
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
 from flask import request
 from flask_jwt_extended import jwt_required
 from flask_restful import Resource
@@ -8,24 +17,160 @@ from model.news_item import NewsItemData
 from model.product import Product
 from model.report_item import ReportItem
 from model.tag_cloud import TagCloud
+from shared.common import TZ
+
+LEGACY_TAG_CLOUD_DAY_CAP: Final = 7
+
+# Compatibility contract: existing API consumers use ``tag_cloud_day``. Keep
+# accepting it with its historical look-back and upper-cap semantics even when
+# adding new interval forms. Removing or silently reinterpreting it would break
+# deployed clients that cannot migrate in lockstep with Core.
+LEGACY_DAY_ARGUMENT: Final = "tag_cloud_day"
+RANGE_ARGUMENT: Final = "tag_cloud_range"
+DATE_FROM_ARGUMENT: Final = "tag_cloud_date_from"
+DATE_TO_ARGUMENT: Final = "tag_cloud_date_to"
+
+TAG_CLOUD_QUERY_ARGUMENTS: Final = (
+    LEGACY_DAY_ARGUMENT,
+    RANGE_ARGUMENT,
+    DATE_FROM_ARGUMENT,
+    DATE_TO_ARGUMENT,
+)
+
+
+class TagCloudQueryError(ValueError):
+    """Indicate invalid or conflicting tag-cloud query arguments."""
+
+
+def _single_value(arguments: Mapping[str, Sequence[str]], name: str) -> str | None:
+    """Return one argument value and reject duplicate query parameters."""
+    values = arguments.get(name)
+    if values is None:
+        return None
+    if len(values) != 1:
+        msg = f"Query argument '{name}' must be specified exactly once"
+        raise TagCloudQueryError(msg)
+    if values[0] == "":
+        msg = f"Query argument '{name}' must not be empty"
+        raise TagCloudQueryError(msg)
+    return values[0]
+
+
+def _validate_interval(date_from: datetime.date, date_to: datetime.date) -> tuple[datetime.date, datetime.date]:
+    """Validate the ordering of an inclusive interval."""
+    if date_from > date_to:
+        msg = f"'{DATE_FROM_ARGUMENT}' must not be after '{DATE_TO_ARGUMENT}'"
+        raise TagCloudQueryError(msg)
+    return date_from, date_to
+
+
+def _parse_legacy_day(value: str, today: datetime.date) -> tuple[datetime.date, datetime.date]:
+    """Parse the backward-compatible relative-day argument."""
+    try:
+        number_of_days = int(value)
+    except ValueError as ex:
+        msg = f"'{LEGACY_DAY_ARGUMENT}' must be an integer"
+        raise TagCloudQueryError(msg) from ex
+
+    if number_of_days < 0:
+        msg = f"'{LEGACY_DAY_ARGUMENT}' must not be negative"
+        raise TagCloudQueryError(msg)
+
+    # Preserve the legacy API contract: values above seven are capped, not
+    # rejected. Some existing clients rely on Core applying this bound.
+    number_of_days = min(number_of_days, LEGACY_TAG_CLOUD_DAY_CAP)
+    return today - datetime.timedelta(days=number_of_days), today
+
+
+def _parse_named_range(value: str, today: datetime.date) -> tuple[datetime.date, datetime.date]:
+    """Parse a named range using the vocabulary of other Core list APIs."""
+    if value == "TODAY":
+        return today, today
+    if value == "WEEK":
+        return today - datetime.timedelta(days=today.weekday()), today
+    if value == "MONTH":
+        return today.replace(day=1), today
+    if value == "LAST_7_DAYS":
+        return today - datetime.timedelta(days=7), today
+    if value == "LAST_31_DAYS":
+        return today - datetime.timedelta(days=31), today
+
+    allowed = "TODAY, WEEK, MONTH, LAST_7_DAYS, LAST_31_DAYS"
+    msg = f"Unsupported '{RANGE_ARGUMENT}' value; expected one of: {allowed}"
+    raise TagCloudQueryError(msg)
+
+
+def _parse_explicit_interval(
+    date_from_value: str | None,
+    date_to_value: str | None,
+) -> tuple[datetime.date, datetime.date]:
+    """Parse a complete pair of inclusive ISO calendar dates."""
+    if date_from_value is None or date_to_value is None:
+        msg = f"'{DATE_FROM_ARGUMENT}' and '{DATE_TO_ARGUMENT}' must be specified together"
+        raise TagCloudQueryError(msg)
+
+    try:
+        date_from = datetime.date.fromisoformat(date_from_value)
+        date_to = datetime.date.fromisoformat(date_to_value)
+    except ValueError as ex:
+        msg = f"'{DATE_FROM_ARGUMENT}' and '{DATE_TO_ARGUMENT}' must use YYYY-MM-DD"
+        raise TagCloudQueryError(msg) from ex
+
+    return _validate_interval(date_from, date_to)
+
+
+def parse_tag_cloud_interval(
+    arguments: Mapping[str, Sequence[str]],
+    today: datetime.date,
+) -> tuple[datetime.date, datetime.date]:
+    """Resolve one mutually exclusive tag-cloud interval mode.
+
+    Supported modes are the legacy relative ``tag_cloud_day`` argument, one
+    named ``tag_cloud_range``, or the explicit ``tag_cloud_date_from`` and
+    ``tag_cloud_date_to`` pair. With no arguments, the historical today-only
+    behavior is retained.
+    """
+    legacy_day = _single_value(arguments, LEGACY_DAY_ARGUMENT)
+    named_range = _single_value(arguments, RANGE_ARGUMENT)
+    date_from = _single_value(arguments, DATE_FROM_ARGUMENT)
+    date_to = _single_value(arguments, DATE_TO_ARGUMENT)
+
+    explicit_interval_requested = date_from is not None or date_to is not None
+    selected_mode_count = sum((legacy_day is not None, named_range is not None, explicit_interval_requested))
+    if selected_mode_count > 1:
+        msg = "Use only one tag-cloud interval mode: day, range, or date_from/date_to"
+        raise TagCloudQueryError(msg)
+
+    if legacy_day is not None:
+        return _parse_legacy_day(legacy_day, today)
+    if named_range is not None:
+        return _parse_named_range(named_range, today)
+    if explicit_interval_requested:
+        return _parse_explicit_interval(date_from, date_to)
+
+    return today, today
 
 
 class Dashboard(Resource):
     """Dashboard API class."""
 
     @jwt_required()
-    def get(self) -> dict:
+    def get(self) -> dict | tuple[dict, HTTPStatus]:
         """Get the dashboard data.
+
+        The tag cloud accepts one interval mode at a time: the legacy
+        ``tag_cloud_day`` look-back, a named ``tag_cloud_range``, or an
+        inclusive ``tag_cloud_date_from``/``tag_cloud_date_to`` ISO date pair.
 
         Returns:
             (dict): The dashboard data.
         """
         try:
-            number_of_days = min(int(request.args.get("tag_cloud_day", 0)), 7)
-        except Exception as ex:
-            msg = "Get Dashboard failed"
-            logger.exception(f"{msg}: {ex}")
-            return {"error": msg}, 400
+            tag_cloud_arguments = {name: request.args.getlist(name) for name in TAG_CLOUD_QUERY_ARGUMENTS if name in request.args}
+            date_from, date_to = parse_tag_cloud_interval(tag_cloud_arguments, datetime.datetime.now(TZ).date())
+        except TagCloudQueryError as ex:
+            logger.warning(f"Invalid dashboard tag-cloud interval: {ex}")
+            return {"error": str(ex)}, HTTPStatus.BAD_REQUEST
 
         total_news_items = NewsItemData.count_all()
         # counts for report items
@@ -38,7 +183,7 @@ class Dashboard(Resource):
         total_database_items = total_news_items + total_products + total_report_items
         latest_collected = NewsItemData.latest_collected()
         news_items_by_day = NewsItemData.count_collected_by_day(7)
-        grouped_words = TagCloud.get_grouped_words(number_of_days)
+        grouped_words = TagCloud.get_grouped_words_between(date_from, date_to)
 
         return {
             "total_news_items": total_news_items,

--- a/src/core/model/tag_cloud.py
+++ b/src/core/model/tag_cloud.py
@@ -72,16 +72,28 @@ class TagCloud(db.Model):
 
     @classmethod
     def get_grouped_words(cls, number_of_days: int) -> list[dict]:
-        """Retrieve grouped words from the tag cloud for a specific day.
+        """Retrieve grouped words using the legacy relative-day interval.
 
         :param number_of_days: The number of days ago to filter the tag cloud.
         :return: List of grouped words with their quantities.
         """
-        day_filter = (datetime.datetime.now(TZ) - datetime.timedelta(days=number_of_days)).date()
+        date_to = datetime.datetime.now(TZ).date()
+        date_from = date_to - datetime.timedelta(days=number_of_days)
+        return cls.get_grouped_words_between(date_from, date_to)
+
+    @classmethod
+    def get_grouped_words_between(cls, date_from: datetime.date, date_to: datetime.date) -> list[dict]:
+        """Retrieve grouped words collected in an inclusive date interval.
+
+        :param date_from: First collection date to include.
+        :param date_to: Last collection date to include.
+        :return: List of grouped words with their quantities.
+        """
         stopwords = WordListEntry.stopwords_subquery()
         grouped_words = (
             db.session.query(TagCloud.word, label("word_quantity", func.sum(TagCloud.word_quantity)))
-            .filter(TagCloud.collected >= day_filter)
+            .filter(TagCloud.collected >= date_from)
+            .filter(TagCloud.collected <= date_to)
             .filter(func.lower(TagCloud.word).notin_(stopwords))
             .group_by(TagCloud.word)
             .order_by(db.desc("word_quantity"))

--- a/src/core/tests/__init__.py
+++ b/src/core/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Core service tests."""

--- a/src/core/tests/test_tag_cloud_query.py
+++ b/src/core/tests/test_tag_cloud_query.py
@@ -1,0 +1,83 @@
+"""Tests for dashboard tag-cloud query parsing."""
+
+# Assertions are the native test contract in this module.
+# ruff: noqa: S101
+
+from datetime import date
+from unittest import TestCase
+
+from api.dashboard import TagCloudQueryError, parse_tag_cloud_interval
+
+
+class ParseTagCloudIntervalTest(TestCase):
+    """Verify supported interval modes and invalid combinations."""
+
+    today = date(2026, 8, 6)
+
+    def test_defaults_to_today(self) -> None:
+        """An empty query retains the historical today-only behavior."""
+        assert parse_tag_cloud_interval({}, self.today) == (self.today, self.today)
+
+    def test_legacy_day_is_inclusive(self) -> None:
+        """The legacy relative day selects its cutoff through today."""
+        assert parse_tag_cloud_interval({"tag_cloud_day": ["2"]}, self.today) == (date(2026, 8, 4), self.today)
+
+    def test_legacy_day_preserves_upper_cap(self) -> None:
+        """Legacy values greater than seven continue to be capped."""
+        assert parse_tag_cloud_interval({"tag_cloud_day": ["99"]}, self.today) == (date(2026, 7, 30), self.today)
+
+    def test_named_ranges(self) -> None:
+        """Named ranges follow established Core range vocabulary."""
+        expected = {
+            "TODAY": (self.today, self.today),
+            "WEEK": (date(2026, 8, 3), self.today),
+            "MONTH": (date(2026, 8, 1), self.today),
+            "LAST_7_DAYS": (date(2026, 7, 30), self.today),
+            "LAST_31_DAYS": (date(2026, 7, 6), self.today),
+        }
+        for value, interval in expected.items():
+            with self.subTest(value=value):
+                assert parse_tag_cloud_interval({"tag_cloud_range": [value]}, self.today) == interval
+
+    def test_explicit_interval_is_inclusive(self) -> None:
+        """A valid ISO date pair is returned unchanged without a span cap."""
+        arguments = {
+            "tag_cloud_date_from": ["2026-06-01"],
+            "tag_cloud_date_to": ["2026-08-05"],
+        }
+        assert parse_tag_cloud_interval(arguments, self.today) == (date(2026, 6, 1), date(2026, 8, 5))
+
+    def test_conflicting_modes_are_rejected(self) -> None:
+        """Day, named range, and explicit interval modes cannot be mixed."""
+        conflicting_queries = (
+            {"tag_cloud_day": ["7"], "tag_cloud_range": ["TODAY"]},
+            {"tag_cloud_day": ["7"], "tag_cloud_date_from": ["2026-08-04"], "tag_cloud_date_to": ["2026-08-05"]},
+            {"tag_cloud_range": ["TODAY"], "tag_cloud_date_from": ["2026-08-04"], "tag_cloud_date_to": ["2026-08-05"]},
+        )
+        for arguments in conflicting_queries:
+            with self.subTest(arguments=arguments):
+                self._assert_invalid(arguments)
+
+    def test_invalid_arguments_are_rejected(self) -> None:
+        """Reject incomplete, malformed, reversed, and duplicate values."""
+        invalid_queries = (
+            {"tag_cloud_day": ["-1"]},
+            {"tag_cloud_day": ["invalid"]},
+            {"tag_cloud_range": ["DATE"]},
+            {"tag_cloud_date_from": ["2026-08-04"]},
+            {"tag_cloud_date_from": ["2026-08-05"], "tag_cloud_date_to": ["2026-08-04"]},
+            {"tag_cloud_date_from": ["not-a-date"], "tag_cloud_date_to": ["2026-08-06"]},
+            {"tag_cloud_range": ["TODAY", "WEEK"]},
+        )
+        for arguments in invalid_queries:
+            with self.subTest(arguments=arguments):
+                self._assert_invalid(arguments)
+
+    def _assert_invalid(self, arguments: dict[str, list[str]]) -> None:
+        """Assert that parsing fails without requiring a pytest dependency."""
+        try:
+            parse_tag_cloud_interval(arguments, self.today)
+        except TagCloudQueryError:
+            return
+        msg = f"Expected TagCloudQueryError for {arguments!r}"
+        raise AssertionError(msg)


### PR DESCRIPTION
### Title

Extend dashboard tag-cloud API with date-range filtering

### Description

This change extends `/api/v1/dashboard-data` with additional ways to select the tag-cloud interval.

Supported modes are mutually exclusive:

- Legacy relative lookback:
  `tag_cloud_day=7`
- Named range:
  `tag_cloud_range=TODAY|WEEK|MONTH|LAST_7_DAYS|LAST_31_DAYS`
- Explicit inclusive interval:
  `tag_cloud_date_from=YYYY-MM-DD&tag_cloud_date_to=YYYY-MM-DD`

### Backward compatibility

`tag_cloud_day` remains supported with its existing behavior, including capping values above seven to seven. The compatibility requirement is documented directly in the code.

Requests using conflicting modes now return HTTP 400. The API also rejects:

- Negative or non-numeric legacy values
- Unsupported named ranges
- Missing date bounds
- Malformed ISO dates
- Reversed intervals
- Empty or duplicate parameters

Explicit date intervals are not restricted by the current seven-day retention period, allowing the retention policy to be increased independently.

### Internal changes

- Added inclusive lower and upper date filtering to the tag-cloud database query.
- Kept request parsing and validation alongside the dashboard endpoint.
- Preserved the existing response schema.
- No GUI changes.

### Testing

- Added focused Core tests covering legacy behavior, named ranges, explicit intervals, conflicting modes, and invalid input.
- All 7 tests pass.
- Ruff lint and formatting checks pass.
- Python compilation and `git diff --check` pass.