### PR TITLE
Fix presenter error: time data '2026-XX-XX' does not match format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,15 +48,15 @@ repos:
       # SKIPS when its tooling is absent (CI adds --require to make that fatal instead).
       - id: ansible-tests
         name: Ansible syntax check and lint
-        entry: python3 scripts/run_tests.py --suite ansible
-        language: system
+        entry: scripts/run_tests.py --suite ansible
+        language: python
         pass_filenames: false
         files: ^(ansible/.*\.(yml|yaml|j2)|scripts/check_ansible_syntax\.py)$
         always_run: false
       - id: python-tests
         name: Python unit tests (pytest)
-        entry: python3 scripts/run_tests.py --suite pytest
-        language: system
+        entry: scripts/run_tests.py --suite pytest
+        language: python
         pass_filenames: false
         files: ^src/(core|shared|bots|collectors|presenters|publishers)/.*\.py$
         always_run: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
 [dependency-groups]
 dev = [
     "djlint==1.44.2",
-    "ruff==0.16.2",
+    "ruff==0.16.3",
     # Keep in lockstep with [tool.uv] required-version below. Declared here so
     # `uv sync` reinstalls it into .venv instead of pruning it — an undeclared
     # .venv/bin/uv gets removed by the first sync, after which no uv on the
@@ -101,7 +101,7 @@ testpaths = ["src/core/tests", "src/shared/tests"]
 pythonpath = ["src/core", "src/shared"]
 
 [tool.ruff]
-required-version = "0.16.2"
+required-version = "0.16.3"
 line-length = 142
 target-version = "py313"
 fix = true

--- a/src/presenters/presenters/jinja_filters.py
+++ b/src/presenters/presenters/jinja_filters.py
@@ -18,12 +18,20 @@ def filter_strfdate(date: str, fmtin: str | None = None, fmtout: str | None = No
         str: The converted date string.
 
     """
-    if date == "":
+    if not date:
         return ""
-    if not fmtin:
-        fmtin = "%Y.%m.%d"
-    date = datetime.datetime.strptime(date, fmtin).replace(tzinfo=TZ)
-    native = date
+
+    formats = [fmtin] if fmtin else ["%Y-%m-%d", "%Y.%m.%d"]
+    for fmt in formats:
+        try:
+            native = datetime.datetime.strptime(date, fmt).replace(tzinfo=TZ)
+            break
+        except ValueError:
+            continue
+    else:
+        msg = f"Unsupported date format: {date!r}. Expected one of: {', '.join(formats)}"
+        raise ValueError(msg)
+
     if not fmtout:
         fmtout = "%-d.%-m.%Y"
     return native.strftime(fmtout)
@@ -56,7 +64,7 @@ def filter_truncate_on_symbol(text: str, symbol: str) -> str:
 
     """
     if symbol in text:
-        return text.split(symbol)[0]
+        return text.split(symbol, maxsplit=1)[0]
     return text
 
 


### PR DESCRIPTION
- Fix presenter error: time data '2026-XX-XX' does not match format '%Y.%m.%d'
Error appear in templates where was used  strfdate function like: {{ rpt.attrs.exposure_date | strfdate | e }}
- ruff version 0.16.3
- fix Python unit tests on windows (Python was not found)