### PR TITLE
Use major version tag for node Docker image base

### DIFF
--- a/docker/Dockerfile.gui
+++ b/docker/Dockerfile.gui
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # metadata stage
-FROM node:lts-alpine AS metadata-stage
+FROM node:26-alpine AS metadata-stage
 
 RUN apk add --no-cache git
 
@@ -14,7 +14,7 @@ RUN --mount=type=bind,source=.git,target=/app/.git \
     node git-info.js
 
 # build stage
-FROM node:lts-alpine AS build-stage
+FROM node:26-alpine AS build-stage
 
 WORKDIR /app
 COPY ./src/gui/package.json ./src/gui/package-lock.json ./

--- a/docker/Dockerfile.gui-v3
+++ b/docker/Dockerfile.gui-v3
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # metadata stage
-FROM node:lts-alpine AS metadata-stage
+FROM node:26-alpine AS metadata-stage
 
 RUN apk add --no-cache git
 
@@ -16,7 +16,7 @@ RUN --mount=type=bind,source=.git,target=/app/.git \
     node scripts/update-version.cjs
 
 # build stage
-FROM node:lts-alpine AS build-stage
+FROM node:26-alpine AS build-stage
 
 WORKDIR /app
 COPY ./src/gui-v3/package.json ./src/gui-v3/package-lock.json ./


### PR DESCRIPTION
Stale `node:lts-alpine` images cannot build the GUI Docker images. Pinning at least the major version would force Docker image pull when super stale/old version is present locally.

```
 > [gui-v3 build-stage 13/13] RUN npm --ignore-scripts run build:
4.603
4.603 > taranis-ng-gui-v3@26.05.1 build
4.603 > vite build
4.603
4.808 You are using Node.js 18.18.0. Vite requires Node.js version 20.19+ or 22.12+. Please upgrade your Node.js version.
4.815 file:///app/node_modules/vite/dist/node/cli.js:533
4.815                           this.dispatchEvent(new CustomEvent(`command:${commandName}`, { detail: command }));
4.815                                                  ^
4.815
4.815 ReferenceError: CustomEvent is not defined
4.815     at CAC.parse (file:///app/node_modules/vite/dist/node/cli.js:533:28)
4.815     at file:///app/node_modules/vite/dist/node/cli.js:834:5
4.815     at ModuleJob.run (node:internal/modules/esm/module_job:194:25)
4.815
4.815 Node.js v18.18.0
```