### PR TITLE
fix: harden the API's browser-facing surface and error responses

### DIFF
--- a/docker/.env.e2e
+++ b/docker/.env.e2e
@@ -85,3 +85,11 @@ E2E_VITE_PORT=4444
 CVE_UPDATE_FILE=/data/cve_dictionary.xml
 CPE_UPDATE_FILE=/data/cpe_dictionary.xml
 CWE_UPDATE_FILE=/data/cwe_dictionary.xml
+
+# The Playwright suite serves the GUI from the Vite dev server on :4444 and points
+# it at the core API on :8090 (`npm run dev:remote`). Different port means a
+# different origin, so the browser needs core to grant it explicitly - without
+# this the login page cannot even fetch /auth/methods. Both spellings are listed
+# because playwright.config.js uses `localhost` while Vite binds `127.0.0.1`,
+# and the two are separate origins to a browser.
+TARANIS_NG_CORS_ORIGINS=http://localhost:4444,http://127.0.0.1:4444

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -93,3 +93,28 @@ MODULES_LOG_LEVEL=WARN
 # To change Nginx log level, go to docker-compose.yml and change NGINX_LOG_LEVEL and NGINX_ACCESS_LOG there
 # To change Redis log level, go to docker-compose.yml and change --loglevel there
 
+# Security
+#
+# Flask debug mode (the Werkzeug interactive debugger, which executes arbitrary
+# code from any traceback page) is off unless FLASK_DEBUG is set. Setting it here
+# has no effect: the variable is not passed through to any container, and the
+# containers run under gunicorn, which never installs the debugger. It only
+# matters when running a service directly from `run.py` on a development
+# machine, where you would export it in your own shell.
+#
+# Cross-origin API access is off unless TARANIS_NG_CORS_ORIGINS lists the origins
+# allowed to make credentialed calls (comma-separated). A normal deployment needs
+# none: Traefik serves the GUI and the API under one hostname, and `npm run dev`
+# proxies /api and /sse through the Vite dev server, so both are same-origin.
+#
+# `npm run dev:remote` is the exception - it points the GUI at an absolute API
+# base on another port, which the browser treats as cross-origin, so the login
+# page cannot even fetch /auth/methods without an entry here. Remember that a
+# port or hostname difference makes a different origin: http://localhost:4444
+# and http://127.0.0.1:4444 both need listing.
+#
+# Never enable this without an explicit list. Credentialed CORS that reflects
+# whatever Origin it is sent lets any site a logged-in analyst visits call the
+# API as them.
+# TARANIS_NG_CORS_ORIGINS=http://localhost:4444,http://127.0.0.1:4444
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -62,6 +62,12 @@ services:
       LDAP_CA_CERT_PATH:
       SQLALCHEMY_WARN_20: "1"
       PYTHONWARNINGS: "default"
+      # Cross-origin API access, off unless an origin list is given. A normal
+      # deployment needs none: Traefik serves the GUI and the API under one
+      # hostname. `npm run dev:remote` does, though - it points the GUI at an
+      # absolute API base on another port, so the browser treats every call as
+      # cross-origin. docker/.env.e2e sets this for the E2E stack.
+      TARANIS_NG_CORS_ORIGINS: "${TARANIS_NG_CORS_ORIGINS:-}"
 
       OPENID_LOGOUT_URL: ""
       GUNICORN_WORKERS: "AUTO"

--- a/src/bots/app.py
+++ b/src/bots/app.py
@@ -2,7 +2,6 @@
 
 from dotenv import load_dotenv
 from flask import Flask
-from flask_cors import CORS
 from managers import api_manager, bots_manager, sse_manager
 from shared.time_manager import SchedulerManager
 
@@ -17,8 +16,6 @@ def create_app() -> Flask:
     load_dotenv()
 
     with app.app_context():
-        CORS(app)
-
         SchedulerManager.init_scheduler()
         api_manager.initialize(app)
         bots_manager.initialize()

--- a/src/bots/config.py
+++ b/src/bots/config.py
@@ -1,5 +1,6 @@
 """Configuration settings for bots."""
 
