### PR TITLE
fix(core): redact secrets from activity logs on every path

### DIFF
--- a/src/core/auth/password_authenticator.py
+++ b/src/core/auth/password_authenticator.py
@@ -53,8 +53,9 @@ class PasswordAuthenticator(BaseAuthenticator):
         user = PasswordAuthenticator.verify(credentials)
 
         if not user:
-            data = request.get_json()
-            data["password"] = log_manager.sensitive_value(data["password"])
+            data = request.get_json(silent=True) or {}
+            if "password" in data:
+                data["password"] = log_manager.sensitive_value(data["password"])
             log_manager.store_auth_error_activity(f"Authentication failed for user: {credentials['username']}", request_data=data)
             time.sleep(random.uniform(1, 3))  # noqa: S311 - timing jitter, not cryptographic
             return BaseAuthenticator.generate_error()

--- a/src/core/managers/auth_manager.py
+++ b/src/core/managers/auth_manager.py
@@ -1113,8 +1113,15 @@ def auth_required(required_permissions: str | list, *acl_args: ACLCheck) -> Call
                 log_manager.store_user_auth_error_activity(user, f"Access denied by ACL for user: {user.username}")
                 return error
 
-            # allow
-            log_manager.store_user_activity(user, str(required_permissions_set), str(request.get_json(force=True, silent=True)))
+            # allow - pass the parsed body through request_data so
+            # generate_escaped_data redacts known-sensitive keys (passwords,
+            # tokens, api keys) before it reaches the activity log.
+            log_manager.store_user_activity(
+                user,
+                str(required_permissions_set),
+                "",
+                request_data=request.get_json(force=True, silent=True),
+            )
             return fn(*args, **kwargs)
 
         return wrapper

--- a/src/core/managers/log_manager.py
+++ b/src/core/managers/log_manager.py
@@ -142,11 +142,20 @@ def generate_escaped_data(request_data: dict) -> str:
         return ""
 
     data = request_data
-    data = _redact_sensitive_body(data.decode("utf-8", errors="replace")) if isinstance(data, (bytes, bytearray)) else str(data)
+    if isinstance(data, (dict, list)):
+        # Callers holding a parsed body (e.g. the API authorization wrapper)
+        # pass it verbatim - redact it the same way as a raw JSON body so no
+        # path dodges the masking.
+        data = json.dumps(_redact_dict(data), ensure_ascii=False)
+    elif isinstance(data, (bytes, bytearray)):
+        data = _redact_sensitive_body(data.decode("utf-8", errors="replace"))
+    else:
+        data = str(data)
 
     data = data[:4096]
-    data = re.sub(r"\s+", " ", data)
-    return re.sub(r"(^\s+)|(\s+$)", "", data)
+    # str.strip() rather than a trimming regex: `(^\s+)|(\s+$)` backtracks
+    # quadratically on a long run of whitespace (CodeQL py/polynomial-redos).
+    return re.sub(r"\s+", " ", data).strip()
 
 
 # Keys whose values are redacted from logged request bodies. Lower-cased for
