### PR TITLE
Remove overlap when aggregate card is oppened + Test fix

### DIFF
--- a/src/gui-v3/src/components/assess/CardAssess.vue
+++ b/src/gui-v3/src/components/assess/CardAssess.vue
@@ -189,10 +189,7 @@
             @after-enter="emitCardItemsReindex"
             @after-leave="emitCardItemsReindex"
         >
-            <div
-                v-if="opened && isAggregate"
-                class="aggregate-items-list"
-            >
+            <div v-if="opened && isAggregate">
                 <CardAssessItem
                     v-for="newsItem in childNewsItems"
                     :key="newsItem.id"
@@ -434,10 +431,6 @@
 <style scoped>
     .aggregate-card-wrapper {
         width: 100%;
-    }
-
-    .aggregate-items-list {
-        margin-top: -4px;
     }
 
     .read-item {

--- a/src/gui-v3/src/components/common/BaseCard.vue
+++ b/src/gui-v3/src/components/common/BaseCard.vue
@@ -22,7 +22,7 @@
         <v-hover v-slot="{ isHovering, props: hoverProps }">
             <v-card
                 v-bind="hoverProps"
-                class="base-card card-item mb-1 flex-grow-1"
+                class="base-card card-item flex-grow-1"
                 :class="[cardClass, { 'selected-item': internalSelected }]"
                 :elevation="0"
                 tabindex="0"

--- a/src/gui-v3/tests/helpers/mount-helpers.js
+++ b/src/gui-v3/tests/helpers/mount-helpers.js
@@ -45,9 +45,9 @@ export function createTestI18n() {
 export function mountWithPlugins(component, options = {}) {
     const pinia = createPinia()
     setActivePinia(pinia)
-    const i18n = createTestI18n()
 
     const globalOptions = options.global || {}
+    const i18n = globalOptions.i18n ?? createTestI18n()
     const existingPlugins = globalOptions.plugins || []
 
     return mount(component, {

--- a/src/gui-v3/tests/unit/ContentDataAssessReload.spec.js
+++ b/src/gui-v3/tests/unit/ContentDataAssessReload.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import { mountWithPlugins } from '../helpers/mount-helpers'
@@ -77,7 +77,10 @@ const commonStubs = {
 const mountAssess = (i18n) =>
     mountWithPlugins(ContentDataAssess, {
         props: { analyze_selector: false },
-        global: { stubs: commonStubs, plugins: i18n ? [i18n] : [] }
+        global: {
+            i18n,
+            stubs: commonStubs
+        }
     })
 
 const createPluralTestI18n = () =>
@@ -88,6 +91,7 @@ const createPluralTestI18n = () =>
         messages: {
             'de-DE': {
                 assess: {
+                    no_items: 'Keine Elemente',
                     show_new_items: 'Keine neuen Elemente | {count} neues Element | {count} neue Elemente'
                 },
                 common: {
@@ -144,6 +148,10 @@ describe('ContentDataAssess list reloads', () => {
                 }
             })
         )
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
     })
 
     it('leaves the rendered cards in the same order across a refresh', async () => {


### PR DESCRIPTION
- remove overlap when aggregate card is opened (aggregate vs item card)
- make same gap between item cards as used in aggregates
- fixed test: pluralizes and locale-formats the held-back item count without changing the banner interaction