+import os
 from pathlib import Path
 
 
@@ -27,5 +28,9 @@ class Config:
             msg = f"Secret file not found: {file_path}"
             raise RuntimeError(msg) from err
 
-    DEBUG = True
+    # Never default the Werkzeug debugger on (RCE from any traceback page); opt in
+    # explicitly for local development instead. This service does not load Config
+    # into app.config, so the value only reaches Flask if that changes - it is set
+    # correctly here so the default is safe if it ever does.
+    DEBUG = os.getenv("FLASK_DEBUG", "false").strip().lower() in ("1", "true", "yes", "on")
     API_KEY = read_secret("api_key")

--- a/src/collectors/app.py
+++ b/src/collectors/app.py
@@ -2,7 +2,6 @@
 
 from dotenv import load_dotenv
 from flask import Flask
-from flask_cors import CORS
 from managers import api_manager, collectors_manager
 from shared.time_manager import SchedulerManager
 
@@ -17,8 +16,6 @@ def create_app() -> Flask:
     load_dotenv()
 
     with app.app_context():
-        CORS(app)
-
         SchedulerManager.init_scheduler()
         api_manager.initialize(app)
         collectors_manager.initialize()

--- a/src/collectors/config.py
+++ b/src/collectors/config.py
@@ -1,5 +1,6 @@
 """Configuration settings for collectors."""
 
+import os
 from pathlib import Path
 
 
@@ -28,4 +29,8 @@ class Config:
             raise RuntimeError(msg) from err
 
     API_KEY = read_secret("api_key")
-    DEBUG = True
+    # Never default the Werkzeug debugger on (RCE from any traceback page); opt in
+    # explicitly for local development instead. This service does not load Config
+    # into app.config, so the value only reaches Flask if that changes - it is set
+    # correctly here so the default is safe if it ever does.
+    DEBUG = os.getenv("FLASK_DEBUG", "false").strip().lower() in ("1", "true", "yes", "on")

--- a/src/core/api/publish.py
+++ b/src/core/api/publish.py
@@ -302,6 +302,10 @@ class ProductGetPreview(Resource):
                 log_manager.store_auth_error_activity(err_msg)
                 return Response(err_msg, HTTPStatus.NOT_FOUND, mimetype="text/plain")
 
+            # Single use: consume the ticket right away, so a URL that leaked
+            # (proxy logs, browser history, shared links) cannot serve the
+            # report a second time.
+            redis_client.delete(cache_key)
             cached_data = json.loads(cached_bytes)
             preview_data = base64.b64decode(cached_data["data"])
             preview_mime = cached_data["mime"]
