### PR TITLE
fix(core): do not log upload bodies, and never write NUL to the log

### DIFF
--- a/src/core/managers/log_manager.py
+++ b/src/core/managers/log_manager.py
@@ -117,6 +117,37 @@ def decrypt(enc_dict: str, password: str) -> str:
     return decrypted.decode("UTF-8")
 
 
+# Request bodies we are willing to log verbatim. Anything else - an upload, an
+# octet-stream - is summarised by _request_body_for_log instead of dumped.
+_TEXTUAL_MIMETYPES = frozenset({"", "application/json", "application/x-www-form-urlencoded", "text/plain"})
+
+
+def _request_body_for_log() -> bytes | str:
+    """Return something loggable for the current request body.
+
+    Only used when a caller passed no ``request_data`` of its own. A file upload
+    must never reach the log verbatim: the body is the file, so the record would
+    hold kilobytes of image bytes, and PostgreSQL rejects the insert outright
+    because a text column cannot contain NUL. Summarise those instead.
+
+    Note that the body is readable here at all only because ``auth_required``
+    calls ``get_json(force=True)``, which reads and caches it regardless of
+    content type.
+
+    Returns:
+        bytes | str: The raw body for textual requests, or a short summary.
+    """
+    if request.mimetype in _TEXTUAL_MIMETYPES:
+        return request.data
+
+    described = ""
+    try:
+        described = ", ".join(f"{field}={file.filename!r} ({file.mimetype})" for field, file in request.files.items())
+    except Exception:  # form parsing is best-effort; never break logging over it
+        described = ""
+    return f"<{request.mimetype or 'binary'} body, {request.content_length or 0} bytes{': ' + described if described else ''}>"
+
+
 def generate_escaped_data(request_data: dict) -> str:
     """Generate escaped data from the given request data.
 
@@ -136,7 +167,7 @@ def generate_escaped_data(request_data: dict) -> str:
         data (str): The generated escaped data.
     """
     if request_data is None:
-        request_data = request.data
+        request_data = _request_body_for_log()
 
     if request_data is None:
         return ""
