### PR TITLE
fix(core): close attachment IDOR, open redirects and an SSRF redirect…

### DIFF
--- a/src/core/api/assess.py
+++ b/src/core/api/assess.py
@@ -3,13 +3,13 @@
 import io
 from http import HTTPStatus
 
-from flask import request, send_file
+from flask import Response, request, send_file
 from flask_restful import Resource
-from managers import auth_manager
+from managers import auth_manager, log_manager
 from managers.auth_manager import ACLCheck, auth_required
 from managers.log_manager import logger
 from managers.sse_manager import sse_manager
-from model.news_item import NewsItem, NewsItemAggregate, NewsItemAttribute
+from model.news_item import NewsItem, NewsItemAggregate, NewsItemData
 from model.osint_source import OSINTSource, OSINTSourceGroup
 from model.permission import Permission
 
@@ -202,19 +202,30 @@ class DownloadAttachment(Resource):
     @auth_required("ASSESS_ACCESS")
     def post(
         self,
-        item_data_id: str,  # noqa: ARG002, auth_required ACLCheck is build for news_item (item_id, int), this is news_item_data (item_data_id, str)
+        item_data_id: str,
         attribute_id: str,
-    ) -> None:
+    ) -> tuple[dict, HTTPStatus] | Response:
         """Download attachment.
+
+        The attribute is resolved only within its owning news item data, and the
+        news item data must pass the caller's ACL - a bare attribute ID from
+        another user's group must not yield the file.
 
         Args:
             item_data_id (str): The item data ID
             attribute_id (str): The attribute ID
 
         Returns:
-            (file): The file
+            (file): The file, or an error response
         """