@@ -344,7 +348,7 @@ class ProductSetPreview(Resource):
         """
         err_msg = None
         user = None
-        cache_ttl = 3600  # 1 hour, Expiration time in seconds (time-to-live)
+        cache_ttl = 600  # 10 minutes: the ticket is single-use; this bounds how long an unused one stays valid
 
         jwt = request.json.get("jwt")
         if not jwt:

--- a/src/core/app.py
+++ b/src/core/app.py
@@ -2,7 +2,7 @@
 
 import os
 
-from flask import Flask
+from flask import Flask, Response, request
 from flask_cors import CORS
 from managers import (
     api_manager,
@@ -42,7 +42,15 @@ def create_app() -> Flask:
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=proxy_hops, x_proto=proxy_hops, x_host=proxy_hops, x_prefix=proxy_hops)
 
     with app.app_context():
-        CORS(app, supports_credentials=True)
+        # credentials-capable CORS must never reflect arbitrary origins (that
+        # would let any website make credentialed cross-site API calls). By
+        # default CORS is therefore not enabled at all - the production
+        # deployment serves the GUI and the API from the same origin. A
+        # development GUI on another port opts in explicitly:
+        #   TARANIS_NG_CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
+        cors_origins = [origin for origin in (os.getenv("TARANIS_NG_CORS_ORIGINS") or "").split(",") if origin.strip()]
+        if cors_origins:
+            CORS(app, supports_credentials=True, origins=cors_origins)
 
         db_manager.initialize(app)
         db_manager.create_tables()
@@ -54,4 +62,55 @@ def create_app() -> Flask:
         remote_manager.initialize(app)
         tagcloud_manager.initialize(app)
 
+        _install_security_headers(app)
+
     return app
+
+
+def _install_security_headers(app: Flask) -> None:
+    """Attach conservative security headers to every API response.
+
+    The API serves JSON (not documents), so the browser-facing hardeners that
+    apply are: content-type sniffing off, framing off, referrer minimisation.
+    CSP here is defense-in-depth for any HTML the API does return (error
+    pages, JSON echoed in browsers): a restrictive default-src blocks script
+    injection in them. Traefik appends HSTS at the TLS edge.
+
+    Rendered product previews are the exception, and there are two of them:
+
+    * HTML previews run the presenter's own template, which owns its styling
+      *and* its scripting - template_osint.html, for one, inlines Chart.js and
+      draws its charts in the browser. Blocking inline script would ship a
+      report with no charts. These templates are server-side code authored by
+      administrators, not user content, and the policy still denies loading
+      anything over the network, framing, and form submission.
+    * Non-HTML previews (PDF above all) are handed to a browser's built-in
+      viewer. ``default-src 'none'`` also zeroes ``object-src``, which has
+      historically kept those viewers from rendering, so previews that are not
+      HTML get no CSP rather than a policy that might silently blank them.
+    """
+    preview_prefix = "/api/v1/publish/products/preview/"
+
+    @app.after_request
+    def set_security_headers(response: Response) -> Response:
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+
+        # One hook decides the CSP outright. Splitting this across two
+        # after_request handlers worked only because Flask runs them in reverse
+        # registration order, which is far too subtle a thing to rely on.
+        if request.path.startswith(preview_prefix):
+            if response.mimetype == "text/html":
+                response.headers.setdefault(
+                    "Content-Security-Policy",
+                    "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline' 'self'; "
+                    "img-src data: 'self'; font-src data: 'self'; frame-ancestors 'none'; form-action 'none'",
+                )
+            return response
+
+        response.headers.setdefault(
+            "Content-Security-Policy",
+            "default-src 'none'; frame-ancestors 'none'",
+        )
+        return response

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -90,7 +90,10 @@ class Config:
     JWT_SECRET_KEY = read_secret("jwt_secret_key")
     JWT_IDENTITY_CLAIM = "sub"
     JWT_ACCESS_TOKEN_EXPIRES = 14400
-    DEBUG = True
+    # Flask DEBUG enables the Werkzeug interactive debugger (arbitrary code
+    # execution from a traceback) - it must never be on in a deployment. Opt in
+    # explicitly for local development instead.
+    DEBUG = os.getenv("FLASK_DEBUG", "false").strip().lower() in ("1", "true", "yes", "on")
 
     # Key used to encrypt secrets stored in the database (auth provider client
     # secrets, LDAP bind passwords, TOTP seeds). Falls back to JWT_SECRET_KEY so

--- a/src/core/managers/api_manager.py
+++ b/src/core/managers/api_manager.py
@@ -19,11 +19,34 @@ from api import (
     user,
 )
 from flask_restful import Api
+from marshmallow import ValidationError
+
+
+class SafeErrorApi(Api):
+    """``Api`` that will not echo a rejected request body back to the client.
+
+    ``flask_restful.Api.handle_error`` builds the error response from
+    ``getattr(e, "data", ...)`` (flask_restful/__init__.py:340). Marshmallow's
+    ``ValidationError`` sets ``.data`` to the *input it just rejected*, so any
+    schema load that escapes a resource returns the whole request body - which
+    for ``POST /config/users`` is the new account's cleartext password, and
+    elsewhere API keys, client secrets and tokens. It is also a 500 for what is
+    a client mistake.
+
+    Both are fixed here rather than at the ~46 ``schema.load()`` call sites,
+    because one missed call site reintroduces the leak.
+    """
+
+    def handle_error(self, e: Exception) -> object:
+        """Turn a schema rejection into a 400 carrying only the field errors."""
+        if isinstance(e, ValidationError):
+            return self.make_response({"error": "Invalid request", "validation": e.normalized_messages()}, 400)
+        return super().handle_error(e)
 
 
 def initialize(app: object) -> None:
     """Initialize all API endpoints."""
-    api = Api(app)
+    api = SafeErrorApi(app)
 
     assess.initialize(api)
     auth.initialize(api)

--- a/src/core/tests/test_api_error_leak.py
+++ b/src/core/tests/test_api_error_leak.py
@@ -1,0 +1,66 @@
+"""A rejected request body must never come back in the error response.
+
+``flask_restful.Api.handle_error`` builds its response from the exception's
+``.data`` attribute, and marshmallow's ``ValidationError.data`` is the input it
+just rejected. Left alone, ``POST /config/users`` with a bad payload answered
+500 with the new account's cleartext password in the body.
+"""
+
+from __future__ import annotations
+
+import pytest
+from flask import Flask, request
+from flask_restful import Resource
+from managers.api_manager import SafeErrorApi
+from marshmallow import Schema, fields
+
+SECRET = "SUPERSECRET-PW"
+
+
+class _UserSchema(Schema):
+    username = fields.Str(required=True)
+    password = fields.Str(load_only=True)
+    role_id = fields.Str(required=True)  # a str field the test will feed an int
+
+
+@pytest.fixture
+def client() -> Flask:
+    app = Flask(__name__)
+
+    class Users(Resource):
+        def post(self) -> dict:
+            return _UserSchema().load(request.json)
+
+    api = SafeErrorApi(app)
+    api.add_resource(Users, "/api/v1/config/users")
+    return app.test_client()
+
+
+def test_validation_failure_does_not_echo_the_payload(client: Flask) -> None:
+    response = client.post("/api/v1/config/users", json={"username": "u", "password": SECRET, "role_id": 2})
+
+    body = response.get_data(as_text=True)
+    assert SECRET not in body, "the rejected request body must not be reflected"
+    assert '"u"' not in body
+
+
+def test_validation_failure_is_a_client_error_with_field_details(client: Flask) -> None:
+    response = client.post("/api/v1/config/users", json={"username": "u", "password": SECRET, "role_id": 2})
+
+    # a malformed payload is the caller's mistake, not a server fault
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["error"] == "Invalid request"
+    # the caller still learns which field to fix
+    assert "role_id" in payload["validation"]
+
+
+def test_other_errors_keep_their_normal_handling(client: Flask) -> None:
+    # the override must be narrow: only marshmallow rejections are rewritten
+    response = client.get("/api/v1/config/users")
+    assert response.status_code == 405
+
+
+def test_a_valid_payload_still_passes_through(client: Flask) -> None:
+    response = client.post("/api/v1/config/users", json={"username": "u", "password": SECRET, "role_id": "2"})
+    assert response.status_code == 200

--- a/src/core/tests/test_security_headers.py
+++ b/src/core/tests/test_security_headers.py
@@ -1,0 +1,67 @@
+"""Response headers the core API attaches to every reply.
+
+The hardening pass added these but nothing pinned them, so a refactor could
+drop a header (or the whole CSP branch for previews) without a test noticing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from app import _install_security_headers
+from flask import Flask, Response
+
+
+@pytest.fixture
+def client() -> Flask:
+    """A minimal app carrying only the header hook and the routes it branches on."""
+    app = Flask(__name__)
+
+    @app.route("/api/v1/assess/news-items")
+    def json_route() -> tuple[dict, int]:
+        return {"ok": True}, 200
+
+    @app.route("/api/v1/publish/products/preview/<token>")
+    def preview_route(token: str) -> Response:
+        mime = {"html": "text/html", "pdf": "application/pdf"}[token]
+        return Response(b"body", mimetype=mime)
+
+    _install_security_headers(app)
+    return app.test_client()
+
+
+def test_json_responses_carry_the_strict_policy(client: Flask) -> None:
+    headers = client.get("/api/v1/assess/news-items").headers
+    assert headers["X-Content-Type-Options"] == "nosniff"
+    assert headers["X-Frame-Options"] == "DENY"
+    assert headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    assert headers["Content-Security-Policy"] == "default-src 'none'; frame-ancestors 'none'"
+
+
+def test_html_preview_may_run_its_own_inline_script(client: Flask) -> None:
+    # template_osint.html inlines Chart.js; a policy without script-src falls
+    # back to default-src 'none' and ships the report with no charts.
+    csp = client.get("/api/v1/publish/products/preview/html").headers["Content-Security-Policy"]
+    assert "script-src 'unsafe-inline'" in csp
+    assert "style-src 'unsafe-inline' 'self'" in csp
+    assert "frame-ancestors 'none'" in csp
+    assert "default-src 'none'" in csp  # network loads stay blocked
+
+
+def test_non_html_preview_gets_no_csp(client: Flask) -> None:
+    # default-src 'none' also zeroes object-src, which can stop a browser's
+    # built-in PDF viewer from rendering the response at all.
+    response = client.get("/api/v1/publish/products/preview/pdf")
+    assert "Content-Security-Policy" not in response.headers
+    assert response.headers["X-Content-Type-Options"] == "nosniff"  # the rest still applies
+
+
+def test_a_handler_set_policy_is_not_overwritten() -> None:
+    # setdefault, not assignment: a route that knows better keeps its own policy
+    app = Flask(__name__)
+
+    @app.route("/api/v1/anything")
+    def route() -> Response:
+        return Response(b"{}", mimetype="application/json", headers={"Content-Security-Policy": "default-src 'self'"})
+
+    _install_security_headers(app)
+    assert app.test_client().get("/api/v1/anything").headers["Content-Security-Policy"] == "default-src 'self'"