@@ -285,7 +316,9 @@ def store_data_error_activity(user: User, activity_detail: str, exception: Excep
         request_data (dict, optional): The data associated with the request.
     """
     if exception:
-        logger.exception(f"{activity_detail}: {exception}")
+        # .error, not .exception: `exception` is a parameter here, not a caught
+        # exception, so .exception() would append a bogus "NoneType: None" traceback.
+        logger.error(f"{activity_detail}: {exception}")
     db.session.rollback()
     ip = resolve_ip_address()
     log_text = (
@@ -310,7 +343,9 @@ def store_data_error_activity_no_user(activity_detail: str, exception: Exception
         request_data (dict, optional): The data associated with the request.
     """
     if exception:
-        logger.exception(f"{activity_detail}: {exception}")
+        # .error, not .exception: `exception` is a parameter here, not a caught
+        # exception, so .exception() would append a bogus "NoneType: None" traceback.
+        logger.error(f"{activity_detail}: {exception}")
     db.session.rollback()
     ip = resolve_ip_address()
     log_text = (
@@ -341,7 +376,9 @@ def store_auth_error_activity(activity_detail: str, exception: Exception | None 
         request_data (dict, optional): The data associated with the request.
     """
     if exception:
-        logger.exception(f"{activity_detail}: {exception}")
+        # .error, not .exception: `exception` is a parameter here, not a caught
+        # exception, so .exception() would append a bogus "NoneType: None" traceback.
+        logger.error(f"{activity_detail}: {exception}")
     db.session.rollback()
     log_text = (
         f"TARANIS NG Auth Error (Method: {resolve_method()}, Resource: {resolve_resource()}, Activity Detail: {activity_detail}, "
@@ -371,7 +408,9 @@ def store_auth_warning_activity(activity_detail: str, exception: Exception | Non
         request_data (dict, optional): The data associated with the request.
     """
     if exception:
-        logger.exception(f"{activity_detail}: {exception}")
+        # .error, not .exception: `exception` is a parameter here, not a caught
+        # exception, so .exception() would append a bogus "NoneType: None" traceback.
+        logger.error(f"{activity_detail}: {exception}")
     db.session.rollback()
     log_text = (
         f"TARANIS NG Auth Warning (Method: {resolve_method()}, Resource: {resolve_resource()}, Activity Detail: {activity_detail}, "
@@ -460,6 +499,24 @@ def store_system_error_activity(
     store_record(ip, None, None, system_id, system_name, None, activity_type, activity_detail, request_data)
 
 
+def _no_nul(value: str | None) -> str | None:
+    r"""Strip NUL from a value bound for a text column.
+
+    PostgreSQL refuses ``\x00`` in text outright and fails the whole
+    transaction, so a log write can take down the request it was only meant to
+    record. Callers should keep binary out of here in the first place - see
+    :func:`_request_body_for_log` - and this is the last line of defence for
+    anything that still slips through.
+
+    Args:
+        value (str | None): The value about to be stored.
+
+    Returns:
+        str | None: The value without NUL bytes.
+    """
+    return value.replace("\x00", "") if isinstance(value, str) else value
+
+
 def store_record(
     ip_address: str,
     user_id: int,
@@ -496,7 +553,7 @@ def store_record(
         module_id,
         activity_type,
         resolve_resource(),
-        activity_detail,
+        _no_nul(activity_detail),
         resolve_method(),
-        generate_escaped_data(request_data),
+        _no_nul(generate_escaped_data(request_data)),
     )

--- a/src/core/tests/test_log_upload_bodies.py
+++ b/src/core/tests/test_log_upload_bodies.py
@@ -1,0 +1,63 @@
+"""A file upload must not put its bytes into the activity log.
+
+Uploading a public-web favicon took the whole request down with
+`psycopg.DataError: PostgreSQL text fields cannot contain NUL (0x00) bytes`.
+`auth_required` calls `get_json(force=True)`, which reads and caches the body
+whatever its content type; the log then fell back to `request.data` and tried to
+store the raw multipart payload — PNG bytes and all — in a text column.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from flask import Flask, request
+from managers.log_manager import _no_nul, generate_escaped_data
+
+PNG = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR" + b"\x00" * 40
+
+
+@pytest.fixture
+def app() -> Flask:
+    return Flask(__name__)
+
+
+def _upload() -> dict:
+    # a fresh stream per request: werkzeug consumes it while encoding
+    return {"file": (io.BytesIO(PNG), "favicon.ico", "image/x-icon")}
+
+
+def test_upload_body_is_summarised_not_dumped(app: Flask) -> None:
+    with app.test_request_context(
+        "/api/v1/config/public-web-nodes/1/webs/1/images/favicon",
+        method="POST",
+        data=_upload(),
+        content_type="multipart/form-data",
+    ):
+        request.get_json(force=True, silent=True)  # what auth_required does before logging
+        logged = generate_escaped_data(None)
+
+    assert "\x00" not in logged, "a NUL byte here makes PostgreSQL reject the whole insert"
+    assert "PNG" not in logged, "raw file bytes must not reach the log"
+    assert "IHDR" not in logged, "raw file bytes must not reach the log"
+    assert "multipart/form-data" in logged
+    # the record is still useful: it names what was uploaded
+    assert "favicon.ico" in logged
+
+
+def test_json_bodies_are_still_logged_and_redacted(app: Flask) -> None:
+    # the summary must not swallow the ordinary case the log exists for
+    body = b'{"username":"jarsvoboda","password":"hunter2"}'
+    with app.test_request_context("/api/v1/auth/login", method="POST", data=body, content_type="application/json"):
+        logged = generate_escaped_data(None)
+
+    assert "jarsvoboda" in logged
+    assert "hunter2" not in logged
+
+
+def test_nul_is_stripped_at_the_column_boundary() -> None:
+    # last line of defence: an audit record must never fail the operation it records
+    assert _no_nul("before\x00after") == "beforeafter"
+    assert _no_nul(None) is None
+    assert _no_nul(123) == 123


### PR DESCRIPTION
## The bug

Uploading a public-web image returned 500 and never saved:

```
POST /api/v1/config/public-web-nodes/1/webs/1/images/favicon -> 500
psycopg.DataError: PostgreSQL text fields cannot contain NUL (0x00) bytes
```

- `auth_required` calls `get_json(force=True)`, which reads and **caches** the body whatever its content type.
- For a multipart upload the parse yields nothing, so the activity log fell back to `request.data` — by then the whole cached payload, image bytes included.
- A text column cannot hold NUL, so the INSERT failed and took the upload with it.

An audit record must never be able to fail the operation it is recording.

## The fix

- `_request_body_for_log()` summarises non-textual bodies instead of dumping them:
  `<multipart/form-data body, 3128 bytes: file='favicon.ico' (image/x-icon)>`
- The record still names what was uploaded, without storing the file — which also keeps arbitrary uploaded content out of the log table.
- JSON and form bodies are logged and redacted exactly as before.
- `store_record` strips NUL from both text columns as a last line of defence.

## Notes

- **Predates the security work** — `main` hits the same `request.data` fallback and produces the same NUL bytes for this request.
- NUL guard sits in `log_manager.store_record`, not `model/log_record.py`: that file has 28 pre-existing ruff errors, so touching it would drag an unrelated cleanup into this PR.
- The four `logger.exception()` → `logger.error()` changes are the same pre-existing fix `sec/log-redaction` makes — ruff blocks any commit touching this file until they are resolved. Both branches make byte-identical edits, so they merge without conflict (verified).

## Tests

`test_log_upload_bodies.py` — upload body is summarised with no NUL and no image bytes, JSON bodies still redacted, NUL stripped at the column boundary.
