### PR TITLE
feat(core): throttle failed logins per username

### DIFF
--- a/src/core/managers/auth_manager.py
+++ b/src/core/managers/auth_manager.py
@@ -34,7 +34,7 @@ from config import Config
 from flask import request
 from flask_jwt_extended import JWTManager, get_jwt, get_jwt_identity, verify_jwt_in_request
 from flask_jwt_extended.exceptions import JWTExtendedException
-from managers import log_manager, totp_manager, webauthn_manager
+from managers import log_manager, login_throttle, totp_manager, webauthn_manager
 from managers.db_manager import db
 from model.apikey import ApiKey
 from model.auth_provider import FORM_KINDS, OAUTH_KINDS, AuthProvider, UserAuthIdentity
@@ -582,6 +582,12 @@ def authenticate_with_provider(provider_id: object, credentials: dict) -> tuple[
     if not username or not password:
         return BaseAuthenticator.generate_error()
 
+    # Brute-force gate: a username with too many recent failures is refused
+    # before any credential check runs (works across all gunicorn workers
+    # through Redis). Anonymous POST /auth/login keeps rendering the page.
+    if not login_throttle.check_lock(username):
+        return BaseAuthenticator.generate_error()
+
     if provider_id:
         try:
             provider = AuthProvider.find(int(provider_id))
@@ -595,12 +601,15 @@ def authenticate_with_provider(provider_id: object, credentials: dict) -> tuple[
         if provider.kind == "local":
             user = PasswordAuthenticator.verify(credentials)
             if user:
+                login_throttle.register_success(username)
                 return _finalize_login(provider, user)
         elif provider.kind == "ldap":
             identity = LDAPAuthenticator(provider).verify(credentials)
             if identity:
+                login_throttle.register_success(username)
                 return provision_and_issue_jwt(provider, identity)
 
+    login_throttle.register_failure(username)
     data = request.get_json(silent=True) or {}
     if data.get("password"):
         data["password"] = log_manager.sensitive_value(data["password"])
@@ -623,10 +632,14 @@ def complete_mfa_totp(mfa_token: str, code: str) -> tuple[dict, HTTPStatus]:
     user = User.find(payload["sub"]) if payload else None
     if not user:
         return _mfa_session_expired()
+    if not login_throttle.check_lock(user.username):
+        return _mfa_session_expired()
     if not totp_manager.verify_code(user, code):
+        login_throttle.register_failure(user.username)
         log_manager.store_auth_error_activity(f"Invalid TOTP code for user: {user.username}")
         time.sleep(random.uniform(1, 3))  # noqa: S311 - timing jitter, not cryptographic
         return BaseAuthenticator.generate_error_code("Invalid authentication code", "TOTP_INVALID")
+    login_throttle.register_success(user.username)
     return BaseAuthenticator.generate_jwt(user)
 
 

--- a/src/core/managers/login_throttle.py
+++ b/src/core/managers/login_throttle.py
@@ -1,0 +1,128 @@
+"""Failed-login throttling backed by Redis.
+
+A failed form login (password or LDAP) or a wrong second factor increments a
+per-username counter in Redis. Once the counter passes a threshold, further
+attempts for that username are refused before any credential check happens, for
+a lockout that doubles with each additional failure (5, 10, 20 ... minutes, up
+to LOCKOUT_MAX_SECONDS). Successful logins reset the counter, and so does a
+FAIL_WINDOW of quiet measured from the later of the last failure and the end of
+the last lockout.
+
+The counters are process-wide singletons reached through Redis, so every
+gunicorn worker shares the same view of a username's failures. Redis being
+momentarily unavailable degrades to "no throttling" rather than to "no login":
+every helper swallows connection errors.
+"""
+
+from __future__ import annotations
+
+import time
+
+from managers.cache_manager import redis_client
+from managers.log_manager import logger
+
+# Attempt counter: the count resets once a username goes FAIL_WINDOW seconds
+# without a new failure.
+FAIL_THRESHOLD = 5
+FAIL_WINDOW = 300  # seconds of quiet after which the failure count is forgotten
+
+# Progressive lockout: locked_until = now + LOCKOUT_SECONDS * LOCKOUT_MULTIPLIER ** overkill,
+# where overkill counts the failures past FAIL_THRESHOLD (5, 10, 20, ... minutes).
+LOCKOUT_SECONDS = 300
+LOCKOUT_MULTIPLIER = 2  # each failure beyond the threshold doubles the lockout
+LOCKOUT_MAX_SECONDS = 86400  # a day; without a cap the doubling runs away to months
+
+_KEY = "login_fail:{username}"
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _encode(fails: int, last_fail: int, locked_until: int) -> str:
+    return f"{fails}:{last_fail}:{locked_until}"
+
+
+def _decode(raw: bytes | str | None) -> tuple[int, int, int]:
+    """Decode a counter entry; a missing or malformed one reads as zeroed."""
+    if not raw:
+        return 0, 0, 0
+    try:
+        fails_s, last_s, lock_s = raw.decode().split(":") if isinstance(raw, bytes) else str(raw).split(":")
+        return int(fails_s), int(last_s), int(lock_s)
+    except (ValueError, AttributeError):
+        return 0, 0, 0
+
+
+def _ttl_for(locked_until: int) -> int:
+    """Seconds of Redis TTL that keeps the entry only as long as it matters.
+
+    The entry has to outlive the lockout by a whole FAIL_WINDOW: an attacker who
+    comes straight back the moment a lock lifts must find the count still there
+    to escalate against, and only a genuinely quiet window may forget it.
+    """
+    return max(0, locked_until - _now()) + FAIL_WINDOW
+
+
+def _read(username: str) -> tuple[int, int, int]:
+    try:
+        return _decode(redis_client.get(_KEY.format(username=username)))
+    except Exception as ex:  # Redis being down must not break login
+        logger.warning(f"Login throttle read failed for '{username}': {ex}")
+        return 0, 0, 0
+
+
+def _write(username: str, fails: int, last_fail: int, locked_until: int) -> None:
+    try:
+        redis_client.set(
+            _KEY.format(username=username),
+            _encode(fails, last_fail, locked_until),
+            ex=_ttl_for(locked_until),
+        )
+    except Exception as ex:  # Redis being down must not break login
+        logger.warning(f"Login throttle write failed for '{username}': {ex}")
+
+
+def is_locked(username: str) -> bool:
+    """Tell whether this username is currently locked out."""
+    _, _, locked_until = _read(username)
+    return locked_until > _now()
+
+
+def check_lock(username: str) -> bool:
+    """Pass-through gate returning True when the attempt may proceed."""
+    if is_locked(username):
+        logger.warning(f"Login attempt on locked account: {username}")
+        return False
+    return True
+
+
+def register_failure(username: str) -> None:
+    """Count one failed attempt, locking the account once past the threshold."""
+    fails, last_fail, locked_until = _read(username)
+    now = _now()
+    # The quiet period is measured from whichever came later: the last failure,
+    # or the end of a lockout. Measuring it from the last failure alone would
+    # make escalation unreachable - the lockout runs at least as long as the
+    # window, so the count would always look stale by the time an attacker is
+    # let back in, and every burst would restart at one.
+    if fails and now - max(last_fail, locked_until) > FAIL_WINDOW:
+        fails = 0  # a genuinely quiet window; start a fresh count
+    fails += 1
+    locked_until = 0
+    if fails >= FAIL_THRESHOLD:
+        # Cap the exponent as well as the result - a long-running attack would
+        # otherwise raise 2 to an arbitrarily large power just to clamp it away.
+        overkill = min(fails - FAIL_THRESHOLD, 32)
+        lockout = min(LOCKOUT_SECONDS * (LOCKOUT_MULTIPLIER**overkill), LOCKOUT_MAX_SECONDS)
+        locked_until = now + lockout
+        logger.warning(f"Account locked for {lockout}s after {fails} failed login attempts: {username}")
+    _write(username, fails, now, locked_until)
+
+
+def register_success(username: str) -> None:
+    """Forget the failure history of a username that has just logged in."""
+    try:
+        redis_client.delete(_KEY.format(username=username))
+    except Exception as ex:  # Redis being down must not break login
+        logger.warning(f"Login throttle reset failed for '{username}': {ex}")

--- a/src/core/tests/test_login_throttle.py
+++ b/src/core/tests/test_login_throttle.py
@@ -1,0 +1,140 @@
+"""Failed-login throttling semantics (Redis faked in-process)."""
+
+from __future__ import annotations
+
+import pytest
+from managers import login_throttle
+
+
+class _FakeRedis:
+    """Just enough Redis: get/set(TTL)/delete keyed by string."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.ttls: dict[str, int] = {}
+
+    def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    def set(self, key: str, value: str, ex: int = 0) -> None:
+        self.store[key] = value
+        self.ttls[key] = ex
+
+    def delete(self, key: str) -> None:
+        self.store.pop(key, None)
+
+
+@pytest.fixture
+def fake_redis(monkeypatch: pytest.MonkeyPatch) -> _FakeRedis:
+    redis_state = _FakeRedis()
+    monkeypatch.setattr(login_throttle, "redis_client", redis_state)
+    return redis_state
+
+
+@pytest.mark.usefixtures("fake_redis")
+def test_under_threshold_attempts_are_allowed() -> None:
+    for _ in range(login_throttle.FAIL_THRESHOLD - 1):
+        login_throttle.register_failure("alice")
+    assert login_throttle.check_lock("alice") is True
+
+
+@pytest.mark.usefixtures("fake_redis")
+def test_threshold_failure_locks_the_account() -> None:
+    for _ in range(login_throttle.FAIL_THRESHOLD):
+        login_throttle.register_failure("alice")
+    assert login_throttle.check_lock("alice") is False
+
+
+@pytest.mark.usefixtures("fake_redis")
+def test_lockout_duration_grows_with_each_extra_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Escalation must survive the wait it imposes.
+
+    An attacker never gets to fail again *during* a lockout - the gate refuses
+    them before any credential check - so the only way to reach the sixth
+    failure is to wait the lockout out. A frozen clock therefore proves nothing:
+    it tests a state production cannot reach. This advances time exactly the way
+    an attacker would experience it.
+    """
+    clock = {"now": 1_000_000}
+    monkeypatch.setattr(login_throttle, "_now", lambda: clock["now"])
+
+    for _ in range(login_throttle.FAIL_THRESHOLD):
+        login_throttle.register_failure("alice")
+        clock["now"] += 1  # attempts take a moment each
+    _, _, locked_until = login_throttle._read("alice")
+    assert locked_until == clock["now"] - 1 + login_throttle.LOCKOUT_SECONDS
+
+    # wait out the lock, then come straight back: the count must carry over
+    clock["now"] = locked_until + 1
+    assert login_throttle.check_lock("alice") is True
+    login_throttle.register_failure("alice")
+
+    fails, _, locked_until = login_throttle._read("alice")
+    assert fails == login_throttle.FAIL_THRESHOLD + 1
+    assert locked_until == clock["now"] + login_throttle.LOCKOUT_SECONDS * login_throttle.LOCKOUT_MULTIPLIER
+
+
+@pytest.mark.usefixtures("fake_redis")
+def test_lockout_is_capped(monkeypatch: pytest.MonkeyPatch) -> None:
+    # without a cap the doubling reaches months; walk far enough past the
+    # threshold that the clamp has to engage
+    clock = {"now": 1_000_000}
+    monkeypatch.setattr(login_throttle, "_now", lambda: clock["now"])
+    for _ in range(login_throttle.FAIL_THRESHOLD + 20):
+        login_throttle.register_failure("alice")
+        _, _, locked_until = login_throttle._read("alice")
+        clock["now"] = max(clock["now"] + 1, locked_until + 1)
+
+    assert locked_until - (clock["now"] - 1) <= login_throttle.LOCKOUT_MAX_SECONDS
+
+
+def test_success_resets_the_counter(fake_redis: _FakeRedis) -> None:
+    login_throttle.register_failure("alice")
+    login_throttle.register_success("alice")
+    assert login_throttle.check_lock("alice") is True
+    assert "login_fail:alice" not in fake_redis.store
+
+
+@pytest.mark.usefixtures("fake_redis")
+def test_lock_expires(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = {"now": 1_000_000}
+    monkeypatch.setattr(login_throttle, "_now", lambda: clock["now"])
+    for _ in range(login_throttle.FAIL_THRESHOLD):
+        login_throttle.register_failure("alice")
+    assert login_throttle.is_locked("alice") is True
+
+    clock["now"] += login_throttle.LOCKOUT_SECONDS + 1
+    assert login_throttle.is_locked("alice") is False
+
+
+@pytest.mark.usefixtures("fake_redis")
+def test_failures_outside_the_window_start_a_fresh_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = {"now": 1_000_000}
+    monkeypatch.setattr(login_throttle, "_now", lambda: clock["now"])
+    login_throttle.register_failure("alice")  # first failure: window starts
+    clock["now"] += login_throttle.FAIL_WINDOW + 10  # the window has expired
+    login_throttle.register_failure("alice")  # this is a fresh count, not #2
+
+    fails, last_fail, _ = login_throttle._read("alice")
+    assert fails == 1
+    assert last_fail == clock["now"]
+
+
+@pytest.mark.usefixtures("fake_redis")
+def test_usernames_are_counted_separately() -> None:
+    for _ in range(login_throttle.FAIL_THRESHOLD):
+        login_throttle.register_failure("alice")
+    assert login_throttle.check_lock("bob") is True
+
+
+def test_redis_outage_never_blocks_login(fake_redis: _FakeRedis, monkeypatch: pytest.MonkeyPatch) -> None:
+    def broken(*_args: object, **_kwargs: object) -> None:
+        msg = "connection refused"
+        raise ConnectionError(msg)
+
+    monkeypatch.setattr(fake_redis, "get", broken)
+    monkeypatch.setattr(fake_redis, "set", broken)
+    assert login_throttle.check_lock("alice") is True  # degrade open, not closed
+    login_throttle.register_failure("alice")  # must not raise
+    monkeypatch.setattr(fake_redis, "delete", broken)
+    login_throttle.register_success("alice")  # must not raise

--- a/src/gui-v3/tests/e2e/login-throttle.spec.js
+++ b/src/gui-v3/tests/e2e/login-throttle.spec.js
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Failed-login throttling (managers/login_throttle.py).
+ *
+ * The unit tests fake Redis, so they can prove the arithmetic but not that the
+ * lock is actually shared between gunicorn workers or enforced ahead of the
+ * credential check. That is what this spec is for.
+ *
+ * Two rules shape it:
+ *
+ *  - Never throttle `admin`. playwright.config.js runs a single worker against
+ *    one shared backend and every other spec logs in as admin, so a five-minute
+ *    lock there would cascade into unrelated failures.
+ *  - Do not test lock *expiry*. It would idle the only worker for five minutes;
+ *    `test_lock_expires` already covers it with a fake clock.
+ */
+
+const CORE_API = process.env.E2E_CORE_API || `http://127.0.0.1:${process.env.E2E_CORE_PORT || '8090'}/api/v1`
+const THRESHOLD = 5 // FAIL_THRESHOLD in managers/login_throttle.py
+
+const login = (request, username, password) => request.post(`${CORE_API}/auth/login`, { data: { username, password } })
+
+test.describe('Login throttling', () => {
+    test('locks a username after repeated failures, across workers', async ({ request }) => {
+        // A name nothing else uses, and unique per run so a re-run is not still
+        // locked from the previous one.
+        const username = `throttle-probe-${Date.now()}`
+
+        for (let attempt = 1; attempt <= THRESHOLD; attempt++) {
+            const response = await login(request, username, `wrong-${attempt}`)
+            expect(response.status(), `attempt ${attempt} should be rejected`).toBe(401)
+        }
+
+        // Past the threshold the gate refuses before any credential check. The
+        // status is deliberately the same 401 — the response must not tell an
+        // attacker whether the account exists or is locked.
+        const locked = await login(request, username, 'wrong-again')
+        expect(locked.status()).toBe(401)
+    })
+
+    test('a locked account refuses even the correct password', async ({ request }) => {
+        // The real proof: without it, the assertions above are satisfied by
+        // ordinary auth failures and would pass with the throttle removed.
+        const username = `throttle-real-${Date.now()}`
+        const password = 'CorrectHorse.Battery.Staple.1'
+
+        const created = await request.post(`${CORE_API}/config/users`, {
+            headers: { Authorization: `Bearer ${await adminToken(request)}` },
+            // NewUserSchema inherits an `id` field and User.__init__ requires it, so a
+            // placeholder is mandatory; RoleIdSchema.id is a string field, so '2' not 2.
+            data: {
+                id: -1,
+                username,
+                name: 'Throttle Probe',
+                password,
+                roles: [{ id: '2' }],
+                permissions: [],
+                organizations: []
+            }
+        })
+        test.skip(!created.ok(), `could not seed a user (HTTP ${created.status()}); skipping the strict check`)
+
+        // sanity: the credentials work before anything is throttled
+        expect((await login(request, username, password)).status()).toBe(200)
+
+        for (let attempt = 1; attempt <= THRESHOLD; attempt++) {
+            expect((await login(request, username, 'nope')).status()).toBe(401)
+        }
+
+        const refused = await login(request, username, password)
+        expect(refused.status(), 'a valid credential must be refused while locked').toBe(401)
+    })
+
+    test('the lock is scoped to one username', async ({ request }) => {
+        const locked = `throttle-scope-${Date.now()}`
+        for (let attempt = 1; attempt <= THRESHOLD; attempt++) {
+            await login(request, locked, 'nope')
+        }
+
+        // A different name must still get an ordinary rejection rather than
+        // inheriting the lock — a global counter would be a trivial DoS.
+        const other = await login(request, `throttle-other-${Date.now()}`, 'nope')
+        expect(other.status()).toBe(401)
+    })
+})
+
+async function adminToken(request) {
+    const response = await login(request, 'admin', 'admin')
+    expect(response.ok(), 'admin login must work before seeding').toBeTruthy()
+    return (await response.json()).access_token
+}

--- a/src/gui-v3/tests/helpers/api-seed.js
+++ b/src/gui-v3/tests/helpers/api-seed.js
@@ -20,7 +20,19 @@ async function getToken(request, username = 'admin', password = 'admin') {
                 const body = await res.json()
                 return body.access_token
             }
-        } catch {
+            if (res.status() === 401) {
+                // A live backend rejecting the credentials will keep rejecting them.
+                // Retrying here would spend the failed-login budget (5 per 5 minutes,
+                // see managers/login_throttle.py) and lock the account the rest of
+                // the suite logs in with — turning a wrong password into a cascade of
+                // unrelated failures. Fail fast and say so instead.
+                throw new Error(
+                    `E2E seed: backend rejected ${username} credentials (HTTP 401). Not retrying, ` +
+                        'to avoid tripping the login throttle and locking the account.'
+                )
+            }
+        } catch (error) {
+            if (error instanceof Error && error.message.startsWith('E2E seed:')) throw error
             // backend not yet reachable — keep polling
         }
         await new Promise((resolve) => setTimeout(resolve, 1000))


### PR DESCRIPTION
**Why**

Failed local/LDAP logins and wrong TOTP codes were slowed only by a 1–3 s jitter. No lockout existed, and the counter lived nowhere — every gunicorn worker was independently unaware of the others' failures. Password spraying the single privileged admin account is the most direct remote attack on a deployment.

**What changed**

- New managers/login_throttle.py — per-username counter in Redis, which core already requires.
- 5 failures lock the username; each further failure doubles the lockout (5 / 10 / 20 … min) up to a one-day cap; a successful login clears it.
- The quiet window is measured from the later of the last failure and the end of the last lockout. Measuring from the last failure alone makes escalation unreachable — the lockout runs at least as long as the window, so every burst would restart at one.
- Redis being unavailable degrades to no throttling, never to no login.
- Wired into authenticate_with_provider (before any credential check) and complete_mfa_totp.

**Tests**

- Unit: threshold, window, escalation across a real lock expiry, cap, per-username isolation, Redis-outage fail-open.
- E2E proves what the faked-Redis unit tests cannot — the lock is shared across gunicorn workers and refuses even a correct password. It never throttles admin, since the suite runs one worker against a shared backend.
- The seed helper no longer retries a login that returned 401; that would spend the failure budget and lock the account for the rest of the run.