### PR TITLE
fix(presenters): sandbox the Jinja environment and make the suite runnable

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -131,12 +131,11 @@ point CI uses.
 
 ## Known gaps
 
-- **`src/presenters/tests` does not run.** The service directory is itself a package
-  (`src/presenters/__init__.py`) *and* contains an inner package of the same name
-  (`src/presenters/presenters/`), so pytest walks up to `src/` and
-  `import presenters.html_presenter` resolves to the service root, which has no such
-  module. Fixing it means dropping the service-root `__init__.py` or renaming the inner
-  package — a structural change, not a pytest setting.
+- **`src/presenters/tests` runs with a stubbed config.** The service reads its Docker
+  secret (`/run/secrets/api_key`) at import time, so `tests/conftest.py` injects a stub
+  `config` module before any application import — the same pattern `src/core/tests`
+  uses. `tests/__init__.py` is deliberately absent (matching core) so pytest imports the
+  test modules top-level instead of walking up to the service-root `__init__.py`.
 - **`src/bots`, `src/collectors`, `src/publishers` have no tests yet.** Add a `tests/`
   directory, then list the project in `PYTEST_SUITES` in `scripts/run_tests.py` and in
   `testpaths` in the root `pyproject.toml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ members = ["src/shared"]
 # scripts/run_tests.py instead runs pytest per project, picking up that project's own
 # [tool.pytest.ini_options]. Keep in sync with PYTEST_SUITES in scripts/run_tests.py.
 [tool.pytest.ini_options]
-testpaths = ["src/core/tests", "src/shared/tests", "src/public_web/tests"]
+testpaths = ["src/core/tests", "src/shared/tests", "src/presenters/tests", "src/public_web/tests"]
 # The projects are never pip-installed for a test run, so their roots go on sys.path.
 pythonpath = ["src/core", "src/shared"]
 

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -43,9 +43,9 @@ VENV_BIN = REPO_ROOT / ".venv" / "bin"
 GUI_DIR = REPO_ROOT / "src" / "gui-v3"
 
 # Projects with a pytest suite, as directories under src/. Keep in sync with `testpaths`
-# in the root pyproject.toml, which is what editors use. presenters is deliberately absent
-# and the other services have no tests yet - see "Known gaps" in docs/testing.md.
-PYTEST_SUITES: tuple[str, ...] = ("core", "shared", "public_web")
+# in the root pyproject.toml, which is what editors use. The other services have no
+# tests yet - see "Known gaps" in docs/testing.md.
+PYTEST_SUITES: tuple[str, ...] = ("core", "shared", "presenters", "public_web")
 
 DEFAULT_SUITES: tuple[str, ...] = ("pytest", "vitest", "ansible")
 ALL_SUITES: tuple[str, ...] = (*DEFAULT_SUITES, "e2e")

--- a/src/presenters/presenters/base_presenter.py
+++ b/src/presenters/presenters/base_presenter.py
@@ -20,6 +20,7 @@ from typing import ClassVar
 
 import jinja2
 from cvss import CVSS2, CVSS3, CVSS4
+from jinja2.sandbox import SandboxedEnvironment
 from shared.common import TZ
 from shared.log_manager import logger
 from shared.schema.presenter import PresenterSchema
@@ -474,18 +475,14 @@ class BasePresenter:
             ValueError: If a template path is outside allowed templates root.
         """
         if template_string:
-            env = jinja2.Environment(autoescape=False)  # noqa: S701 # safe for plaintext
+            env = SandboxedEnvironment(autoescape=False)  # safe for plaintext
             cls.load_filters(env)
             template = env.from_string(template_string)
         else:
             head, tail = cls.resolve_template_path(template_path)
-            env = jinja2.Environment(loader=jinja2.FileSystemLoader(head), autoescape=escape_html)  # noqa: S701
+            env = SandboxedEnvironment(loader=jinja2.FileSystemLoader(head), autoescape=escape_html)
             cls.load_filters(env)
             template = env.get_template(tail)
-        func_dict = {
-            "vars": vars,
-        }
-        template.globals.update(func_dict)
 
         if is_pdf:
             output_text = template.render(data=input_data)

--- a/src/presenters/tests/__init__.py
+++ b/src/presenters/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Presenter service tests."""

--- a/src/presenters/tests/conftest.py
+++ b/src/presenters/tests/conftest.py
@@ -1,0 +1,39 @@
+"""Pytest bootstrap for the presenters package.
+
+Importing the application packages reads the Docker secret ``/run/secrets/api_key``
+at import time (``config.Config``). Tests have no secrets, so a stub ``config``
+module is injected before any application import: every ``Config.<ATTR>``
+yields a throwaway string, which is all the import-time code requires. The
+core package's conftest does the same for the core service.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+# Make the service importable when the suite runs from the repo root (the
+# aggregate testpaths config) as well as from src/presenters: `presenters` then
+# resolves to the inner package at src/presenters/presenters. Appended, not
+# prepended, so a root-level pythonpath (src/core, src/shared) keeps priority
+# for any same-named top-level module.
+_SERVICE_ROOT = str(Path(__file__).resolve().parents[1])
+if _SERVICE_ROOT not in sys.path:
+    sys.path.append(_SERVICE_ROOT)
+
+if "config" not in sys.modules:
+
+    class _AnyConfig(type):
+        """Metaclass yielding a throwaway value for any Config attribute access."""
+
+        def __getattr__(cls, name: str) -> str:
+            return "test-value"
+
+    _module = types.ModuleType("config")
+
+    class Config(metaclass=_AnyConfig):
+        """Stub of ``config.Config`` for import-time use in tests."""
+
+    _module.Config = Config
+    sys.modules["config"] = _module

--- a/src/presenters/tests/test_jinja_sandbox.py
+++ b/src/presenters/tests/test_jinja_sandbox.py
@@ -1,0 +1,97 @@
+"""The presenter's Jinja environment must be sandboxed.
+
+Report templates are edited by users inside the GUI; news-item content flowing
+into them is attacker-controlled OSINT. A plain ``jinja2.Environment`` turns a
+malicious template into RCE on the presenter container. These tests pin the two
+properties that prevent it:
+
+1. ``SandboxedEnvironment`` blocks attribute/private-dunder escapes.
+2. The ``vars`` builtin (which used to be injected as a template global and
+   reaches the module namespace) is gone.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+from jinja2.exceptions import SecurityError, UndefinedError
+from jinja2.sandbox import SandboxedEnvironment
+from presenters.base_presenter import BasePresenter
+
+
+def _render(template_string: str) -> str:
+    output = BasePresenter.render_jinja({}, None, template_string=template_string)
+    return base64.b64decode(output).decode("UTF-8")
+
+
+def test_plain_template_string_still_renders() -> None:
+    assert _render("hello {{ 'wor' + 'ld' }}") == "hello world"
+
+
+def test_mro_walk_is_blocked() -> None:
+    with pytest.raises(SecurityError):
+        _render("{{ ''.__class__.__mro__ }}")
+
+
+def test_subclasses_escape_is_blocked() -> None:
+    with pytest.raises(SecurityError):
+        _render("{{ ''.__class__.__mro__[1].__subclasses__() }}")
+
+
+def test_attr_filter_escape_yields_nothing() -> None:
+    # the |attr() variant of the same climb must not hand out the MRO either:
+    # it renders empty (no escalation) rather than reachable classes.
+    assert _render("{{ ''|attr('__class__')|attr('__mro__') }}") == ""
+
+
+def test_vars_global_is_gone() -> None:
+    # `vars` used to expose the module namespace to the template; removed,
+    # it is now an undefined name - indexing it fails as undefined.
+    assert _render("{{ vars }}") == ""
+    with pytest.raises(UndefinedError):
+        _render("{{ vars['os'] }}")
+
+
+def test_template_path_is_confined_to_the_templates_root() -> None:
+    with TemporaryDirectory() as tmp:
+        outside = Path(tmp) / "outside.html"
+        outside.write_text("secret")
+        with pytest.raises(ValueError, match="outside the allowed templates directory"):
+            BasePresenter.render_jinja({}, str(outside))
+
+
+def test_custom_filters_still_registered() -> None:
+    assert _render("{{ '2026-08-28' | strfdate(fmtout='%Y/%m/%d') }}") == "2026/08/28"
+    assert _render("{{ none | strfdate }}") == ""
+
+
+def test_html_output_escapes_attacker_markup() -> None:
+    """SK-CERT#724: a report attribute must not carry script into the rendered HTML.
+
+    The pentest captured `test<script>alert(1)</script>test1` intact in a
+    text/html product. The HTML presenter renders with ``escape_html=True``
+    (``html_presenter.py:42``) and no shipped template uses ``|safe``, so the
+    payload comes back escaped. This pins that: autoescape is what stands
+    between OSINT content and stored XSS, and it is one keyword away from off.
+    """
+    payload = "test<script>alert(1)</script>test1"
+    env = SandboxedEnvironment(autoescape=True)
+    BasePresenter.load_filters(env)
+    rendered = env.from_string("<td>{{ data.v }}</td>").render(data={"v": payload})
+
+    assert "<script>" not in rendered
+    assert rendered == "<td>test&lt;script&gt;alert(1)&lt;/script&gt;test1</td>"
+
+
+def test_no_shipped_template_disables_escaping() -> None:
+    # a single `| safe` in a template would reopen SK-CERT#724 for that report
+    templates = Path(__file__).resolve().parents[1] / "templates"
+    offenders = [
+        path.relative_to(templates)
+        for path in templates.rglob("*.html")
+        if "|safe" in path.read_text(encoding="utf-8", errors="replace").replace(" ", "")
+    ]
+    assert not offenders, f"templates bypassing autoescape: {offenders}"


### PR DESCRIPTION
**Why**

BasePresenter.render_jinja built a plain jinja2.Environment and injected vars as a template global. Report templates are edited through the GUI and the data flowing into them is attacker-controlled OSINT content, so a plain environment turns {{ ''.__class__... }} style template injection into code execution inside the presenter container — and vars shortcuts several of the well-known escape chains by handing out a module namespace directly.

**What changed**

- Both environments (file-loaded and from_string) now use jinja2.sandbox.SandboxedEnvironment; the vars global is gone.
- Autoescape behaviour is unchanged: HTML and PDF render escaped, plaintext does not. Custom filters and template path confinement untouched.
- The sandbox is not a hard boundary against someone who can write arbitrary templates, so template editing should stay an admin capability. This removes the trivial primitives and the free escalation vars was handing out.

**The presenters suite had never run** — importing the application packages reads /run/secrets/api_key at import time and raises outside a container, which is why the project was deliberately absent from PYTEST_SUITES.

- tests/conftest.py injects a stub config module before any application import (the same recipe src/core/tests uses).
- tests/__init__.py dropped so pytest imports the test modules top-level.
- 27 tests now run, including two pre-existing modules that had been silently dead.

**Tests** — pin the escape payloads (__mro__ / __subclasses__ raise SecurityError, the |attr() variant yields nothing, vars is undefined), plus HTML output escaping and that no shipped template disables autoescape with |safe.