--- a/src/gui-v3/tests/README.md
+++ b/src/gui-v3/tests/README.md
@@ -95,6 +95,20 @@ Assess, access management, roles, organizations, collectors, presenters,
 workflow states, selected Publish behavior, and My Assets permission and CRUD
 paths.
 
+Some specs are API-level rather than browser workflows, covering security
+behavior that only shows up against a real stack — the unit suites stub exactly
+the parts that matter (the attachment ACL query is monkeypatched, Redis is
+faked, and nothing else asserts a response header). They are named after the
+behavior they pin, for example:
+
+- `security-headers.spec.js` — the hardening headers on every response, and that
+  a foreign origin gets no CORS grant.
+- `publish-preview-ticket.spec.js` — product preview tickets are single use, and
+  the CSP matches what the rendered format needs.
+
+These need no browser, so `--no-deps` runs them without the seed project when you
+only want a quick check.
+
 ### Continuous integration
 
 `.github/workflows/gui-v3-tests.yml` runs the suite on Chromium, Firefox and

--- a/src/gui-v3/tests/e2e/publish-preview-ticket.spec.js
+++ b/src/gui-v3/tests/e2e/publish-preview-ticket.spec.js
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test'
+import { createApiContext } from '../helpers/api-seed'
+
+/**
+ * Product preview tickets and the CSP the preview is served under.
+ *
+ * The preview endpoint mints a uuid4 ticket in Redis and serves the rendered
+ * report from a GET with no re-authentication. Two properties matter and neither
+ * can be checked without a real backend:
+ *
+ *  - the ticket is single use, so a URL that leaks (proxy logs, browser history,
+ *    a shared link) cannot serve the report again. The code claimed this in a
+ *    comment long before it did it.
+ *  - an HTML preview must be able to run the inline script its own template
+ *    ships (template_osint.html inlines Chart.js), while still being denied
+ *    everything it does not need.
+ */
+
+const CORE_API = process.env.E2E_CORE_API || `http://127.0.0.1:${process.env.E2E_CORE_PORT || '8090'}/api/v1`
+
+async function mintTicket(request, token) {
+    // product types are a config resource, not a publish one
+    const types = await request.get(`${CORE_API}/config/product-types`, {
+        headers: { Authorization: `Bearer ${token}` }
+    })
+    if (!types.ok()) return null
+    const body = await types.json()
+    const productType = (body.items || []).find(Boolean)
+    if (!productType) return null
+
+    const response = await request.post(`${CORE_API}/publish/products/preview-ticket`, {
+        data: { jwt: token, product: { product_type_id: productType.id, title: 'E2E preview', description: 'E2E' } }
+    })
+    if (!response.ok()) return null
+    return (await response.json()).token
+}
+
+test.describe('Product preview ticket', () => {
+    let request
+    let token
+
+    test.beforeAll(async ({ playwright }) => {
+        ;({ request, token } = await createApiContext(playwright))
+    })
+
+    test.afterAll(async () => {
+        await request?.dispose()
+    })
+
+    test('a preview ticket may be redeemed exactly once', async () => {
+        const ticket = await mintTicket(request, token)
+        test.skip(!ticket, 'no product type available to preview in this environment')
+
+        const first = await request.get(`${CORE_API}/publish/products/preview/${ticket}`)
+        expect(first.status(), 'the first redemption serves the report').toBe(200)
+
+        // Before the fix this returned the report again, for an hour.
+        const second = await request.get(`${CORE_API}/publish/products/preview/${ticket}`)
+        expect(second.status(), 'a redeemed ticket must be spent').toBe(404)
+    })
+
+    test('an unknown ticket is not found', async () => {
+        const response = await request.get(`${CORE_API}/publish/products/preview/00000000-0000-0000-0000-000000000000`)
+        expect(response.status()).toBe(404)
+    })
+
+    test('the preview CSP matches what the rendered format needs', async () => {
+        const ticket = await mintTicket(request, token)
+        test.skip(!ticket, 'no product type available to preview in this environment')
+
+        const response = await request.get(`${CORE_API}/publish/products/preview/${ticket}`)
+        expect(response.status()).toBe(200)
+
+        const contentType = response.headers()['content-type'] || ''
+        const csp = response.headers()['content-security-policy']
+
+        // Whatever the format, the non-CSP hardening always applies.
+        expect(response.headers()['x-content-type-options']).toBe('nosniff')
+
+        if (contentType.includes('text/html')) {
+            // template_osint.html builds its charts from an inlined Chart.js; a
+            // policy without script-src would ship the report with no charts.
+            expect(csp).toContain("script-src 'unsafe-inline'")
+            expect(csp).toContain("default-src 'none'") // still no network loads
+            expect(csp).toContain("frame-ancestors 'none'")
+        } else {
+            // A PDF (or any non-HTML preview) goes to the browser's built-in
+            // viewer. `default-src 'none'` also zeroes object-src, which has
+            // historically stopped those viewers rendering, so these carry no
+            // CSP at all rather than one that might silently blank the page.
+            expect(csp, `${contentType} preview must not carry a CSP`).toBeUndefined()
+        }
+    })
+})

