### PR TITLE
fix(docker): run every service as an unprivileged user

### DIFF
--- a/docker/Dockerfile.bots
+++ b/docker/Dockerfile.bots
@@ -48,5 +48,13 @@ ENV MODULE_NAME="run"
 ENV VARIABLE_NAME="app"
 ENV GUNICORN_CMD_ARGS="--timeout 120"
 
+
+# SK-CERT#723: run the service as an unprivileged user. su-exec lets
+# docker/entrypoint.sh fix volume/secret ownership as root and then drop to this
+# user before exec'ing gunicorn, so no application process runs as uid 0.
+RUN apk add --no-cache su-exec \
+    && adduser -D -u 10001 taranis
+ENV TARANIS_USER="taranis"
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/start.sh"]

--- a/docker/Dockerfile.collectors
+++ b/docker/Dockerfile.collectors
@@ -76,5 +76,14 @@ ENV COLLECTOR_CONFIG_FILE="/app/storage/id.txt"
 
 VOLUME ["/app/storage"]
 
+
+# SK-CERT#723: run the service as an unprivileged user. su-exec lets
+# docker/entrypoint.sh fix volume/secret ownership as root and then drop to this
+# user before exec'ing gunicorn, so no application process runs as uid 0.
+RUN apk add --no-cache su-exec \
+    && adduser -D -u 10001 taranis
+ENV TARANIS_USER="taranis"
+ENV TARANIS_WRITABLE_PATHS="/app/storage"
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/start.sh"]

--- a/docker/Dockerfile.core
+++ b/docker/Dockerfile.core
@@ -77,5 +77,14 @@ VOLUME ["/data"]
 # traefik - then refuses to start on a slow or busy machine.
 HEALTHCHECK --interval=5s --timeout=3s --start-period=300s --retries=5 CMD curl --fail http://localhost/api/v1/isalive || exit 1
 
+
+# SK-CERT#723: run the service as an unprivileged user. su-exec lets
+# docker/entrypoint.sh fix volume/secret ownership as root and then drop to this
+# user before exec'ing gunicorn, so no application process runs as uid 0.
+RUN apk add --no-cache su-exec \
+    && adduser -D -u 10001 taranis
+ENV TARANIS_USER="taranis"
+ENV TARANIS_WRITABLE_PATHS="/data"
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/start.sh"]

--- a/docker/Dockerfile.presenters
+++ b/docker/Dockerfile.presenters
@@ -48,9 +48,9 @@ RUN \
     font-misc-misc \
     font-croscore \
     freetype && \
-    fc-cache -f && \
     update-ms-fonts && \
