### PR TITLE
Firewall role: make the policy expressible, then describe it accurately

### DIFF
--- a/ansible/.ansible-lint
+++ b/ansible/.ansible-lint
@@ -4,8 +4,10 @@
 #
 #     cd ansible && ansible-lint --offline playbooks/ roles/
 #
-# CI runs exactly that; see the `ansible-checks` job in
-# .github/workflows/linting.yaml.
+# That exact command is what `scripts/run_tests.py --suite ansible` runs, after
+# populating the offline collections cache — and that entry point is what both
+# the ansible-tests pre-commit hook and the `ansible-checks` job in
+# .github/workflows/linting.yaml invoke, so local and CI runs cannot drift.
 
 profile: basic
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,17 +1,18 @@
 # Ansible deployment
 
-Taranis-NG ships two supported Ansible playbooks:
+Taranis-NG ships two deployment playbooks:
 
 - **`playbooks/site.yml`** — the default single-host install. Installs Docker
   Engine on the target host and brings up the all-in-one Compose stack
   (`docker/docker-compose.yml`). No operator customization required when run
   against the default `inventory/localhost.yml`.
 - **`playbooks/distribute-worker.yml`** — distributed (remote worker) install.
-  Deploys one or more worker containers (collectors/bots/presenters/publishers)
-  to each remote host over SSH, then registers every new node in Core. Runs only
-  against the worker groups defined in your `inventory/distributed.local.yml`.
+  Deploys one or more worker containers (collectors / bots / presenters /
+  publishers / public-web) to each remote host over SSH, then registers every
+  new node in Core. Runs against the worker groups defined in your
+  `inventory/distributed.local.yml`.
 
-Two more playbooks manage a worker after it is deployed:
+Three more playbooks operate on a host after it is deployed:
 
 - **`playbooks/worker-power.yml`** — stop, start or restart the worker
   containers on a remote host. Non-destructive and fully reversible; the Core
@@ -19,9 +20,12 @@ Two more playbooks manage a worker after it is deployed:
 - **`playbooks/worker-remove.yml`** — remove a worker deployment: delete its
   node rows from Core, then the containers, volumes, `/etc/taranis-ng` and the
   control-host copies of its API keys. Destructive; always pass `--limit`.