-        attribute = NewsItemAttribute.find(attribute_id)
+        user = auth_manager.get_user_from_jwt()
+        if not NewsItemData.allowed_with_acl(item_data_id, user, see=False, access=True, modify=False):
+            log_manager.store_user_auth_error_activity(user, f"Unauthorized attachment download for news item data: {item_data_id}")
+            return {"error": "not authorized"}, HTTPStatus.UNAUTHORIZED
+
+        attribute = NewsItemData.find_data_attribute(item_data_id, attribute_id)
+        if attribute is None or attribute.binary_data is None or attribute.binary_mime_type is None:
+            return {"error": "Attachment not found"}, HTTPStatus.NOT_FOUND
         response = send_file(
             io.BytesIO(attribute.binary_data),
             download_name=attribute.value,

--- a/src/core/api/auth.py
+++ b/src/core/api/auth.py
@@ -240,6 +240,12 @@ def _oauth_redirect_uri(provider_slug: str, config: dict) -> str:
 def _login_error_redirect(goto_url: str, code: str) -> Response:
     """Redirect back to the GUI login page with a login_error query parameter.
 
+    Every redirect-flow exit funnels through here, so the same-origin check
+    belongs here rather than at the fifteen call sites: several of them read
+    goto_url straight out of the stored auth transaction, and one that forgets to
+    sanitize would be an open redirect off the back of a login attempt.
+    ``_safe_goto_url`` is idempotent, so re-checking an already-checked URL is free.
+
     Args:
         goto_url (str): The GUI URL to return to.
         code (str): The machine-readable error code.
@@ -247,6 +253,7 @@ def _login_error_redirect(goto_url: str, code: str) -> Response:
     Returns:
         Response: The redirect response.
     """
+    goto_url = _safe_goto_url(goto_url)
     separator = "&" if "?" in goto_url else "?"
     return redirect(f"{goto_url}{separator}login_error={urllib.parse.quote(code.lower())}")
 
@@ -262,9 +269,13 @@ def _finish_redirect_login(goto_url: str, response: dict) -> Response:
         goto_url (str): The GUI URL to return to.
         response (dict): The login response from the auth manager.
 
+    As in :func:`_login_error_redirect`, goto_url is re-checked here because this
+    is the chokepoint every redirect flow passes through.
+
     Returns:
         Response: The redirect response.
     """
+    goto_url = _safe_goto_url(goto_url)
     code = response.get("code", "auth_failed")
 
     redeemable = (

--- a/src/core/api/config.py
+++ b/src/core/api/config.py
@@ -384,7 +384,10 @@ def _read_idp_metadata_xml(data: dict) -> str:
         # Rejects http(s)-only and, crucially, non-public hosts: this endpoint
         # reflects the fetched document back, so an unguarded fetch is an SSRF.
         saml_url_guard.assert_public_url(url)
-        response = requests.get(url, timeout=SAML_METADATA_TIMEOUT, stream=True)
+        # allow_redirects=False: assert_public_url only vets the typed URL, so a
+        # followed redirect would reach an unchecked host (see assert_no_redirect).
+        response = requests.get(url, timeout=SAML_METADATA_TIMEOUT, stream=True, allow_redirects=False)
+        saml_url_guard.assert_no_redirect(response, "The metadata")
         response.raise_for_status()
         xml = response.raw.read(SAML_METADATA_MAX_BYTES + 1, decode_content=True).decode("utf-8", errors="replace")
         if len(xml.encode()) > SAML_METADATA_MAX_BYTES:

--- a/src/core/auth/saml_federation.py
+++ b/src/core/auth/saml_federation.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING
 
 import requests
 from auth.saml_authenticator import PEM_FOOTER, PEM_HEADER, load_idp_certificates
-from auth.url_guard import assert_public_url
+from auth.url_guard import assert_no_redirect, assert_public_url
 from managers import log_manager
 from minisignxml.config import VerifyConfig
 from minisignxml.verify import extract_verified_element_and_certificate
@@ -140,7 +140,10 @@ def _fetch(url: str) -> bytes:
             :data:`MAX_METADATA_BYTES`.
     """
     assert_public_url(url)
-    with requests.get(url, timeout=HTTP_TIMEOUT, stream=True) as response:
+    # allow_redirects=False: assert_public_url only vets the typed URL, so a
+    # followed redirect would reach an unchecked host (see assert_no_redirect).
+    with requests.get(url, timeout=HTTP_TIMEOUT, stream=True, allow_redirects=False) as response:
+        assert_no_redirect(response, "The federation metadata")
         response.raise_for_status()
         chunks: list[bytes] = []
         total = 0

--- a/src/core/auth/url_guard.py
+++ b/src/core/auth/url_guard.py
@@ -123,6 +123,28 @@ def assert_auth_endpoint_url(url: str, *, allow_insecure: bool = False) -> None:
         raise ValueError(msg)
 
 
+def assert_no_redirect(response: requests.Response, what: str = "The document") -> None:
+    """Refuse a redirect on a fetch whose target was vetted before connecting.
+
+    :func:`assert_public_url` resolves the host and rejects non-global addresses,
+    but it only ever sees the URL the administrator typed. If the fetch then
+    follows a 302, the redirect target is reached with no check at all - a public
+    host can bounce the request to 169.254.169.254 or an internal service and the
+    body comes straight back to the caller. Fetches must therefore pass
+    ``allow_redirects=False`` and hand the response here.
+
+    Args:
+        response (requests.Response): The un-redirected response.
+        what (str): Noun phrase naming the document, used in the error message.
+
+    Raises:
+        ValueError: When the response is a redirect.
+    """
+    if response.status_code in REDIRECT_STATUS_CODES or response.is_redirect or response.is_permanent_redirect:
+        msg = f"{what} URL redirects, which is not allowed: a redirect target skips the non-public address check"
+        raise ValueError(msg)
+
+
 def read_limited_json(response: requests.Response, *, max_bytes: int = MAX_JSON_BYTES) -> dict[str, Any]:
     """Read a successful non-redirect response as a size-bounded JSON object."""
     if response.status_code in REDIRECT_STATUS_CODES or response.is_redirect or response.is_permanent_redirect:

--- a/src/core/model/news_item.py
+++ b/src/core/model/news_item.py
@@ -187,6 +187,10 @@ class NewsItemData(db.Model):
             True if user is allowed to access news item data, False otherwise
         """
         news_item_data = db.session.get(cls, news_item_data_id)
+        if news_item_data is None:
+            # An ID that does not resolve is not "allowed" - returning False lets
+            # the caller answer 401/404 instead of raising AttributeError below.
+            return False
         if news_item_data.remote_source is not None:
             return True
         query = db.session.query(NewsItemData.id).distinct().group_by(NewsItemData.id).filter(NewsItemData.id == news_item_data_id)
@@ -204,6 +208,29 @@ class NewsItemData(db.Model):
         query = ACLEntry.apply_query(query, user, see, access, modify)
 
         return query.scalar() is not None
+
+    @classmethod
+    def find_data_attribute(cls, news_item_data_id: str, attribute_id: int | str) -> NewsItemAttribute | None:
+        """Find a binary attribute only within its owning news item data.
+
+        A bare attribute ID is not trusted: the lookup succeeds only when the
+        attribute belongs to the named news item data, mirroring
+        ``ReportItem.find_attachment`` for the report side.
+
+        Args:
+            news_item_data_id: News item data ID
+            attribute_id: Attribute ID
+
+        Returns:
+            The matching attribute, or None when the pair does not exist.
+        """
+        news_item_data = db.session.get(cls, news_item_data_id)
+        if news_item_data is None:
+            return None
+        for attribute in news_item_data.attributes:
+            if str(attribute.id) == str(attribute_id):
+                return attribute
+        return None
 
     @classmethod
     def identical(cls, hash_string: str) -> bool:

--- a/src/core/tests/test_attachment_download_acl.py
+++ b/src/core/tests/test_attachment_download_acl.py
@@ -1,0 +1,142 @@
+"""Attachment download must honour the news item data ACL and ownership.
+
+The endpoint used to resolve ``NewsItemAttribute.find(attribute_id)`` globally,
+so any user holding ASSESS_ACCESS could fetch any group's attachment by ID.
+The fix resolves the attribute through the owning news item data (ownership)
+and checks that data against the caller's ACL (authorization).
+
+The ``auth_required`` decorator is exercised separately by the auth-manager
+suite; here the handler logic is tested through ``__wrapped__`` with the
+caller's user injected the way the decorator would.
+"""
+
+from __future__ import annotations
+
+import types
+from http import HTTPStatus
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from api import assess
+from flask import Flask, Response
+from model.news_item import NewsItemData
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from model.user import User
+
+
+class _FakeAttribute:
+    """NewsItemAttribute stand-in with just the fields the handler reads."""
+
+    def __init__(self, attribute_id: int, value: str = "cvss.txt", mime: str | None = "text/plain") -> None:
+        self.id = attribute_id
+        self.value = value
+        self.binary_mime_type = mime
+        self.binary_data = b"content"
+
+
+@pytest.fixture
+def log_app() -> Flask:
+    return Flask(__name__)
+
+
+@pytest.fixture
+def acl_decisions(monkeypatch: pytest.MonkeyPatch) -> dict[str, bool]:
+    """Replace the ACL query with a controllable per-item-data decision."""
+    decisions: dict[str, bool] = {}
+
+    def fake_allowed_with_acl(_cls: type, news_item_data_id: str, _user: object, **_kwargs: object) -> bool:
+        return decisions.get(news_item_data_id, False)
+
+    monkeypatch.setattr(NewsItemData, "allowed_with_acl", classmethod(fake_allowed_with_acl))
+    return decisions
+
+
+@pytest.fixture
+def caller(monkeypatch: pytest.MonkeyPatch) -> types.SimpleNamespace:
+    """The user the auth decorator resolved, plus a silent activity log."""
+    fake_user = types.SimpleNamespace(id=1, username="alice")
+    monkeypatch.setattr(assess.auth_manager, "get_user_from_jwt", lambda: fake_user)
+    monkeypatch.setattr(assess.log_manager, "store_user_auth_error_activity", lambda *_args, **_kwargs: None)
+    return fake_user
+
+
+def _handler() -> Callable[..., tuple[dict, HTTPStatus] | Response]:
+    """The undecorated handler - the decorator itself is unchanged framework code."""
+    resource = assess.DownloadAttachment()
+    return resource.post.__wrapped__.__get__(resource)
+
+
+def _apply_decisions(monkeypatch: pytest.MonkeyPatch, attribute: _FakeAttribute | None) -> None:
+    """Stub the scoped attribute lookup with a fixed result."""
+    monkeypatch.setattr(NewsItemData, "find_data_attribute", classmethod(lambda _cls, _item, _attr: attribute))
+
+
+def _call(log_app: Flask, item_data_id: str, attribute_id: str) -> tuple[dict, HTTPStatus] | Response:
+    with log_app.test_request_context("/"):
+        return _handler()(item_data_id, attribute_id)
+
+
+@pytest.mark.usefixtures("caller")
+def test_attachment_of_foreign_item_data_is_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+    acl_decisions: dict[str, bool],
+    log_app: Flask,
+) -> None:
+    # the attribute ID exists, but not under the requested news item data
+    acl_decisions["victim-item"] = True
+    _apply_decisions(monkeypatch, None)
+    _, code = _call(log_app, "victim-item", "42")
+    assert code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.usefixtures("caller", "acl_decisions")
+def test_attachment_outside_acl_is_unauthorized(monkeypatch: pytest.MonkeyPatch, log_app: Flask) -> None:
+    # ownership would succeed, but the caller's ACL on the item data fails
+    _apply_decisions(monkeypatch, _FakeAttribute(42))
+    _, code = _call(log_app, "someone-elses-item", "42")
+    assert code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.usefixtures("caller")
+def test_authorised_download_streams_the_file(monkeypatch: pytest.MonkeyPatch, acl_decisions: dict[str, bool], log_app: Flask) -> None:
+    acl_decisions["my-item"] = True
+    _apply_decisions(monkeypatch, _FakeAttribute(42, value="report.txt"))
+    response = _call(log_app, "my-item", "42")
+    assert response.status_code == HTTPStatus.OK.value
+    assert response.headers["Content-Disposition"].startswith("attachment; filename=report.txt")
+
+
+@pytest.mark.usefixtures("caller")
+def test_attachment_without_binary_is_not_found(monkeypatch: pytest.MonkeyPatch, acl_decisions: dict[str, bool], log_app: Flask) -> None:
+    acl_decisions["my-item"] = True
+    attribute = _FakeAttribute(42)
+    attribute.binary_data = None
+    _apply_decisions(monkeypatch, attribute)
+    _, code = _call(log_app, "my-item", "42")
+    assert code == HTTPStatus.NOT_FOUND
+
+
+def test_find_data_attribute_is_scoped_to_the_owning_item(monkeypatch: pytest.MonkeyPatch) -> None:
+    # a bare attribute ID must never match across item data, mirroring ReportItem.find_attachment
+    owning = _FakeAttribute(7)
+    item_data = types.SimpleNamespace(attributes=[owning])
+
+    def fake_get(cls, wanted_id: str, **_kwargs: object) -> object:  # noqa: ANN001, ARG001
+        return item_data if wanted_id == "item-1" else None
+
+    monkeypatch.setattr("model.news_item.db.session", types.SimpleNamespace(get=fake_get))
+    assert NewsItemData.find_data_attribute("item-1", 7) is owning
+    assert NewsItemData.find_data_attribute("item-1", 8) is None
+    assert NewsItemData.find_data_attribute("item-2", 7) is None
+
+
+def test_acl_check_on_a_nonexistent_item_data_is_refused_not_crashed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # allowed_with_acl used to dereference the result of db.session.get() without
+    # a None check, so an ID that resolves to nothing raised AttributeError and
+    # the endpoint answered 500 instead of refusing the request.
+    monkeypatch.setattr("model.news_item.db.session", types.SimpleNamespace(get=lambda _cls, _id, **_kw: None))
+    nobody = cast("User", types.SimpleNamespace(id=1, username="alice"))
+    assert NewsItemData.allowed_with_acl("no-such-item", nobody, see=False, access=True, modify=False) is False

--- a/src/core/tests/test_login_redirect_safety.py
+++ b/src/core/tests/test_login_redirect_safety.py
@@ -1,0 +1,53 @@
+"""Redirect-flow exits must not become open redirects.
+
+`_login_error_redirect` and `_finish_redirect_login` are the two chokepoints
+every OIDC/OAuth2/SAML login passes through on its way back to the GUI. Most of
+their fifteen call sites hand them a goto_url read straight out of the stored
+auth transaction rather than one already passed through `_safe_goto_url`, so the
+check has to live in the helpers themselves.
+"""
+
+from __future__ import annotations
+
+import pytest
+from api import auth
+from flask import Flask
+
+EVIL = "https://evil.example/phish"
+
+
+@pytest.fixture
+def app() -> Flask:
+    return Flask(__name__)
+
+
+def _location(response: object) -> str:
+    return response.headers["Location"]
+
+
+def test_error_redirect_refuses_a_foreign_host(app: Flask) -> None:
+    with app.test_request_context("/", base_url="https://taranis.example"):
+        assert _location(auth._login_error_redirect(EVIL, "auth_failed")).startswith("/?login_error=")
+
+
+def test_error_redirect_keeps_a_same_origin_target(app: Flask) -> None:
+    with app.test_request_context("/", base_url="https://taranis.example"):
+        assert _location(auth._login_error_redirect("/v2/login", "auth_failed")) == "/v2/login?login_error=auth_failed"
+        absolute = _location(auth._login_error_redirect("https://taranis.example/v2/", "auth_failed"))
+        assert absolute.startswith("https://taranis.example/v2/?login_error=")
+
+
+@pytest.mark.parametrize("candidate", ["//evil.example/x", "/\\evil.example/x", "https://evil.example"])
+def test_protocol_relative_and_backslash_forms_are_refused(app: Flask, candidate: str) -> None:
+    # browsers normalize these to another origin, so a plain startswith("/") is not enough
+    with app.test_request_context("/", base_url="https://taranis.example"):
+        assert _location(auth._login_error_redirect(candidate, "auth_failed")).startswith("/?login_error=")
+
+
+def test_successful_redirect_login_refuses_a_foreign_host(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth.auth_transaction_manager, "create", lambda *_a, **_kw: "handle-1")
+    with app.test_request_context("/", base_url="https://taranis.example"):
+        response = auth._finish_redirect_login(EVIL, {"access_token": "t", "code": "OK"})
+    assert _location(response) == "/"
+    # the redemption cookie must not have been planted on the attacker's origin either
+    assert "evil.example" not in response.headers.get("Set-Cookie", "")

--- a/src/gui-v3/tests/e2e/assess-attachment-acl.spec.js
+++ b/src/gui-v3/tests/e2e/assess-attachment-acl.spec.js
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test'
+import { createApiContext, getFirstOSINTSourceId } from '../helpers/api-seed'
+
+/**
+ * Attachment download authorization (api/assess.py DownloadAttachment).
+ *
+ * The endpoint used to resolve `NewsItemAttribute.find(attribute_id)` globally
+ * and ignore the item_data_id in the URL entirely, so any user with
+ * ASSESS_ACCESS could read any group's attachment by guessing attribute IDs.
+ *
+ * The unit suite monkeypatches `allowed_with_acl`, so no test anywhere exercises
+ * the real ACL query. That is what this spec adds — plus the regression test for
+ * the unguarded db.session.get() that turned an unknown ID into a 500.
+ */
+
+const CORE_API = process.env.E2E_CORE_API || `http://127.0.0.1:${process.env.E2E_CORE_PORT || '8090'}/api/v1`
+
+test.describe('Attachment download authorization', () => {
+    let request
+    let token
+
+    test.beforeAll(async ({ playwright }) => {
+        ;({ request, token } = await createApiContext(playwright))
+    })
+
+    test.afterAll(async () => {
+        await request?.dispose()
+    })
+
+    const download = (itemDataId, attributeId) =>
+        request.post(`${CORE_API}/assess/news-item-data/${itemDataId}/attributes/${attributeId}/file`, {
+            headers: { Authorization: `Bearer ${token}` }
+        })
+
+    test('an unknown item-data id is refused, not a server error', async () => {
+        // allowed_with_acl dereferenced db.session.get() without a None check, so
+        // this raised AttributeError and the endpoint answered 500.
+        const response = await download('no-such-news-item-data', 1)
+        expect(response.status(), 'must not be a 5xx').toBeLessThan(500)
+        expect([401, 404]).toContain(response.status())
+    })
+
+    test('a bare attribute id does not yield a file on its own', async () => {
+        // The IDOR: an attribute that exists but does not belong to the named
+        // news item data must not be served.
+        const sourceId = await getFirstOSINTSourceId(request, token)
+        test.skip(!sourceId, 'no OSINT source available in this environment')
+
+        for (const attributeId of [1, 2, 3]) {
+            const response = await download('not-the-owning-item-data', attributeId)
+            expect(response.status(), `attribute ${attributeId} must not be served`).not.toBe(200)
+            expect(response.status()).toBeLessThan(500)
+        }
+    })
+
+    test('the endpoint still requires authentication', async ({ request: anonymous }) => {
+        const response = await anonymous.post(`${CORE_API}/assess/news-item-data/whatever/attributes/1/file`)
+        expect([401, 403, 422]).toContain(response.status())
+    })
+})


### PR DESCRIPTION
Three authorization defects in the same area.

**Attachment download ignored the item it was asked for**

- DownloadAttachment resolved NewsItemAttribute.find(attribute_id) — a global primary-key lookup — and never used the item_data_id from the URL, which was literally marked as an unused argument. No ACL was checked either.
- Any user with ASSESS_ACCESS could fetch any group's attachment by enumerating attribute IDs, across the OSINT source group boundary that separates tenants.
- Now resolved only within its owning news item data (mirroring ReportItem.find_attachment on the report side) and checked against the caller's ACL.
- NewsItemData.allowed_with_acl also gained a None guard — it dereferenced db.session.get() unchecked, so an unknown ID raised AttributeError and answered 500 instead of refusing.

**Login redirects were not all same-origin checked**

- _login_error_redirect and _finish_redirect_login are the chokepoints every OIDC/OAuth2/SAML flow returns through, with 15 call sites between them.
- Only some sanitized on the way in; the rest passed a goto_url read straight out of the stored auth transaction.
- Both now run it through _safe_goto_url themselves. It's idempotent, so re-checking costs nothing and no call site can forget.

**SAML metadata fetches followed redirects past their own guard**

- assert_public_url resolves the host and refuses non-global addresses — but it only ever sees the URL the administrator typed.
- Both metadata fetches then let requests follow a 302, so a public host could bounce the fetch to 169.254.169.254 and the document came straight back to the caller.
- Now allow_redirects=False plus a shared assert_no_redirect.