--- a/src/gui-v3/tests/e2e/security-headers.spec.js
+++ b/src/gui-v3/tests/e2e/security-headers.spec.js
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Response headers the core API attaches to every reply.
+ *
+ * These are cheap to add and easy to lose in a refactor, and nothing else in the
+ * suite looks at them. Asserted against the real backend rather than a Flask test
+ * client, because gunicorn and Traefik both sit in the path in production.
+ */
+
+const CORE_API = process.env.E2E_CORE_API || `http://127.0.0.1:${process.env.E2E_CORE_PORT || '8090'}/api/v1`
+
+test.describe('Core API security headers', () => {
+    test('every response carries the hardening headers', async ({ request }) => {
+        const response = await request.get(`${CORE_API}/isalive`)
+        expect(response.ok()).toBeTruthy()
+
+        const headers = response.headers()
+        expect(headers['x-content-type-options']).toBe('nosniff')
+        expect(headers['x-frame-options']).toBe('DENY')
+        expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin')
+        expect(headers['content-security-policy']).toBe("default-src 'none'; frame-ancestors 'none'")
+    })
+
+    test('a foreign origin gets no CORS grant', async ({ request }) => {
+        // The API used to run flask-cors with supports_credentials and no origin
+        // list, which reflects whatever Origin is sent — so any site a logged-in
+        // analyst visited could call the API as them. Nothing may come back now.
+        const response = await request.get(`${CORE_API}/isalive`, {
+            headers: { Origin: 'https://evil.example' }
+        })
+
+        const headers = response.headers()
+        expect(headers['access-control-allow-origin']).toBeUndefined()
+        expect(headers['access-control-allow-credentials']).toBeUndefined()
+    })
+
+    test('a preflight from a foreign origin is not granted either', async ({ request }) => {
+        const response = await request.fetch(`${CORE_API}/assess/news-items`, {
+            method: 'OPTIONS',
+            headers: {
+                'Origin': 'https://evil.example',
+                'Access-Control-Request-Method': 'POST',
+                'Access-Control-Request-Headers': 'authorization'
+            }
+        })
+
+        expect(response.headers()['access-control-allow-origin']).toBeUndefined()
+    })
+})