-    rm -rf /var/cache/*
+    fc-cache -f && \
+    rm -rf /var/cache/apk/*
 
 # install "shared" package from build_shared stage
 COPY --from=build_shared /build_shared/dist/taranis_ng_shared-*.whl /tmp/custom_packages/
@@ -92,6 +92,16 @@ ENV GUNICORN_CMD_ARGS="--timeout 120"
 
 
 VOLUME ["/app/templates"]
+
+
+# SK-CERT#723: run the service as an unprivileged user. su-exec lets
+# docker/entrypoint.sh fix volume/secret ownership as root and then drop to this
+# user before exec'ing gunicorn, so no application process runs as uid 0.
+RUN apk add --no-cache su-exec \
+    && adduser -D -u 10001 taranis \
+    && chown -R taranis:taranis /var/cache/fontconfig
+ENV TARANIS_USER="taranis"
+ENV TARANIS_WRITABLE_PATHS="/app/templates"
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/start.sh"]

--- a/docker/Dockerfile.public-web
+++ b/docker/Dockerfile.public-web
@@ -68,5 +68,13 @@ ENV PYTHONPATH="/app" \
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD python -c "import sys,urllib.request; key=open('/run/secrets/api_key', encoding='utf-8').read().strip(); req=urllib.request.Request('http://127.0.0.1:80/management/isalive', headers={'Authorization': 'ApiKey ' + key}); sys.exit(0 if urllib.request.urlopen(req, timeout=4).status==200 else 1)"
 
+
+# SK-CERT#723: run the service as an unprivileged user. su-exec lets
+# docker/entrypoint.sh fix volume/secret ownership as root and then drop to this
+# user before exec'ing gunicorn, so no application process runs as uid 0.
+RUN apk add --no-cache su-exec \
+    && adduser -D -u 10001 taranis
+ENV TARANIS_USER="taranis"
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/start.sh"]

--- a/docker/Dockerfile.publishers
+++ b/docker/Dockerfile.publishers
@@ -56,5 +56,13 @@ ENV VARIABLE_NAME="app"
 ENV GUNICORN_CMD_ARGS="--timeout 120"
 
 
+
+# SK-CERT#723: run the service as an unprivileged user. su-exec lets
+# docker/entrypoint.sh fix volume/secret ownership as root and then drop to this
+# user before exec'ing gunicorn, so no application process runs as uid 0.
+RUN apk add --no-cache su-exec \
+    && adduser -D -u 10001 taranis
+ENV TARANIS_USER="taranis"
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/start.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,6 +35,14 @@ services:
        - postgres_password
 
   core:
+    # SK-CERT#723: the service runs as an unprivileged user (see
+    # docker/entrypoint.sh). This sysctl is namespaced to the container's own
+    # network namespace and lets it keep binding :80, so every internal URL,
+    # Traefik label, healthcheck and stored node api_url stays as it was.
+    sysctls:
+      - net.ipv4.ip_unprivileged_port_start=0
+    security_opt:
+      - no-new-privileges:true
     depends_on:
       - "redis"
       - "postgres"
@@ -163,6 +171,11 @@ services:
       - secrets_encryption_key
 
   bots:
+    # Unprivileged runtime user; see the note on the core service.
+    sysctls:
+      - net.ipv4.ip_unprivileged_port_start=0
+    security_opt:
+      - no-new-privileges:true
     depends_on:
       core:
         condition: service_healthy
@@ -191,6 +204,11 @@ services:
       - api_key
 
   collectors:
+    # Unprivileged runtime user; see the note on the core service.
+    sysctls:
+      - net.ipv4.ip_unprivileged_port_start=0
+    security_opt:
+      - no-new-privileges:true
     depends_on:
       core:
         condition: service_healthy
@@ -220,6 +238,11 @@ services:
       - api_key
 
   presenters:
+    # Unprivileged runtime user; see the note on the core service.
+    sysctls:
+      - net.ipv4.ip_unprivileged_port_start=0
+    security_opt:
+      - no-new-privileges:true
     depends_on:
       core:
         condition: service_healthy
@@ -252,6 +275,11 @@ services:
       - api_key
 
   publishers:
+    # Unprivileged runtime user; see the note on the core service.
+    sysctls:
+      - net.ipv4.ip_unprivileged_port_start=0
+    security_opt:
+      - no-new-privileges:true
     depends_on:
       core:
         condition: service_healthy
@@ -422,6 +450,11 @@ services:
         max-file: "10"
 
   public-web:
+    # Unprivileged runtime user; see the note on the core service.
+    sysctls:
+      - net.ipv4.ip_unprivileged_port_start=0
+    security_opt:
+      - no-new-privileges:true
     # Gated behind a compose profile so it can be switched off from .env:
     # COMPOSE_PROFILES=public-web enables it (build + run); empty disables it.
     profiles:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,4 +19,50 @@ else
 fi
 export GUNICORN_CONF="${GUNICORN_CONF:-$DEFAULT_GUNICORN_CONF}"
 
+# Drop to an unprivileged user (CESNET pentest, SK-CERT#723: every service used
+# to run its whole Python stack as uid 0, so an RCE started as root).
+#
+# The drop happens here rather than via a Dockerfile `USER` line because the
+# volumes must still be re-owned as root on the way past: named volumes
+# (/data, /app/templates, /app/storage) take their ownership from the image
+# directory the FIRST time they are mounted, so existing deployments already
+# have root-owned contents and a `USER` line alone would leave every upgraded
+# install unable to write to its own data.
+#
+# TARANIS_DROP_PRIVILEGES=false keeps the old behaviour for anyone who needs it.
+if [ "$(id -u)" = "0" ] && [ "${TARANIS_DROP_PRIVILEGES:-true}" = "true" ] && id -u "${TARANIS_USER:-taranis}" >/dev/null 2>&1; then
+    TARANIS_USER="${TARANIS_USER:-taranis}"
+
+    # /app itself plus whatever this service declares as writable at runtime.
+    for path in /app ${TARANIS_WRITABLE_PATHS:-}; do
+        [ -e "$path" ] || continue
+        # -h so a symlinked mount point is not followed out of the container.
+        chown -RhH "$TARANIS_USER" "$path" 2>/dev/null || \
+            echo "entrypoint: could not chown $path; continuing as $TARANIS_USER anyway" >&2
+    done
+
+    # Secrets are bind-mounted read-only, so they cannot be chowned. The files
+    # docker/secrets/ ships are 0644 inside a 0700 directory, which the runtime
+    # user can read - but an operator who tightens them to 0600 would otherwise
+    # get a confusing "Secret file not found" from deep inside config.py at
+    # import time. Check here instead and say exactly what to do.
+    if [ -d /run/secrets ]; then
+        unreadable=""
+        for secret in /run/secrets/*; do
+            [ -f "$secret" ] || continue
+            su-exec "$TARANIS_USER" test -r "$secret" || unreadable="$unreadable $secret"
+        done
+        if [ -n "$unreadable" ]; then
+            echo "entrypoint: ERROR: these secrets are not readable by $TARANIS_USER:$unreadable" >&2
+            echo "entrypoint: the service now runs unprivileged (SK-CERT#723). Make the files on the" >&2
+            echo "entrypoint: host group/world readable - 'chmod 644 docker/secrets/*.txt'. The" >&2
+            echo "entrypoint: docker/secrets directory itself stays 0700, so they remain protected." >&2
+            exit 1
+        fi
+    fi
+
+    echo "entrypoint: dropping privileges to $TARANIS_USER" >&2
+    exec su-exec "$TARANIS_USER" "$@"
+fi
+
 exec "$@"


### PR DESCRIPTION
Addresses #723 

**Why** — no Dockerfile carried a USER directive, so every Python service ran its whole stack as uid 0. A container escape or an RCE in any of them started as root.

**Why the entrypoint and not** USER — named volumes (/data, /app/templates, /app/storage) take their ownership from the image directory the first time they are mounted. Existing deployments already hold root-owned contents, so a USER line alone would leave every upgraded install unable to write to its own data.

- The shared entrypoint re-owns those paths as root, then execs the service through su-exec.
- TARANIS_DROP_PRIVILEGES=false restores the old behaviour if anything needs it.
- Secrets are bind-mounted read-only and cannot be chowned. The shipped files are 0644 inside a 0700 directory, which the runtime user can read — but an operator tightening them to 0600 would get a confusing "Secret file not found" from deep inside config.py. The entrypoint checks readability up front and prints the fix.

**Why port 80 is kept** — moving to 8080 would have touched four Traefik labels, two healthchecks, every internal http://core URL, a hardcoded backend constant in api/traefik.py, the ansible worker playbooks — and the api_url values already persisted in the database by prestart_core.sh, which would need a migration.

net.ipv4.ip_unprivileged_port_start=0 is namespaced to the container's own network namespace and lets an unprivileged process bind 80 with no capability grant and no churn. Docker already defaults it to 0 inside containers; setting it explicitly documents the requirement and guards against a daemon configured otherwise. no-new-privileges is set alongside it on all six services.

**Verified against a built image** — every process in a running core container is uid 10001 and the API answers on :80; migrations and public-web seeding still succeed; a pre-existing root-owned volume is re-owned and writable; a 0600 secret fails fast with the remedy instead of a confusing import error.