### PR TITLE
Fix lost selection color on card

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
 [dependency-groups]
 dev = [
     "djlint==1.43.1",
-    "ruff==0.16.0",
+    "ruff==0.16.1",
 ]
 
 [tool.uv]
@@ -63,7 +63,7 @@ required-version = "0.11.19"
 members = ["src/shared"]
 
 [tool.ruff]
-required-version = "0.16.0"
+required-version = "0.16.1"
 line-length = 142
 target-version = "py313"
 fix = true

--- a/src/gui-v3/src/components/analyze/CardAnalyze.vue
+++ b/src/gui-v3/src/components/analyze/CardAnalyze.vue
@@ -5,7 +5,6 @@
             :show-selection-checkbox="!isRemote"
             :preselected="preselected"
             card-class="review-list__row"
-            :card-color="selectedColor"
             :card-id="card.id"
             @card-click="cardItemClick"
             @selection-change="selectionChanged"
@@ -202,10 +201,6 @@
 
     const multiSelectActive = computed(() => {
         return analyzeStore.getMultiSelectReport
-    })
-
-    const selectedColor = computed(() => {
-        return analyzeStore.selectedReports.has(props.card.id) ? 'orange-lighten-4' : ''
     })
 
     const itemStatus = computed(() => {

--- a/src/gui-v3/src/components/assess/CardAssess.vue
+++ b/src/gui-v3/src/components/assess/CardAssess.vue
@@ -4,7 +4,6 @@
             :multi-select-active="multiSelectActive"
             :show-selection-checkbox="true"
             :preselected="preselected"
-            :card-color="selectedColor"
             card-class="review-list__row"
             :class="{ 'read-item': card.read }"
             :card-id="card.id"
@@ -277,9 +276,6 @@
     const highlightWords = computed(() => collectHighlightWords(settingsStore.getProfileWordLists))
 
     const multiSelectActive = computed(() => assessStore.getMultiSelect)
-    const selectedColor = computed(() => {
-        return assessStore.selectedItems.has(props.card.id) ? 'orange-lighten-4' : ''
-    })
 
     const hasComments = computed(() => {
         if (!props.card.comments) return false

--- a/src/gui-v3/src/components/common/BaseCard.vue
+++ b/src/gui-v3/src/components/common/BaseCard.vue
@@ -22,9 +22,8 @@
             <v-card
                 v-bind="hoverProps"
                 class="base-card card-item mb-1 flex-grow-1"
-                :class="cardClass"
+                :class="[cardClass, { 'selected-item': internalSelected }]"
                 :elevation="0"
-                :color="cardColor"
                 tabindex="0"
                 :data-id="cardId"
                 @click="handleCardClick"
@@ -79,10 +78,6 @@
         cardClass: {
             type: [String, Object],
             default: ''
-        },
-        cardColor: {
-            type: String,
-            default: undefined
         }
     })
 
@@ -183,6 +178,25 @@
         box-shadow: none !important;
     }
 
+    /* Selected state overrides default background with same specificity */
+    .review-list__row.selected-item {
+        background: var(--review-list-row-selected) !important;
+    }
+
+    .review-list__row::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: rgba(var(--v-theme-primary), 0);
+        transition: background 0.18s ease;
+        pointer-events: none;
+    }
+
+    .review-list__row:hover::before,
+    .review-list__row:focus-visible::before {
+        background: rgba(var(--v-theme-primary), 0.05);
+    }
+
     .review-list__row::after {
         position: absolute;
         z-index: 1;
@@ -196,11 +210,6 @@
     .review-list__row:hover::after,
     .review-list__row:focus-visible::after {
         border-color: rgba(var(--v-theme-primary), 0.52);
-    }
-
-    .review-list__row:hover,
-    .review-list__row:focus-visible {
-        background: var(--review-list-row-hover) !important;
     }
 
     .assess-list > :first-child .review-list__row,

--- a/src/gui-v3/src/components/publish/CardProduct.vue
+++ b/src/gui-v3/src/components/publish/CardProduct.vue
@@ -5,7 +5,6 @@
             :show-selection-checkbox="true"
             :preselected="preselected"
             card-class="review-list__row"
-            :card-color="selectedColor"
             :card-id="card.id"
             @card-click="cardItemClick"
             @selection-change="selectionChanged"
@@ -149,10 +148,6 @@
     const showDeleteDialog = ref<boolean>(false)
 
     const multiSelectActive = computed(() => publishStore.getMultiSelect)
-
-    const selectedColor = computed(() => {
-        return publishStore.selectedProducts.has(props.card.id) ? 'orange-lighten-4' : ''
-    })
 
     const canDelete = computed(() => {
         // Check permission - modify check may not be needed or property may be named differently

--- a/src/gui-v3/src/styles/colors.css
+++ b/src/gui-v3/src/styles/colors.css
@@ -88,7 +88,7 @@ html.light-mode {
     --color-drawer-divider: var(--color-light-drawer-divider);
     --review-workspace: #d7e1e9;
     --review-list-row: #ffffff;
-    --review-list-row-hover: #edf6fc;
+    --review-list-row-selected: #fff3cd;
     --review-list-border: rgba(52, 82, 104, 0.34);
     --review-panel-border: rgba(52, 82, 104, 0.58);
     --filter-controls-bg: #d8e3eb;
@@ -103,7 +103,7 @@ html.dark-mode {
     --color-drawer-divider: var(--color-dark-drawer-divider);
     --review-workspace: #07141e;
     --review-list-row: #132838;
-    --review-list-row-hover: #19364b;
+    --review-list-row-selected: rgba(var(--v-theme-primary), 0.22);
     --review-list-border: rgba(126, 169, 198, 0.38);
     --review-panel-border: rgba(126, 169, 198, 0.58);
     --filter-controls-bg: #0a1b28;


### PR DESCRIPTION
- fix lost selection color by latest changes
- no need send card-color for selected card (this can be done automatically inside BaseCard)
- fixed hover color (it's dynamically based on background color, not fixed color, works together with selected items color and other colors on background)
- ruff 0.16.0 -> 0.16.1