--- a/src/presenters/app.py
+++ b/src/presenters/app.py
@@ -4,7 +4,6 @@ import logging
 import os
 
 from flask import Flask
-from flask_cors import CORS
 from managers import api_manager, presenters_manager
 
 # fix for fontTools which is ignoring global logging settings and puts garbage into the logs
@@ -29,8 +28,6 @@ def create_app() -> Flask:
     app = Flask(__name__)
 
     with app.app_context():
-        CORS(app)
-
         api_manager.initialize(app)
         presenters_manager.initialize()
 

--- a/src/publishers/app.py
+++ b/src/publishers/app.py
@@ -1,7 +1,6 @@
 """App factory for publishers service."""
 
 from flask import Flask
-from flask_cors import CORS
 from managers import api_manager, publishers_manager
 
 
@@ -14,8 +13,6 @@ def create_app() -> Flask:
     app = Flask(__name__)
 
     with app.app_context():
-        CORS(app)
-
         api_manager.initialize(app)
         publishers_manager.initialize()
 


### PR DESCRIPTION
**Five related fixes to what core hands a browser.**

CORS reflected any origin — CORS(app, supports_credentials=True) with no origin list makes flask-cors echo back whatever Origin it is sent, with credentials, so any website a logged-in analyst visited could make authenticated API calls. Now off unless TARANIS_NG_CORS_ORIGINS names the allowed origins. Production needs none (Traefik serves GUI and API under one hostname); npm run dev:remote does, so docker/.env.e2e sets it. The four worker services dropped CORS(app) outright — nothing browser-based reaches them.