-- **`playbooks/firewall.yml`** — deny-by-default host firewall: allows inbound
-  tcp/22, tcp/80, tcp/443 and udp/443 only, outbound unrestricted. ufw on
-  Debian/Ubuntu, firewalld on the RedHat family.
+- **`playbooks/firewall.yml`** — deny-by-default host firewall: inbound is
+  denied except the ports you list, outbound is unrestricted. ufw on
+  Debian/Ubuntu, firewalld on the RedHat family. The role's own default opens
+  SSH and nothing else, so set the ports the host actually needs in its
+  `host_vars/<host>.yml` before running it — `host_vars/worker.example.yml`
+  has a worked example.
 
 See [`docs/distributed-deployment.md`](../docs/distributed-deployment.md) for
 the full distributed path (architecture, addressing & TLS, secrets,
@@ -39,8 +43,7 @@ python3 scripts/dev_setup.py --all
 
 Use that rather than a bare `uv sync --group ansible`: `uv sync` makes the
 environment match exactly the groups it is given, so naming `ansible` alone
-removes pytest, the service dependencies and `.venv/bin/uv` itself — and no
-other uv exists to run the command that would put it back.
+removes pytest, the service dependencies and `.venv/bin/uv` itself.
 
 Every command below is prefixed with `uv run --group ansible` so it uses that
 environment; drop the prefix if you have `.venv/bin` on your `PATH`.

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -38,6 +38,6 @@ timeout = 20
 retries = 3
 
 [privilege_escalation]
-# Both playbooks declare `become: true` per play; no global setting, so
+# Every playbook declares `become: true` per play; no global setting, so
 # delegate_to: localhost tasks do not sudo on the control host.
 become_method = sudo

--- a/ansible/inventory/README.md
+++ b/ansible/inventory/README.md
@@ -44,11 +44,12 @@ cp group_vars/all.example.yml            group_vars/all.yml
 cp group_vars/core.example.yml           group_vars/core.yml
 
 # Per-host overrides — REQUIRED one file per remote host (named after the
-# inventory hostname). Defines the worker_types list for that host.
-# Examples:
+# inventory hostname). Defines the worker_types list for that host, chosen from
+# collectors, bots, presenters, publishers and public-web. Examples:
 #   host_vars/collector-01.yml:    worker_types: ["collectors"]
 #   host_vars/worker-multi-01.yml: worker_types: ["collectors", "bots"]
 #   host_vars/worker-all-01.yml:   worker_types: ["collectors", "bots", "presenters", "publishers"]
+#   host_vars/feed-01.yml:         worker_types: ["public-web"]
 cp host_vars/worker.example.yml host_vars/collector-01.yml
 ```
 
@@ -67,10 +68,16 @@ worker_base_hostname: "worker-multi-01.example.org"
 ```
 
 On the host above, Ansible deploys:
-- `collectors` container → reachable at `https://collectors.worker-multi-01.example.org`
-- `bots` container → reachable at `https://bots.worker-multi-01.example.org`
+- `collectors` container → Core reaches it at
+  `https://collectors.worker-multi-01.example.org:8443`
+- `bots` container → Core reaches it at
+  `https://bots.worker-multi-01.example.org:8443`
 - ONE Traefik serving both, with per-type subdomain routing
 - ONE node row per worker_type registered in Core (so two rows: collectors + bots)
+
+The API lives on `worker_api_port` (8443), not 443, so a `public-web` host can
+publish 443 to the world while the API stays restrictable to the Core host. The
+names must still resolve publicly for ACME to validate them.
 
 ### Run
 
@@ -86,5 +93,8 @@ uv run --group ansible ansible-playbook -i inventory/distributed.local.yml \
   playbooks/distribute-worker.yml --limit worker-multi-01
 ```
 
-After editing, `git status` should report a clean working tree — all real
-inventory files are gitignored under the `*.yml` convention.
+After editing, `git status` should report a clean working tree: `.gitignore`
+ignores `group_vars/` and `host_vars/` wholesale and re-admits only the tracked
+`*.example.yml` templates, plus `inventory/*.local.yml` for the top-level
+inventory. Anything of yours that shows up there means the ignore rules missed
+it.

--- a/ansible/inventory/distributed.example.yml
+++ b/ansible/inventory/distributed.example.yml
@@ -8,11 +8,12 @@
 # Then run with `-i inventory/distributed.local.yml`.
 #
 # Each remote host in the [worker_hosts] group can run ONE OR MORE worker
-# types — set `worker_types` in that host's host_vars/<host>.yml.
-# Example host_vars entries:
+# types — set `worker_types` in that host's host_vars/<host>.yml, choosing from
+# collectors, bots, presenters, publishers and public-web. Example entries:
 #   worker_types: ["collectors"]                              # just collectors
 #   worker_types: ["collectors", "bots"]                      # collectors + bots on one host
 #   worker_types: ["collectors", "bots", "presenters", "publishers"]
+#   worker_types: ["public-web"]                              # a public report feed
 #
 # The [core] group is the machine running the all-in-one docker-compose stack.
 
@@ -28,7 +29,8 @@ all:
           # ansible_become_password: CHANGEME_SUDO_PASSWORD  # or use --ask-become-pass
 
     # Remote worker hosts — every host that should run one or more Taranis-NG
-    # worker containers (collectors / bots / presenters / publishers).
+    # worker containers (collectors / bots / presenters / publishers /
+    # public-web).
     # `worker_types` for each host is declared in its host_vars/<host>.yml.
     worker_hosts:
       hosts:

--- a/ansible/inventory/group_vars/all.example.yml
+++ b/ansible/inventory/group_vars/all.example.yml
@@ -20,11 +20,17 @@ taranis_ng_tag: "latest"
 # ---------------------------------------------------------------------------
 
 # Core's HTTPS Traefik URL, as reachable from the worker hosts. Required.
+# Port-less: node registration uses the config API on Core's 443.
 core_url: "https://CHANGEME_CORE_FQDN"
 
-# (bots only) Core SSE URL. Defaults to <core_url>/sse. Override only if your
-# Traefik routes /sse differently.
-core_sse_url: "{{ core_url }}/sse"
+# The port on the Core host serving the satellite traffic — /api/v1/{collectors,
+# bots,public-web}, /sse and /traefik/dynamic/node. Those prefixes are carved out
+# of Core's 443 router so this port can be restricted to worker hosts, and the
+# workers are pointed at <core_url>:<core_satellite_port> for them. Must match
+# TARANIS_NG_SATELLITE_PORT in the Core host's docker/.env, and Core only
+# publishes it once TARANIS_NG_SATELLITE_BIND / _BIND6 are widened there — they
+# are 127.0.0.1 and ::1 by default, so from off-host there is no listener.
+core_satellite_port: 8443
 
 # ---------------------------------------------------------------------------
 # Default worker TLS settings — can be overridden per-group or per-host.
@@ -44,21 +50,11 @@ worker_tls_mode: "selfsigned"
 # ---------------------------------------------------------------------------
 # ACME (used when worker_tls_mode == "acme")
 # ---------------------------------------------------------------------------
-# These are the SHARED DEFAULTS for every worker host — every var set here is
-# inherited by every host unless overridden in that host's
-# host_vars/<host>.yml (which wins via Ansible's precedence).
-#
-# Recommended pattern (DRY):
-#   - Put the ACME shape that's identical for every worker here (email,
-#     keytype, challenge type, caserver if using the same CA everywhere).
-#   - Per-host vars live in host_vars/<host>.yml and only override what
-#     actually differs (typically the EAB creds if each host uses a separate
-#     ACME account, or the caserver if a host uses a different CA).
-#
-# Alternative pattern (explicit per host):
-#   - Comment out every ACME var here and declare them all in every host's
-#     host_vars/<host>.yml. More verbose but each host is fully
-#   self-describing.
+# Shared defaults for every worker host: put the ACME shape that is identical
+# fleet-wide here (email, keytype, challenge, and the caserver when every host
+# uses the same CA), and override only what actually differs in that host's
+# host_vars/<host>.yml, which wins by Ansible's precedence. The usual per-host
+# difference is the EAB credential, when each host has its own ACME account.
 #
 # All values below are secrets/operator-specific — put real values only in
 # gitignored `group_vars/<group>.yml` or `host_vars/<host>.yml`, NEVER in

--- a/ansible/inventory/host_vars/worker.example.yml
+++ b/ansible/inventory/host_vars/worker.example.yml
@@ -11,18 +11,17 @@
 #
 #     cp host_vars/worker.example.yml host_vars/collector-01.yml
 #
-# Per-host vars OVERFLOW into group_vars/all.yml (which holds the
+# Anything not set here falls back to group_vars/all.yml (which holds the
 # shared shape: core_url, admin creds, ACME/EAB), so this file only sets the
 # things that genuinely vary per-host: which worker_types run here, the
-# host's public DNS base, and (if you don't want fail-closed behaviour) the
-# per-worker_type API keys.
+# host's public DNS base, and optionally the per-worker_type API keys.
 
 # ---------------------------------------------------------------------------
 # REQUIRED: which Taranis-NG worker containers run on this host.
 # ---------------------------------------------------------------------------
-# A list. Each entry must be one of: collectors, bots, presenters, publishers.
-# The play brings up ONE Traefik on this host fronting ALL the worker_types
-# listed here, with per-type subdomain routing
+# A list. Each entry must be one of: collectors, bots, presenters, publishers,
+# public-web. The play brings up ONE Traefik on this host fronting ALL the
+# worker_types listed here, with per-type subdomain routing
 # (<type>.<worker_base_hostname>) — so Core reaches each worker_type at its
 # own FQDN and (in ACME mode) each gets its own cert via the router's Host().
 #
@@ -33,6 +32,11 @@
 #                  "bots",
 #                  "presenters",
 #                  "publishers"]                                  # full worker stack on one host
+#   worker_types: ["public-web"]                                  # a public report feed
+#
+# public-web is the odd one out: the other types are private endpoints only Core
+# calls, while a public web serves the internet on its own hostnames, so that
+# host publishes 443 to the world as well as the Core-only API port.
 worker_types: ["collectors"]
 
 # ---------------------------------------------------------------------------
@@ -43,55 +47,34 @@ worker_types: ["collectors"]
 # e.g. worker_base_hostname: "taranis1.example.org"
 #      → collectors.taranis1.example.org, bots.taranis1.example.org, ...
 #
+# Core dials those names on worker_api_port (8443), not 443, so the registered
+# api_url is https://<type>.<worker_base_hostname>:8443. The name still has to
+# resolve publicly for ACME to validate it — DNS records carry no port.
+#
 # This is DECOUPLED from where Ansible SSH's into (`ansible_host` in your
-# distributed.local.yml inventory). Two common patterns:
+# distributed.local.yml inventory), so it is whatever public DNS name you have
+# configured — set it to the PARENT domain of the per-type subdomains:
 #
-# ----------
-# Pattern A — VM hostname == public API hostname
-#   The VM IS the public FQDN; no extra prefix.
+#   inventory key `collectors.example.org` (the VM is already the public FQDN)
+#     → worker_base_hostname: "example.org"
+#     → collectors API at https://collectors.example.org:8443
 #
-#   # distributed.local.yml
-#   worker_hosts:
-#     hosts:
-#       collectors.example.org:
-#         ansible_host: collectors.example.org   # SSH target == public FQDN
-#         ansible_user: ops
+#   inventory key `taranis1` (a short VM name, ansible_host taranis1.example.org)
+#     → worker_base_hostname: "taranis1.example.org"
+#     → collectors API at https://collectors.taranis1.example.org:8443
+#     → bots API at       https://bots.taranis1.example.org:8443
 #
-#   # host_vars/collectors.example.org.yml
-#   worker_types: ["collectors"]
-#   worker_base_hostname: "example.org"
-#   # → collectors API at https://collectors.example.org   ✓ exact match
+# ⚠ SET THIS. The role's default is `{{ inventory_hostname }}`, so an inventory
+# key that is already a worker's public FQDN yields
+# `collectors.collectors.example.org`: DNS won't resolve it, the certificate
+# won't match it, and Core registers a node it can never reach. The role asserts
+# on this, but set the parent domain here and be done with it.
 #
-# ----------
-# Pattern B — VM hostname ≠ public API hostname
-#   The VM is named "taranis1", but the API is exposed under a subdomain.
+# docs/distributed-deployment.md has both patterns spelled out in full.
 #
-#   # distributed.local.yml
-#   worker_hosts:
-#     hosts:
-#       taranis1:                                       # inventory key — any string
-#         ansible_host: taranis1.example.org             # SSH target (the VM)
-#         ansible_user: ops
-#
-#   # host_vars/taranis1.yml   (filename matches inventory key "taranis1")
-#   worker_types: ["collectors", "bots"]
-#   worker_base_hostname: "taranis1.example.org"
-#   # → collectors API at https://collectors.taranis1.example.org   ✓
-#   # → bots API at       https://bots.taranis1.example.org         ✓
-#   # (Cert SANs match these — Traefik requests them via the Host() labels.)
-# ----------
-#
-# ⚠ SET THIS. The role's default is `{{ inventory_hostname }}`, and the FQDN is
-# built as <type>.<worker_base_hostname>. So if your inventory key is already a
-# worker's public FQDN — the Pattern A case above, `collectors.example.org`
-# — leaving the default in place produces
-# `collectors.collectors.example.org`: DNS won't resolve it, the
-# certificate won't match it, and Core registers a node it can never reach.
-# The role asserts on this, but set the parent domain here and be done with it.
-#
-# Pattern A (inventory key is the worker FQDN)  → the PARENT domain:
+# Inventory key is already the worker FQDN → the PARENT domain:
 worker_base_hostname: "example.org"
-# Pattern B (inventory key is a short VM name)  → the VM's own domain:
+# Inventory key is a short VM name → that VM's own domain:
 # worker_base_hostname: "taranis1.example.org"
 
 # ---------------------------------------------------------------------------
@@ -148,44 +131,105 @@ worker_api_keys: {}
 # OPTIONAL: host firewall (taranis-ng-firewall, via playbooks/firewall.yml).
 # ---------------------------------------------------------------------------
 # Set these HERE, per host, rather than editing the role defaults - a role
-# default is the whole fleet's default, so changing it there to suit one worker
-# changes every worker.
+# default is the whole fleet's.
 #
-# READ THIS FIRST, because the answer differs per address family and the usual
-# "Docker bypasses your firewall" is only half of it:
+# What a rule here can actually do to a Docker-published port depends on the
+# address family. Over IPv4 it does nothing: Docker DNATs in nat/PREROUTING and
+# filters in filter/FORWARD, which never traverses the filter/INPUT chain ufw and
+# firewalld write to. Over IPv6 it does everything: Docker leaves ip6tables
+# management off, so docker-proxy takes that traffic through INPUT like any host
+# service, and a published port missing from these lists is dropped - reachable
+# over v4, timing out over v6. Giving such a port a source of "::/0" opens it for
+# v6 only, which is exactly what is in this role's power to grant. Narrowing a
+# port over IPv4 needs a DOCKER-USER rule or worker_api_bind (bottom of file).
 #
-#   IPv4 - bypasses these rules. Docker writes DNAT into nat/PREROUTING and filter
-#          rules into its own chain in filter/FORWARD; ufw and firewalld write to
-#          filter/INPUT, which that traffic never traverses. Listing a published
-#          port here buys nothing on v4.
-#   IPv6 - does NOT bypass them. Docker ships with ip6tables management off, so
-#          there is no v6 DNAT: the userland docker-proxy listens in the HOST
-#          namespace and the traffic goes through INPUT like any host service. A
-#          published port missing from this list is therefore reachable over v4
-#          and dropped over v6 - and dropped, not refused, so it times out and
-#          looks like a routing fault.
+# Two things that surprise people:
 #
-# The worker role already opens 80, 443 and worker_api_port itself for that
-# reason, so you do not need them here. What this list governs is traffic
-# terminating on the host - sshd above all.
+# 1. The role only ADDS rules. ufw and firewalld take the first matching rule, so
+#    a blanket "allow 8443" from an earlier run sits in front of a source-
+#    restricted 8443 written here and silently cancels it. Set firewall_reset:
+#    true on a host whose policy this role owns end to end; ufw is disabled while
+#    it resets, so nothing is filtered until the allow rules are back.
 #
-# To restrict a published port over IPv4, bind it to one address
-# (worker_api_bind below) or add rules to Docker's DOCKER-USER chain, which is
-# traversed before Docker's own and which Docker never flushes. Over IPv6, a
-# source restriction in this role is effective on its own.
+# 2. taranis-ng-worker opens 80, 443 and worker_api_port itself - unrestricted,
+#    on both families - but only `when` ufw is ALREADY active. So on the first
+#    firewall.yml run those ports are closed on IPv6 until the next
+#    distribute-worker.yml, and after that every worker deploy re-adds the
+#    blanket rules over anything narrower set here. Set worker_open_firewall:
+#    false and list the ports below, so one role owns the policy.
 #
-# firewall_allowed_tcp_ports: [22]        # host services only; 22 must stay
+# -- The variables ----------------------------------------------------------
+#
+# Ports opened to everyone, on both families. A port listed here must NOT also
+# appear in a restricted list below: both emit ALLOW rules, the blanket one wins,
+# and the restriction becomes inert.
+# firewall_allowed_tcp_ports: [22]
 # firewall_allowed_udp_ports: []
 #
-# Source-restricted host ports. Same caveat: effective for host services,
-# NOT for Docker-published ones.
+# Ports opened only to named sources. ONE ADDRESS PER LIST ENTRY: the role
+# expands these with subelements() into a rule per (port, source) pair, because
+# ufw takes a single address per rule and rejects a comma-joined string as a bad
+# address, failing the play before any policy is applied.
 # firewall_restricted_tcp_ports:
-#   - port: 9100                         # e.g. a node_exporter run on the host
+#   - port: 9100                          # e.g. a node_exporter on the host
 #     sources: ["198.51.100.10"]
+# firewall_restricted_udp_ports:
+#   - port: 443
+#     sources: ["::/0"]
 #
-# Address the worker API port is published on. The default binds every
-# interface, which leaves the API reachable from anywhere - authentication is
-# then its only protection. Set the host's private/VPN address when Core
-# reaches it that way, and the port stops being world-visible without needing
-# any firewall rule at all.
+# Discard the existing ruleset first, so this file is the whole policy and not a
+# delta on whatever the host already had. See point 1 above.
+# firewall_reset: true
+#
+# Leave the ufw rules to taranis-ng-firewall alone. See point 2 above.
+# worker_open_firewall: false
+#
+# The role refuses to run unless the SSH port is in firewall_allowed_tcp_ports,
+# so a deny-by-default policy cannot end the session applying it. Source-
+# restricting SSH means dropping 22 from that list, which needs the guard off.
+# Do that only with console access, and only once the host you run Ansible from
+# is among the port 22 sources: ufw permits established connections, so the run
+# itself always succeeds and the lockout appears at the NEXT login.
+# firewall_guard_ssh: false
+#
+# -- A worked example -------------------------------------------------------
+#
+# A worker running public-web, with SSH restricted to a management range and the
+# API restricted to Core. Everything is v6-only except SSH, which is a real host
+# service rather than a container and so binds on both families:
+#
+# firewall_reset: true
+# worker_open_firewall: false
+# firewall_guard_ssh: false
+# firewall_allowed_tcp_ports: []
+# firewall_allowed_udp_ports: []
+# firewall_restricted_tcp_ports:
+#   - port: 80                            # ACME HTTP-01, for every hostname on
+#     sources: ["::/0"]                   #   this host - see the note below
+#   - port: 443                           # public-web serves the internet
+#     sources: ["::/0"]
+#   - port: 8443                          # worker_api_port: Core is its only
+#     sources: ["2001:db8:1::10"]         #   legitimate caller
+#   - port: 22
+#     sources:
+#       - "198.51.100.10"
+#       - "2001:db8:2::/64"
+# firewall_restricted_udp_ports:
+#   - port: 443                           # HTTP/3; Traefik advertises h3
+#     sources: ["::/0"]
+#
+# 80 is load-bearing and must stay reachable: the CA validates every hostname
+# there, INCLUDING hostnames whose router lives on the API port, so a closed 80
+# breaks renewal about thirty days later rather than immediately.
+#
+# ---------------------------------------------------------------------------
+# OPTIONAL: where the worker API port is published.
+# ---------------------------------------------------------------------------
+# The default binds every interface, which leaves the API reachable from
+# anywhere - the ApiKey on every endpoint is then its only protection. Set the
+# host's private or VPN address when Core reaches it that way and the listener
+# exists only there, which Docker does honour and which needs no firewall rule.
+#
+# It cannot help when Core reaches the worker across the public internet: there
+# is no private address to bind to. Use DOCKER-USER there instead.
 # worker_api_bind: "10.0.0.5"

--- a/ansible/playbooks/distribute-worker.yml
+++ b/ansible/playbooks/distribute-worker.yml
@@ -2,10 +2,12 @@
 # distribute-worker.yml — deploy Taranis-NG worker container(s) to remote
 # host(s) over SSH and register each one as a node in Core.
 #
-# Each remote host can run ONE OR MORE worker types — set `worker_types` in
-# that host's `host_vars/<host>.yml`. The play brings up ONE Traefik
-# per host fronting ALL the worker_types on that host, with per-type
-# subdomain routing (e.g. collectors.hostA.example.com, bots.hostA.example.com).
+# Each remote host can run ONE OR MORE worker types (collectors, bots,
+# presenters, publishers, public-web) — set `worker_types` in that host's
+# `host_vars/<host>.yml`. The play brings up ONE Traefik per host fronting ALL
+# the worker_types on that host, with per-type subdomain routing (e.g.
+# collectors.hostA.example.com, bots.hostA.example.com), served on
+# worker_api_port.
 #
 # Run the playbook against the worker_hosts group defined in your
 # distributed.local.yml inventory:
@@ -60,6 +62,7 @@
               worker_types: ["collectors"]
               worker_types: ["collectors", "bots"]
               worker_types: ["collectors", "bots", "presenters", "publishers"]
+              worker_types: ["public-web"]
 
     # A group_vars/host_vars file whose name does not exactly match the group or
     # host is never loaded, and the failure is otherwise silent — every value

--- a/ansible/playbooks/firewall.yml
+++ b/ansible/playbooks/firewall.yml
@@ -1,10 +1,16 @@
 ---
-# firewall.yml — deny all inbound traffic on a host except SSH, HTTP and HTTPS.
+# firewall.yml — deny-by-default inbound host firewall.
 #
-# Opens tcp/22, tcp/80, tcp/443 and udp/443; denies everything else inbound;
-# leaves outbound unrestricted. ufw on Debian/Ubuntu, firewalld on the RedHat
-# family. Allow rules are always applied before the deny policy, so the SSH
-# session Ansible is running over is never cut.
+# Opens the ports listed in firewall_allowed_tcp_ports / _udp_ports (plus the
+# source-restricted ones), denies everything else inbound and leaves outbound
+# unrestricted. ufw on Debian/Ubuntu, firewalld on the RedHat family. Allow
+# rules are always applied before the deny policy, so the SSH session Ansible is
+# running over is never cut.
+#
+# The role default opens SSH and nothing else. A worker host needs 80, 443 and
+# worker_api_port on top of that — set them per host in host_vars/<host>.yml
+# (see host_vars/worker.example.yml for a worked example), not in the role
+# defaults, which are the whole fleet's.
 #
 #   cd ansible
 #
@@ -26,11 +32,13 @@
 #   -e '{"firewall_allowed_tcp_ports": [22, 80, 443, 9090]}'   extra port
 #   -e firewall_enable=false                                    stage without enabling
 #
-# NOTE: Docker publishes container ports past both ufw and firewalld. The
-# worker stack publishes only 80 and 443, which this policy opens anyway, so
-# nothing is currently exposed beyond it — but a container published on another
-# port later would be reachable regardless of these rules. The play prints the
-# published ports at the end so that stays visible.
+# NOTE: over IPv4, Docker publishes container ports past both ufw and
+# firewalld — the worker's 80, 443 and worker_api_port are reachable whatever
+# this policy says. Over IPv6 they are not: Docker leaves ip6tables management
+# off, so that traffic traverses INPUT like any host service and a port missing
+# from the lists above is dropped. The play prints the published ports at the
+# end so the v4 gap stays visible; see the taranis-ng-firewall role defaults for
+# the full reasoning.
 
 - name: "Enable a deny-by-default host firewall"
   hosts: "{{ firewall_hosts | default('worker_hosts') }}"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -18,7 +18,8 @@ collections:
   # selfsigned.
   - name: community.crypto
     version: ">=2.0.0"
-  # ufw, for opening 80/443 on Debian-family worker hosts.
+  # ufw, used by taranis-ng-worker to open the worker's ports and by
+  # taranis-ng-firewall for the whole host policy, on Debian-family hosts.
   - name: community.general
     version: ">=7.0.0"
   # firewalld, for the same on the RedHat family.

--- a/ansible/roles/taranis-ng-firewall/defaults/main.yml
+++ b/ansible/roles/taranis-ng-firewall/defaults/main.yml
@@ -5,15 +5,18 @@
 # open ports. Outbound is left open because workers must reach Core, the ACME
 # CA and whatever OSINT sources they collect from.
 
-# Inbound TCP ports left open:
-#   22   SSH — Ansible's own transport. Dropping it from this list makes the
-#        role refuse to run; see firewall_guard_ssh below.
-#   80   HTTP — ACME HTTP-01 validation and Traefik's http→https redirect.
-#   443  HTTPS — the worker API Core calls.
+# Inbound TCP ports opened to everyone. SSH only by default — dropping it from
+# this list makes the role refuse to run; see firewall_guard_ssh below.
 #
-# 80 is load-bearing for ACME HTTP-01: the CA validates every hostname there,
-# INCLUDING hostnames whose router lives on the restricted API port below, and a
-# closed 80 breaks renewal about thirty days later rather than immediately.
+# A worker host also needs 80 (ACME HTTP-01 and Traefik's http→https redirect),
+# 443 (a public-web's own hostnames) and worker_api_port. Add them per host in
+# host_vars/<host>.yml, blanket here or source-restricted below — a role default
+# is the whole fleet's default.
+#
+# 80 is load-bearing for ACME HTTP-01 wherever certificates are issued: the CA
+# validates every hostname there, INCLUDING hostnames whose router lives on the
+# restricted API port below, and a closed 80 breaks renewal about thirty days
+# later rather than immediately.
 firewall_allowed_tcp_ports: [22]
 
 # Inbound TCP ports open only to specific sources. Each entry is a port plus the
@@ -28,11 +31,28 @@ firewall_allowed_tcp_ports: [22]
 # filter - so the API is on its own port (taranis-ng-worker: worker_api_port) and
 # admitted from the Core host alone. Ports listed here must NOT also appear in
 # firewall_allowed_tcp_ports, which would open them to everyone.
+#
+# A source of "::/0" is the useful special case on a Docker host: it opens the
+# port for IPv6 only. IPv4 reaches a published container through nat/PREROUTING
+# and FORWARD without ever traversing INPUT, so a v4 rule here grants nothing to
+# the container and only ever exposes a HOST process that later binds the port.
+# IPv6 has no DNAT (Docker leaves ip6tables management off), goes through the
+# userland proxy in the host namespace, and does traverse INPUT - so v6 is the
+# only family for which the rule does any work.
 firewall_restricted_tcp_ports: []
 
-# Inbound UDP ports left open:
-#   443  HTTP/3. The worker's Traefik advertises h3 and publishes 443/udp.
+# Inbound UDP ports opened to everyone. Empty by default; a worker host serving
+# a public web wants 443 here or below, since its Traefik advertises h3 and
+# publishes 443/udp.
 firewall_allowed_udp_ports: []
+
+# Inbound UDP ports open only to specific sources. Identical shape and identical
+# reasoning to firewall_restricted_tcp_ports above, including the "::/0" case:
+#
+#   firewall_restricted_udp_ports:
+#     - port: 443
+#       sources: ["::/0"]
+firewall_restricted_udp_ports: []
 
 # The SSH port to protect against lock-out. Follows ansible_port when the
 # inventory sets a non-standard one, so the guard in tasks/main.yml checks the
@@ -47,6 +67,25 @@ firewall_guard_ssh: true
 # Switch the firewall on at the end. Set false to install the rules and leave
 # the firewall inactive — useful for staging a policy before committing to it.
 firewall_enable: true
+
+# Discard the existing ruleset before writing this one.
+#
+# The tasks below only ADD rules; nothing here removes one. On a host with no
+# prior rules that is the same thing as a declarative policy, but on a host that
+# already has some it is not: a stale allow rule survives, and because ufw and
+# firewalld both take the first matching rule, a leftover blanket "allow 8443"
+# silently overrides a source-restricted 8443 added here. The deny-by-default
+# target never sees that traffic. So the role's contract — "only these ports,
+# only from these sources" — holds only when the ruleset started empty or this
+# is true.
+#
+# Left false because a reset also discards rules someone added deliberately and
+# outside this role. Turn it on for a host whose policy this role owns
+# end-to-end, which is the normal case for a Taranis worker.
+#
+# It is not a lock-out risk in itself: ufw is disabled while reset, so nothing
+# is filtered until the allow rules are back and `ufw enable` runs at the end.
+firewall_reset: false
 
 # firewalld zone (RedHat family only). Ignored on Debian/Ubuntu, which uses ufw.
 firewall_zone: public

--- a/ansible/roles/taranis-ng-firewall/tasks/debian.yml
+++ b/ansible/roles/taranis-ng-firewall/tasks/debian.yml
@@ -30,6 +30,15 @@
 - name: "Apply the ufw policy"
   when: firewall_ufw_binary.stat.exists or not ansible_check_mode
   block:
+    # Everything below only adds rules, so without this a previously-added
+    # blanket rule outlives the run and overrides a narrower one written here.
+    # `reset` disables ufw first, so the session applying the policy is not
+    # filtered in the gap between the wipe and `ufw enable` at the end.
+    - name: "Discard the existing ruleset"
+      community.general.ufw:
+        state: reset
+      when: firewall_reset | bool
+
     - name: "Allow inbound TCP ports"
       community.general.ufw:
         rule: allow
@@ -53,6 +62,16 @@
         proto: tcp
         src: "{{ item.1 }}"
       loop: "{{ firewall_restricted_tcp_ports | subelements('sources') }}"
+      loop_control:
+        label: "{{ item.0.port }} from {{ item.1 }}"
+
+    - name: "Allow restricted inbound UDP ports from their permitted sources only"
+      community.general.ufw:
+        rule: allow
+        port: "{{ item.0.port }}"
+        proto: udp
+        src: "{{ item.1 }}"
+      loop: "{{ firewall_restricted_udp_ports | subelements('sources') }}"
       loop_control:
         label: "{{ item.0.port }} from {{ item.1 }}"
 

--- a/ansible/roles/taranis-ng-firewall/tasks/main.yml
+++ b/ansible/roles/taranis-ng-firewall/tasks/main.yml
@@ -6,14 +6,19 @@
 # rules are written BEFORE the deny policy takes effect, so the SSH session
 # Ansible is running over is never cut.
 #
-# ── Docker publishes past the firewall ──────────────────────────────────────
-# Docker inserts its own iptables rules ahead of ufw's, and container ports
-# published with `-p` are therefore reachable whatever ufw says. The same is
-# broadly true of firewalld. The worker stack publishes only 80, 443/tcp and
-# 443/udp — exactly the ports this role opens anyway — so today nothing is
-# exposed beyond the policy. But publishing another container port later WILL
-# make it reachable from the internet regardless of these rules. The final task
-# prints what is currently published so the gap is visible rather than assumed.
+# ── Docker publishes past the firewall, but only over IPv4 ──────────────────
+# Docker DNATs a published port in nat/PREROUTING and filters it in its own
+# chain in filter/FORWARD; ufw and firewalld write to filter/INPUT, which that
+# traffic never traverses. So the worker's 80, 443/tcp, 443/udp and
+# worker_api_port stay reachable over IPv4 whatever this policy says — narrowing
+# them there needs a DOCKER-USER rule or worker_api_bind.
+#
+# Over IPv6 the opposite holds: Docker ships with ip6tables management off, so
+# there is no v6 DNAT and docker-proxy takes the traffic through INPUT like any
+# host service. A published port missing from the lists here is therefore
+# reachable on v4 and dropped on v6 — a timeout that reads like a routing fault.
+# The final task prints what is currently published so the v4 gap is visible
+# rather than assumed.
 
 - name: "Refuse to lock ourselves out of SSH"
   ansible.builtin.assert:
@@ -52,11 +57,23 @@
   # skipped, it would report "none" while ports are in fact published.
   check_mode: false
 
+# Summarised separately so the report below can name the source-restricted ports
+# too: with only the blanket lists in it, a policy built out of restricted
+# entries reported itself as far tighter than it actually is.
+- name: "Summarise the source-restricted ports"
+  ansible.builtin.set_fact:
+    firewall_restricted_summary: >-
+      {{ (firewall_restricted_tcp_ports | map(attribute='port') | map('regex_replace', '^', 'tcp/') | list)
+      + (firewall_restricted_udp_ports | map(attribute='port') | map('regex_replace', '^', 'udp/') | list) }}
+
 - name: "Report the policy and the container ports that bypass it"
   ansible.builtin.debug:
     msg: >-
       {{ inventory_hostname }}: inbound denied except
-      tcp/{{ firewall_allowed_tcp_ports | join(',') }} and
-      udp/{{ firewall_allowed_udp_ports | join(',') }}; outbound unrestricted.
-      Container ports published past the firewall:
+      tcp/{{ firewall_allowed_tcp_ports | join(',') | default('none', true) }},
+      udp/{{ firewall_allowed_udp_ports | join(',') | default('none', true) }}
+      from anywhere, plus
+      {{ firewall_restricted_summary | join(',') | default('nothing', true) }}
+      from named sources only; outbound unrestricted.
+      Container ports published past the firewall over IPv4:
       {{ firewall_published_ports.stdout_lines | default([]) | join(' | ') | default('none', true) }}

--- a/ansible/roles/taranis-ng-firewall/tasks/redhat.yml
+++ b/ansible/roles/taranis-ng-firewall/tasks/redhat.yml
@@ -33,6 +33,38 @@
         state: "{{ 'started' if firewall_enable | bool else 'stopped' }}"
         enabled: "{{ firewall_enable | bool }}"
 
+    # See the equivalent note in debian.yml. firewalld has no single reset, so
+    # the zone's existing ports and rich rules are enumerated and removed. The
+    # service entries are stripped further down for every run, reset or not.
+    - name: "List the ports and rich rules already in the zone"
+      ansible.builtin.command: "firewall-cmd --permanent --zone={{ firewall_zone }} --list-{{ item }}"
+      register: firewall_zone_existing
+      changed_when: false
+      loop:
+        - ports
+        - rich-rules
+      when: firewall_reset | bool
+
+    - name: "Discard the existing ports"
+      ansible.posix.firewalld:
+        zone: "{{ firewall_zone }}"
+        port: "{{ item }}"
+        permanent: true
+        immediate: "{{ firewall_enable | bool }}"
+        state: disabled
+      loop: "{{ firewall_zone_existing.results[0].stdout.split() | default([], true) }}"
+      when: firewall_reset | bool
+
+    - name: "Discard the existing rich rules"
+      ansible.posix.firewalld:
+        zone: "{{ firewall_zone }}"
+        rich_rule: "{{ item }}"
+        permanent: true
+        immediate: "{{ firewall_enable | bool }}"
+        state: disabled
+      loop: "{{ firewall_zone_existing.results[1].stdout_lines | default([], true) }}"
+      when: firewall_reset | bool
+
     - name: "Allow inbound TCP ports"
       ansible.posix.firewalld:
         zone: "{{ firewall_zone }}"
@@ -53,14 +85,36 @@
 
     # A rich rule rather than a plain port: firewalld's `port:` has no source, so
     # it would open the port to the whole zone. One rule per (port, source) pair.
+    #
+    # `family` is derived from the address rather than fixed: firewalld rejects a
+    # rich rule whose family does not match its source, so a hardcoded ipv4 makes
+    # every IPv6 source a hard failure. A colon appears in every IPv6 literal and
+    # in no IPv4 one, so the test is exact.
     - name: "Allow restricted inbound TCP ports from their permitted sources only"
       ansible.posix.firewalld:
         zone: "{{ firewall_zone }}"
-        rich_rule: "rule family='ipv4' source address='{{ item.1 }}' port port='{{ item.0.port }}' protocol='tcp' accept"
+        rich_rule: >-
+          rule family='{{ 'ipv6' if ':' in item.1 else 'ipv4' }}'
+          source address='{{ item.1 }}'
+          port port='{{ item.0.port }}' protocol='tcp' accept
         permanent: true
         immediate: "{{ firewall_enable | bool }}"
         state: enabled
       loop: "{{ firewall_restricted_tcp_ports | subelements('sources') }}"
+      loop_control:
+        label: "{{ item.0.port }} from {{ item.1 }}"
+
+    - name: "Allow restricted inbound UDP ports from their permitted sources only"
+      ansible.posix.firewalld:
+        zone: "{{ firewall_zone }}"
+        rich_rule: >-
+          rule family='{{ 'ipv6' if ':' in item.1 else 'ipv4' }}'
+          source address='{{ item.1 }}'
+          port port='{{ item.0.port }}' protocol='udp' accept
+        permanent: true
+        immediate: "{{ firewall_enable | bool }}"
+        state: enabled
+      loop: "{{ firewall_restricted_udp_ports | subelements('sources') }}"
       loop_control:
         label: "{{ item.0.port }} from {{ item.1 }}"
 

--- a/docs/distributed-deployment.md
+++ b/docs/distributed-deployment.md
@@ -45,9 +45,15 @@ The connection is **bidirectional**:
 
 | Direction                 | Path                                  | Purpose                                  |
 | ------------------------- | ------------------------------------- | ---------------------------------------- |
-| Worker → Core             | `https://<core>/api/v1/...`           | Workers poll Core for work (collectors fetch source list, bots poll presets) |
-| Worker → Core (bots only) | `https://<core>/sse`                  | Long-lived SSE stream of bot events      |
-| Core → Worker             | `https://<worker>/api/v1/...`         | Core pushes work (collectors refresh, presenter generate, publisher publish) |
+| Worker → Core             | `https://<core>:8443/api/v1/...`      | Workers poll Core for work (collectors fetch source list, bots poll presets) |
+| Worker → Core (bots only) | `https://<core>:8443/sse`             | Long-lived SSE stream of bot events      |
+| Worker → Core (public-web) | `https://<core>:8443/traefik/dynamic/node` | The worker's Traefik polls Core for its routers and certificates |
+| Core → Worker             | `https://<type>.<worker>:8443/api/v1/...` | Core pushes work (collectors refresh, presenter generate, publisher publish) |
+| Control host → Core       | `https://<core>/api/v1/config/...`    | Ansible registers the node rows over Core's 443 |
+
+Both 8443s are separate ports on separate hosts: `core_satellite_port` on Core
+and `worker_api_port` on the worker. Only the control host's registration calls
+use Core's 443.
 
 Both legs must be reachable. Failures here are the most common distributed
 deployment issue.
@@ -86,9 +92,11 @@ On each **worker host**:
     443 router and served only here, so a worker that can reach Core's 443 but
     not its 8443 registers fine and then does no work.
 
-  Core does not publish that port unless told to: set
-  `TARANIS_NG_SATELLITE_BIND=0.0.0.0` in the Core host's `.env` and restrict it
-  to your worker addresses.
+  Core does not publish that port unless told to: it binds `127.0.0.1` and
+  `::1` by default. Set `TARANIS_NG_SATELLITE_BIND=0.0.0.0` and
+  `TARANIS_NG_SATELLITE_BIND6=::` in the Core host's `.env` — one per address
+  family, so a worker that reaches Core over IPv6 needs the second one — and
+  restrict the port to your worker addresses.
 
 ## Addressing model — VM hostname vs public API hostname
 
@@ -129,7 +137,7 @@ worker_hosts:
 # host_vars/collectors.example.org.yml
 worker_types: ["collectors"]
 worker_base_hostname: "example.org"
-# → collectors API at https://collectors.example.org  (matches the VM's hostname ✓)
+# → collectors API at https://collectors.example.org:8443  (matches the VM's hostname ✓)
 ```
 
 *(Without the `worker_base_hostname: "example.org"` override, the default
@@ -152,8 +160,8 @@ worker_hosts:
 # host_vars/taranis1.yml   (filename matches inventory key)
 worker_types: ["collectors", "bots"]
 worker_base_hostname: "taranis1.example.org"
-# → collectors API at https://collectors.taranis1.example.org  ✓
-# → bots API at       https://bots.taranis1.example.org        ✓
+# → collectors API at https://collectors.taranis1.example.org:8443  ✓
+# → bots API at       https://bots.taranis1.example.org:8443        ✓
 # (Cert SANs match — Traefik requests them via the per-type Host() labels.)
 ```
 
@@ -198,8 +206,8 @@ with `worker_base_hostname: "taranis1.example.org"`:
 | Collectors container's public FQDN | `collectors.taranis1.example.org` | computed as `<type>.<base>` |
 | Bots container's public FQDN | `bots.taranis1.example.org` | same |
 | ACME cert SAN for collectors router | `collectors.taranis1.example.org` | driven by Traefik `Host()` label |
-| Core's `CollectorsNode.api_url` | `https://collectors.taranis1.example.org` | registered by `taranis-ng-node-register` |
-| Core's `BotsNode.api_url` | `https://bots.taranis1.example.org` | registered by `taranis-ng-node-register` |
+| Core's `CollectorsNode.api_url` | `https://collectors.taranis1.example.org:8443` | registered by `taranis-ng-node-register` |
+| Core's `BotsNode.api_url` | `https://bots.taranis1.example.org:8443` | registered by `taranis-ng-node-register` |
 
 ## Addressing & TLS
 
@@ -209,7 +217,7 @@ or `host_vars/<host>.yml`:
 
 1. **`selfsigned`** (default) — Ansible generates a self-signed cert on the
    worker host via `community.crypto`. Core then reaches the worker at
-   `https://<worker_fqdn>/...` but the Core host must trust the cert.
+   `https://<worker_fqdn>:8443/...` but the Core host must trust the cert.
    Currently a manual step: copy the worker cert into the Core host's trust
    store (`/usr/local/share/ca-certificates/` + `update-ca-certificates`).
    See TODO below.
@@ -243,15 +251,29 @@ nobody — hence the split.
 | Core | 443 | world | GUI, the browser API, `/sse` |
 | Core | `TARANIS_NG_SATELLITE_PORT` (8443) | worker hosts only | `/api/v1/{collectors,bots,public-web}`, `/sse`, `/traefik/dynamic/node` |
 
-**A host firewall does not restrict the container ports.** Docker publishes a port
-by writing DNAT rules into `nat/PREROUTING` and filter rules into its own chain in
-`filter/FORWARD`; ufw and firewalld write to `filter/INPUT`, which container-bound
-traffic never traverses. So 80, 443 and the API port are reachable whatever
-`firewall_allowed_tcp_ports` lists, and the `taranis-ng-firewall` role governs only
-traffic terminating on the host itself — sshd above all. Keep 22 there and set the
-rest per host in `host_vars/<host>.yml`, not in the role defaults.
+**Whether a host firewall restricts these ports depends on the address family**,
+and the familiar "Docker bypasses your firewall" is only half of it:
 
-To narrow the API port for real, pick one of:
+- **IPv4 — bypassed.** Docker publishes a port by writing DNAT rules into
+  `nat/PREROUTING` and filter rules into its own chain in `filter/FORWARD`; ufw
+  and firewalld write to `filter/INPUT`, which that traffic never traverses. So
+  80, 443 and the API port are reachable over v4 whatever
+  `firewall_allowed_tcp_ports` lists.
+- **IPv6 — not bypassed.** Docker ships with `ip6tables` management off, so
+  there is no v6 DNAT: `docker-proxy` listens in the host namespace and the
+  traffic goes through `INPUT` like any host service. A published port missing
+  from the firewall lists is therefore reachable over v4 and *dropped* over v6 —
+  a timeout, not a refusal, so it reads like a routing fault.
+
+IPv6 is thus the only family in which a rule in `taranis-ng-firewall` does
+anything for a published container port; a source of `::/0` opens one for v6
+only. Set those ports per host in `host_vars/<host>.yml`, not in the role
+defaults, which are the whole fleet's. Note that `taranis-ng-worker` opens 80,
+443 and `worker_api_port` unrestricted itself whenever ufw is already active, so
+set `worker_open_firewall: false` on a host whose policy you want
+`taranis-ng-firewall` to own.
+
+To narrow the API port over IPv4, pick one of:
 
 ```yaml
 # host_vars/<host>.yml — bind the listener to one address. Docker honours this,
@@ -445,14 +467,14 @@ key value, so leaving the files in place is a no-op.
      or use ACME where Traefik requests per-type certs on demand).
    - Authenticates to Core as an admin user and POSTs a node row to
      `/api/v1/config/<type>-nodes` for each `worker_types` entry (the same
-     collection endpoint for all four types). Core's `add_*_node` manager probes
+     collection endpoint shape for every type). Core's `add_*_node` manager probes
      the worker with the supplied key before persisting — so a successful POST
      also verifies the Core→worker direction *and* the key. When a node with
      that `api_url` already exists the playbook PUTs instead, so a rotated key
      reaches Core rather than being silently skipped.
 
 5. The new collectors node appears in the Core GUI under
-   `Config → Collector Nodes` and can receive OSINT sources.
+   *Configuration → Collector Nodes* and can receive OSINT sources.
 
 ## Managing a worker after deployment
 
@@ -515,14 +537,22 @@ installed. Each part is independent:
 ### Firewalling a worker host
 
 `firewall.yml` applies a deny-by-default inbound policy and leaves outbound
-unrestricted:
+unrestricted. The role's own default opens **SSH and nothing else** — every
+other port a host needs is declared in that host's `host_vars/<host>.yml`,
+because a role default is the whole fleet's default:
 
-| Port | Why it stays open |
+| Variable | What it opens |
 | --- | --- |
-| tcp/22 | SSH — Ansible's own transport |
-| tcp/80 | ACME HTTP-01 validation and Traefik's http→https redirect |
-| tcp/443 | the worker API Core calls |
-| udp/443 | HTTP/3, which the worker's Traefik advertises and publishes |
+| `firewall_allowed_tcp_ports` (default `[22]`) | TCP ports open to everyone, on both address families |
+| `firewall_allowed_udp_ports` (default `[]`) | the same for UDP |
+| `firewall_restricted_tcp_ports` / `_udp_ports` (default `[]`) | `{port, sources}` entries, one rule per (port, source) pair |
+| `firewall_reset` (default `false`) | discard the host's existing ruleset first, so this policy is the whole policy rather than a delta |
+
+A worker host typically wants 80 (ACME HTTP-01 and the http→https redirect), 443
+plus udp/443 (a public-web's own hostnames, and HTTP/3, which Traefik
+advertises), and `worker_api_port` restricted to the Core host.
+[`host_vars/worker.example.yml`](../ansible/inventory/host_vars/worker.example.yml)
+carries a worked example of exactly that.
 
 ```bash
 cd ansible
@@ -539,38 +569,37 @@ missing from `firewall_allowed_tcp_ports` — override with
 
 Other knobs: `-e firewall_hosts=core` to target a different group,
 `-e firewall_enable=false` to stage the rules without switching the firewall on,
-and `-e '{"firewall_allowed_tcp_ports": [22, 80, 443, 9090]}'` to open more.
+and `-e '{"firewall_allowed_tcp_ports": [22, 80, 443]}'` to open more.
 
-> **Docker publishes past the firewall.** Docker inserts its own iptables rules
-> ahead of ufw's, so container ports published with `-p` are reachable whatever
-> the policy says; firewalld behaves similarly. The worker stack publishes only
-> 80 and 443 — the ports this policy opens anyway — so nothing is currently
-> exposed beyond it. Publish a container on another port later and it *will* be
-> reachable regardless of these rules. The play prints the currently published
-> ports at the end so the gap stays visible.
+> **Over IPv4, Docker publishes past the firewall.** Container ports published
+> with `-p` are reachable over v4 whatever this policy says; over IPv6 they are
+> not, and a published port left off these lists is dropped there. See
+> [Ports and exposure](#ports-and-exposure) for the mechanism and for the
+> `worker_open_firewall: false` interaction with `taranis-ng-worker`, which
+> otherwise re-adds blanket rules for 80, 443 and `worker_api_port` on every
+> deploy. The play prints the currently published ports at the end so the v4 gap
+> stays visible.
 
 ## Moving work items between nodes
 
 Once multiple nodes of a given type exist (e.g. two collectors nodes), you can
 move individual work items (OSINT sources, bot presets, product types,
-publisher presets) between them directly from the existing admin dialogs in the
-**Vue 3 GUI** (`src/gui-v3/`, served at `/`):
+publisher presets) between them from the admin dialogs in the **Vue 3 GUI**
+(`src/gui-v3/`, served at `/`):
 
-1. Open the work item's edit dialog (e.g. `Config → OSINT Sources → Edit`).
-2. The **Node** and **Collector/Bot/Presenter/Publisher** `v-select`s are now
-   editable in edit mode (previously they were locked to the create-time
-   choice — `:disabled="isEdit || ..."`).
-3. Pick the target node + worker. Parameter values whose `parameter.key`
-   matches are carried over to the new worker's parameter set automatically;
-   parameters absent on the new worker fall back to their defaults.
-4. Save. The backend `update()` validates that the target worker is of the
-   same type as the current worker (so you can move an RSS source between two
-   collectors nodes hosting `RSS_COLLECTOR`, but not from `RSS_COLLECTOR`
-   to `PLAYWRIGHT_COLLECTOR`).
+1. Open the work item's edit dialog (e.g. *Configuration → OSINT Sources →
+   Edit*).
+2. Pick the target node and worker — both selects stay editable in edit mode.
+   Parameter values whose `parameter.key` matches are carried over to the new
+   worker's parameter set automatically; parameters absent on the new worker
+   fall back to their defaults.
+3. Save. The backend validates that the target worker is of the same type as
+   the current one, so you can move an RSS source between two collectors nodes
+   hosting `RSS_COLLECTOR`, but not from `RSS_COLLECTOR` to
+   `PLAYWRIGHT_COLLECTOR`.
 
-> **Note:** The Vue 2 GUI (`src/gui/`) is left intentionally untouched by this
-> change — operators using the Vue 2 UI will not see the unlock. Move work
-> items via the Vue 3 UI or via the admin REST API directly.
+> **Note:** the Vue 2 GUI (`src/gui/`) does not offer this; move work items via
+> the Vue 3 UI or the admin REST API.
 
 ## Operator-supplied values never dirty the repo
 
@@ -662,9 +691,10 @@ be fixed.
 - **Worker Traefik logs `Provider error … context deadline exceeded` for
   `/traefik/dynamic/node`**: the worker cannot reach Core's satellite port. Nearly
   always the opt-in publish — Core binds `:8443` to loopback by default
-  (`TARANIS_NG_SATELLITE_BIND=127.0.0.1`), so from outside the Core host there is
-  no listener at all. Set it to `0.0.0.0`, `docker compose up -d traefik`, and
-  confirm with `ss -tlnp | grep 8443`.
+  (`TARANIS_NG_SATELLITE_BIND=127.0.0.1`, `TARANIS_NG_SATELLITE_BIND6=::1`), so
+  from outside the Core host there is no listener at all. Set them to `0.0.0.0`
+  and `::` respectively, `docker compose up -d traefik`, and confirm with
+  `ss -tlnp | grep 8443` — check both families, since they are separate publishes.
 
   The error text tells you which leg is broken, so read it before changing
   anything: **timeout** (`context deadline exceeded`, `i/o timeout`) means packets
@@ -681,7 +711,7 @@ be fixed.
   `worker_api_port`, neither of which uses this leg — and then do no work at all.
 - **A public web serves the wrong certificate, or 404s every hostname**: the
   worker's Traefik could not poll `/traefik/dynamic/node`. Check that the Core
-  host publishes its satellite port (`TARANIS_NG_SATELLITE_BIND=0.0.0.0`) and
+  host publishes its satellite port (`TARANIS_NG_SATELLITE_BIND` / `_BIND6`) and
   admits this worker, and that the node's API key matches. The catch-all keeps
   answering from `fallback.yml` meanwhile, which is why the site stays up but
   unconfigured.
@@ -726,6 +756,12 @@ be fixed.
   default install.
 - [`ansible/playbooks/distribute-worker.yml`](../ansible/playbooks/distribute-worker.yml)
   — remote-only worker deployment + node registration.
+- [`ansible/playbooks/worker-power.yml`](../ansible/playbooks/worker-power.yml)
+  — stop / start / restart a deployed worker host.
+- [`ansible/playbooks/worker-remove.yml`](../ansible/playbooks/worker-remove.yml)
+  — remove a worker from its host and from Core.
+- [`ansible/playbooks/firewall.yml`](../ansible/playbooks/firewall.yml) —
+  deny-by-default host firewall (`taranis-ng-firewall`).
 - [`ansible/roles/taranis-ng-docker/`](../ansible/roles/taranis-ng-docker/) —
   Docker Engine install role (apt + dnf).
 - [`ansible/roles/taranis-ng-image-transfer/`](../ansible/roles/taranis-ng-image-transfer/)
@@ -761,7 +797,7 @@ Supported:
   - `["public-web"]` — a public report feed; see "A public-web worker" above.
 - **Per-worker-type node rows in Core.** Each entry in `worker_types` becomes
   a separate row in the corresponding `*Node` table; each has its own
-  per-type subdomain (so Core addresses `https://<type>.<host>/...`) and its
+  per-type subdomain (so Core addresses `https://<type>.<host>:8443/...`) and its
   own `api_key` (separate secret file at
   `/etc/taranis-ng/secrets/api_key.<type>.txt`).
 - **ACME** — one ACME resolver on the host's Traefik requests per-type certs


### PR DESCRIPTION
### Role changes

- **Fix:** firewalld rich rules hardcoded `family='ipv4'`, so any IPv6 source failed the play. The family is now derived from the address.
- **Add** `firewall_reset` — the role only ever added rules, and both ufw and firewalld take the first match, so a leftover blanket `allow 8443` silently cancelled a source-restricted one. Off by default; ufw is disabled during the reset, so there is no lock-out window.
- **Add** `firewall_restricted_udp_ports`, matching the TCP list.
- **Fix:** the end-of-run report listed only the blanket ports, understating a policy built from restricted ones.

### Documentation corrections

- The role was documented as opening tcp/22, 80, 443 and udp/443. It opens **22 and nothing else**; the rest is per-host config.
- tcp/443 was called "the worker API Core calls" — the API is on `worker_api_port` (8443); 443 belongs to public-web.
- "Docker publishes past the firewall" was stated unconditionally. True over IPv4; over IPv6 there is no DNAT, so these rules are the only thing gating a published port.
- `group_vars/all.example.yml` shipped `core_sse_url: "{{ core_url }}/sse"`, overriding the role default and dropping the satellite port — bots pointed at a 404.
- Worker `api_url` examples omitted the `:8443` that registration actually writes.
- `public-web` was absent from every valid-`worker_types` list.
- Smaller: README promised two playbooks then listed five; `ansible.cfg` said "both playbooks"; "all four types" (there are five); `Config →` vs the GUI's `Configuration →`; publishing the satellite port needs `_BIND6` too.

Duplicated walkthroughs in `worker.example.yml` and `all.example.yml` were condensed to pointers into `docs/distributed-deployment.md`.

### Verification

`scripts/run_tests.py --suite ansible` passes (5 playbooks syntax-checked, ansible-lint clean). The reworked report task and the corrected `core_sse_url` were rendered against the real inventory to confirm output.