@@ -285,7 +294,9 @@ def store_data_error_activity(user: User, activity_detail: str, exception: Excep
         request_data (dict, optional): The data associated with the request.
     """
     if exception:
-        logger.exception(f"{activity_detail}: {exception}")
+        # .error, not .exception: `exception` is a parameter here, not a caught
+        # exception, so .exception() would append a bogus "NoneType: None" traceback.
+        logger.error(f"{activity_detail}: {exception}")
     db.session.rollback()
     ip = resolve_ip_address()
     log_text = (
@@ -310,7 +321,9 @@ def store_data_error_activity_no_user(activity_detail: str, exception: Exception
         request_data (dict, optional): The data associated with the request.
     """
     if exception:
-        logger.exception(f"{activity_detail}: {exception}")
+        # .error, not .exception: `exception` is a parameter here, not a caught
+        # exception, so .exception() would append a bogus "NoneType: None" traceback.
+        logger.error(f"{activity_detail}: {exception}")
     db.session.rollback()
     ip = resolve_ip_address()
     log_text = (
@@ -341,7 +354,9 @@ def store_auth_error_activity(activity_detail: str, exception: Exception | None 
         request_data (dict, optional): The data associated with the request.
     """
     if exception:
-        logger.exception(f"{activity_detail}: {exception}")
+        # .error, not .exception: `exception` is a parameter here, not a caught
+        # exception, so .exception() would append a bogus "NoneType: None" traceback.
+        logger.error(f"{activity_detail}: {exception}")
     db.session.rollback()
     log_text = (
         f"TARANIS NG Auth Error (Method: {resolve_method()}, Resource: {resolve_resource()}, Activity Detail: {activity_detail}, "
@@ -371,7 +386,9 @@ def store_auth_warning_activity(activity_detail: str, exception: Exception | Non
         request_data (dict, optional): The data associated with the request.
     """
     if exception:
-        logger.exception(f"{activity_detail}: {exception}")
+        # .error, not .exception: `exception` is a parameter here, not a caught
+        # exception, so .exception() would append a bogus "NoneType: None" traceback.
+        logger.error(f"{activity_detail}: {exception}")
     db.session.rollback()
     log_text = (
         f"TARANIS NG Auth Warning (Method: {resolve_method()}, Resource: {resolve_resource()}, Activity Detail: {activity_detail}, "

--- a/src/core/tests/test_log_redaction.py
+++ b/src/core/tests/test_log_redaction.py
@@ -1,0 +1,70 @@
+"""Redaction of request bodies that reach the activity log.
+
+Two shapes of body must be redacted the same way: the raw bytes fallback used
+by the auth error path, and the parsed dict that the API authorization wrapper
+passes for every successful call. The parsed-dict path is what previously
+dodged the masking entirely.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from flask import Flask
+from managers.log_manager import _SENSITIVE_JSON_KEYS, generate_escaped_data, sensitive_value
+
+
+@pytest.fixture
+def log_app() -> Flask:
+    """Bare Flask app providing the request context generate_escaped_data reads."""
+    return Flask(__name__)
+
+
+def _login_body() -> bytes:
+    return json.dumps({"username": "jarsvoboda", "password": "HERE IS THE PASSWORD", "provider_id": 5}).encode()
+
+
+def test_parsed_dict_body_is_redacted(log_app: Flask) -> None:
+    # the API wrapper passes the body parsed by Flask, not raw bytes
+    body = {"username": "jarsvoboda", "password": "HERE IS THE PASSWORD", "provider_id": 5}
+    with log_app.test_request_context("/api/v1/auth/login", data=_login_body()):
+        logged = generate_escaped_data(body)
+    assert "HERE IS THE PASSWORD" not in logged
+    assert sensitive_value("x") in logged  # the mask actually replaced it
+    assert "jarsvoboda" in logged  # non-sensitive fields survive
+
+
+def test_raw_bytes_body_is_redacted(log_app: Flask) -> None:
+    with log_app.test_request_context("/api/v1/auth/login", data=_login_body()):
+        logged = generate_escaped_data(None)
+    assert "HERE IS THE PASSWORD" not in logged
+    assert "jarsvoboda" in logged
+
+
+def test_nested_secrets_inside_lists_are_redacted(log_app: Flask) -> None:
+    body = [{"api_key": "k-123", "name": "node"}]
+    with log_app.test_request_context("/", data=json.dumps(body).encode()):
+        logged = generate_escaped_data(body)
+    assert "k-123" not in logged
+    assert "node" in logged
+
+
+def test_non_json_payloads_pass_through(log_app: Flask) -> None:
+    raw = b"not a json payload"
+    with log_app.test_request_context("/", data=raw):
+        assert generate_escaped_data(None) == "not a json payload"
+
+
+def test_sensitive_value_masking_modes(monkeypatch: pytest.MonkeyPatch) -> None:
+    # default mode masks; the operator opt-in modes must keep working
+    assert sensitive_value("secret") == "•••••"
+    monkeypatch.setenv("LOG_SENSITIVE_DATA", "yes")
+    assert sensitive_value("secret") == "secret"
+    monkeypatch.setenv("LOG_SENSITIVE_DATA", "no")
+    assert sensitive_value("secret") == "•••••"
+
+
+def test_sensitive_key_coverage() -> None:
+    for key in ("password", "token", "api_key", "client_secret", "access_token", "totp", "otp", "mfa_token", "credentials"):
+        assert key in _SENSITIVE_JSON_KEYS, f"{key} missing from the redaction set"


### PR DESCRIPTION
**Why**

auth_required guards nearly every API route, and it passed the request body to the activity log as a pre-stringified dict — opaque to the redaction logic, which only handled raw bytes. Creating a user, updating an auth provider or setting an API key wrote the cleartext secret into the activity_data column on every successful call, not just on errors. Those records go to the database and to syslog.

**What changed**

- Redaction moved into the chokepoint (generate_escaped_data) so no caller can bypass it — dict/list bodies now run through the existing _redact_dict; bytes keep the previous path.
- auth_required passes the parsed body as request_data instead of stringifying it.
- PasswordAuthenticator.authenticate error branch hardened with get_json(silent=True) and a key-presence check.
- Same function: trailing-whitespace regex → str.strip(). (^\s+)|(\s+$) backtracks quadratically (CodeQL py/polynomial-redos).
- Four logger.exception() → logger.error(). They sit outside any except block, so they appended a bogus NoneType: None traceback. Pre-existing, but ruff blocks any commit touching this file until they're resolved.

Tests — 6 new cases in test_log_redaction.py: dict, raw-bytes and nested/list bodies, non-JSON passthrough, masking modes, sensitive-key coverage.