**No security headers**

- after_request now sets nosniff, X-Frame-Options: DENY, a referrer policy and a restrictive CSP.
- Two preview carve-outs: an HTML preview may run the inline script its own template ships (template_osint.html inlines Chart.js and draws charts in the browser); a non-HTML preview gets no CSP, because default-src 'none' also zeroes object-src, which has historically stopped browsers' built-in PDF viewers rendering.
- Both live in one hook. The previous split worked only because Flask runs after_request handlers in reverse registration order.

Config.DEBUG was hardcoded True — the Werkzeug debugger executes arbitrary code from any traceback page, and run.py hands it app.debug directly. Now reads FLASK_DEBUG, default off.

Preview tickets were replayable — the endpoint minted a uuid4 in Redis and served the report from an unauthenticated GET. The comment claimed single use; nothing ever deleted the key, so anyone with the URL could replay it for an hour. Now consumed on read, TTL 3600 → 600 s.

A rejected request body came back in the error response — flask_restful builds error responses from the exception's .data, and marshmallow's ValidationError.data is the input it just rejected, so POST /config/users with a malformed payload answered 500 with the new account's cleartext password in the body. SafeErrorApi turns those into a 400 carrying only field errors. Fixed centrally rather than at the ~46 schema.load() call sites, because one missed site reintroduces the leak.