### PR TITLE
Move public-web seeding into `bootstrap`

### DIFF
--- a/docker/Dockerfile.bots
+++ b/docker/Dockerfile.bots
@@ -49,11 +49,13 @@ ENV VARIABLE_NAME="app"
 ENV GUNICORN_CMD_ARGS="--timeout 120"
 
 
-# SK-CERT#723: run the service as an unprivileged user. su-exec lets
-# docker/entrypoint.sh fix volume/secret ownership as root and then drop to this
-# user before exec'ing gunicorn, so no application process runs as uid 0.
+# Run the service as an unprivileged user; docker/entrypoint.sh drops to it via
+# su-exec. /app stays root-owned so the runtime user cannot rewrite its own code;
+# the bytecode is precompiled instead.
 RUN apk add --no-cache su-exec \
-    && adduser -D -u 10001 taranis
+    && adduser -D -u 10001 taranis \
+    && python -m compileall -q /app
+ENV PYTHONDONTWRITEBYTECODE="1"
 ENV TARANIS_USER="taranis"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile.collectors
+++ b/docker/Dockerfile.collectors
@@ -74,16 +74,22 @@ ENV VARIABLE_NAME="app"
 ENV GUNICORN_CMD_ARGS="--timeout 120"
 ENV COLLECTOR_CONFIG_FILE="/app/storage/id.txt"
 
-VOLUME ["/app/storage"]
-
-
-# SK-CERT#723: run the service as an unprivileged user. su-exec lets
-# docker/entrypoint.sh fix volume/secret ownership as root and then drop to this
-# user before exec'ing gunicorn, so no application process runs as uid 0.
+# Run the service as an unprivileged user; docker/entrypoint.sh drops to it via
+# su-exec. /app stays root-owned so the runtime user cannot rewrite its own code;
+# the bytecode is precompiled instead.
+# Must precede VOLUME: a build's changes to an already-declared volume path are
+# discarded.
 RUN apk add --no-cache su-exec \
-    && adduser -D -u 10001 taranis
+    && adduser -D -u 10001 taranis \
+    && python -m compileall -q /app \
+    && mkdir -p /app/storage \
+    && chown -R taranis /app/storage
+ENV PYTHONDONTWRITEBYTECODE="1"
 ENV TARANIS_USER="taranis"
 ENV TARANIS_WRITABLE_PATHS="/app/storage"
+
+VOLUME ["/app/storage"]
+
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/start.sh"]

--- a/docker/Dockerfile.core
+++ b/docker/Dockerfile.core
@@ -68,6 +68,20 @@ ENV MODULE_NAME="run"
 ENV VARIABLE_NAME="app"
 ENV GUNICORN_CMD_ARGS="--timeout 120"
 
+# Run the service as an unprivileged user; docker/entrypoint.sh drops to it via
+# su-exec. /app stays root-owned so the runtime user cannot rewrite its own code;
+# the bytecode is precompiled instead.
+# Must precede VOLUME: a build's changes to an already-declared volume path are
+# discarded.
+RUN apk add --no-cache su-exec \
+    && adduser -D -u 10001 taranis \
+    && python -m compileall -q /app \
+    && mkdir -p /data \
+    && chown -R taranis /data
+ENV PYTHONDONTWRITEBYTECODE="1"
+ENV TARANIS_USER="taranis"
+ENV TARANIS_WRITABLE_PATHS="/data"
+
 VOLUME ["/data"]
 
 # start-period covers the boot work before gunicorn answers (migrations, seeding,
@@ -77,14 +91,6 @@ VOLUME ["/data"]
 # traefik - then refuses to start on a slow or busy machine.
 HEALTHCHECK --interval=5s --timeout=3s --start-period=300s --retries=5 CMD curl --fail http://localhost/api/v1/isalive || exit 1
 
-
-# SK-CERT#723: run the service as an unprivileged user. su-exec lets
-# docker/entrypoint.sh fix volume/secret ownership as root and then drop to this
-# user before exec'ing gunicorn, so no application process runs as uid 0.
-RUN apk add --no-cache su-exec \
-    && adduser -D -u 10001 taranis
-ENV TARANIS_USER="taranis"
-ENV TARANIS_WRITABLE_PATHS="/data"
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/start.sh"]

--- a/docker/Dockerfile.presenters
+++ b/docker/Dockerfile.presenters
@@ -91,17 +91,23 @@ ENV VARIABLE_NAME="app"
 ENV GUNICORN_CMD_ARGS="--timeout 120"
 
 
-VOLUME ["/app/templates"]
-
-
-# SK-CERT#723: run the service as an unprivileged user. su-exec lets
-# docker/entrypoint.sh fix volume/secret ownership as root and then drop to this
-# user before exec'ing gunicorn, so no application process runs as uid 0.
+# Run the service as an unprivileged user; docker/entrypoint.sh drops to it via
+# su-exec. /app stays root-owned so the runtime user cannot rewrite its own code;
+# the bytecode is precompiled instead.
+# Must precede VOLUME: a build's changes to an already-declared volume path are
+# discarded.
 RUN apk add --no-cache su-exec \
     && adduser -D -u 10001 taranis \
-    && chown -R taranis:taranis /var/cache/fontconfig
+    && python -m compileall -q /app \
+    && chown -R taranis /var/cache/fontconfig \
+    && mkdir -p /app/templates/user_templates \
+    && chown -R taranis /app/templates
+ENV PYTHONDONTWRITEBYTECODE="1"
 ENV TARANIS_USER="taranis"
 ENV TARANIS_WRITABLE_PATHS="/app/templates"
+
+VOLUME ["/app/templates"]
+
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/start.sh"]

--- a/docker/Dockerfile.public-web
+++ b/docker/Dockerfile.public-web
@@ -69,11 +69,13 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD python -c "import sys,urllib.request; key=open('/run/secrets/api_key', encoding='utf-8').read().strip(); req=urllib.request.Request('http://127.0.0.1:80/management/isalive', headers={'Authorization': 'ApiKey ' + key}); sys.exit(0 if urllib.request.urlopen(req, timeout=4).status==200 else 1)"
 
 
-# SK-CERT#723: run the service as an unprivileged user. su-exec lets
-# docker/entrypoint.sh fix volume/secret ownership as root and then drop to this
-# user before exec'ing gunicorn, so no application process runs as uid 0.
+# Run the service as an unprivileged user; docker/entrypoint.sh drops to it via
+# su-exec. /app stays root-owned so the runtime user cannot rewrite its own code;
+# the bytecode is precompiled instead.
 RUN apk add --no-cache su-exec \
-    && adduser -D -u 10001 taranis
+    && adduser -D -u 10001 taranis \
+    && python -m compileall -q /app
+ENV PYTHONDONTWRITEBYTECODE="1"
 ENV TARANIS_USER="taranis"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile.publishers
+++ b/docker/Dockerfile.publishers
@@ -57,11 +57,13 @@ ENV GUNICORN_CMD_ARGS="--timeout 120"
 
 
 
-# SK-CERT#723: run the service as an unprivileged user. su-exec lets
-# docker/entrypoint.sh fix volume/secret ownership as root and then drop to this
-# user before exec'ing gunicorn, so no application process runs as uid 0.
+# Run the service as an unprivileged user; docker/entrypoint.sh drops to it via
+# su-exec. /app stays root-owned so the runtime user cannot rewrite its own code;
+# the bytecode is precompiled instead.
 RUN apk add --no-cache su-exec \
-    && adduser -D -u 10001 taranis
+    && adduser -D -u 10001 taranis \
+    && python -m compileall -q /app
+ENV PYTHONDONTWRITEBYTECODE="1"
 ENV TARANIS_USER="taranis"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,10 +35,10 @@ services:
        - postgres_password
 
   core:
-    # SK-CERT#723: the service runs as an unprivileged user (see
-    # docker/entrypoint.sh). This sysctl is namespaced to the container's own
-    # network namespace and lets it keep binding :80, so every internal URL,
-    # Traefik label, healthcheck and stored node api_url stays as it was.
+    # The service runs as an unprivileged user (see docker/entrypoint.sh). This
+    # sysctl is namespaced to the container's own network namespace and lets it
+    # keep binding :80, so every internal URL, Traefik label, healthcheck and
+    # stored node api_url stays as it was.
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0
     security_opt:
@@ -93,11 +93,6 @@ services:
       TRAEFIK_CERT_RESOLVER: "${TRAEFIK_CERT_RESOLVER:-}"
       # So the certificate panel can report the main hostname alongside the webs.
       TARANIS_NG_HOSTNAME: "${TARANIS_NG_HOSTNAME}"
-      # Which optional services this deployment runs. prestart_core.sh reads it to
-      # seed the default public-web node only when the public-web container really
-      # exists. Passing it here also means flipping the profile in .env recreates
-      # core, so the node is seeded the moment the feed is switched on.
-      COMPOSE_PROFILES: "${COMPOSE_PROFILES:-}"
     labels:
       traefik.enable: "true"
       traefik.http.services.taranis-api.loadbalancer.server.port: "80"
@@ -324,6 +319,11 @@ services:
         condition: service_started
       publishers:
         condition: service_started
+      # Optional (compose profile "public-web"), hence required: false - with the
+      # profile off the service does not exist and compose must not wait for it.
+      public-web:
+        condition: service_started
+        required: false
     restart: "no"
     image: "skcert/taranis-ng-core:${TARANIS_NG_TAG}"
     command: ["python", "bootstrap_docker.py"]
@@ -338,6 +338,11 @@ services:
       TARANIS_LOG_LEVEL: "${TARANIS_LOG_LEVEL}"
       MODULES_LOG_LEVEL: "${MODULES_LOG_LEVEL}"
       DEBUG_SQL: "false"
+      # Which optional services this deployment runs. bootstrap_docker.py reads it
+      # to seed the default public-web node only when the public-web container
+      # really exists. This service re-runs on every `docker compose up`, so
+      # switching the feed on in .env seeds the node on the next start.
+      COMPOSE_PROFILES: "${COMPOSE_PROFILES:-}"
     logging:
       driver: "json-file"
       options:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,33 +19,17 @@ else
 fi
 export GUNICORN_CONF="${GUNICORN_CONF:-$DEFAULT_GUNICORN_CONF}"
 
-# Drop to an unprivileged user (CESNET pentest, SK-CERT#723: every service used
-# to run its whole Python stack as uid 0, so an RCE started as root).
-#
-# The drop happens here rather than via a Dockerfile `USER` line because the
-# volumes must still be re-owned as root on the way past: named volumes
-# (/data, /app/templates, /app/storage) take their ownership from the image
-# directory the FIRST time they are mounted, so existing deployments already
-# have root-owned contents and a `USER` line alone would leave every upgraded
-# install unable to write to its own data.
-#
-# TARANIS_DROP_PRIVILEGES=false keeps the old behaviour for anyone who needs it.
 if [ "$(id -u)" = "0" ] && [ "${TARANIS_DROP_PRIVILEGES:-true}" = "true" ] && id -u "${TARANIS_USER:-taranis}" >/dev/null 2>&1; then
     TARANIS_USER="${TARANIS_USER:-taranis}"
 
-    # /app itself plus whatever this service declares as writable at runtime.
-    for path in /app ${TARANIS_WRITABLE_PATHS:-}; do
+    for path in ${TARANIS_WRITABLE_PATHS:-}; do
         [ -e "$path" ] || continue
-        # -h so a symlinked mount point is not followed out of the container.
-        chown -RhH "$TARANIS_USER" "$path" 2>/dev/null || \
+        find "$path" ! -user "$TARANIS_USER" -exec chown -h "$TARANIS_USER" {} + 2>/dev/null || \
             echo "entrypoint: could not chown $path; continuing as $TARANIS_USER anyway" >&2
     done
 
-    # Secrets are bind-mounted read-only, so they cannot be chowned. The files
-    # docker/secrets/ ships are 0644 inside a 0700 directory, which the runtime
-    # user can read - but an operator who tightens them to 0600 would otherwise
-    # get a confusing "Secret file not found" from deep inside config.py at
-    # import time. Check here instead and say exactly what to do.
+    # Read-only bind mounts, so they cannot be chowned. Checked here because the
+    # alternative is a confusing "Secret file not found" from inside config.py.
     if [ -d /run/secrets ]; then
         unreadable=""
         for secret in /run/secrets/*; do
@@ -54,7 +38,7 @@ if [ "$(id -u)" = "0" ] && [ "${TARANIS_DROP_PRIVILEGES:-true}" = "true" ] && id
         done
         if [ -n "$unreadable" ]; then
             echo "entrypoint: ERROR: these secrets are not readable by $TARANIS_USER:$unreadable" >&2
-            echo "entrypoint: the service now runs unprivileged (SK-CERT#723). Make the files on the" >&2
+            echo "entrypoint: the service now runs unprivileged. Make the files on the" >&2
             echo "entrypoint: host group/world readable - 'chmod 644 docker/secrets/*.txt'. The" >&2
             echo "entrypoint: docker/secrets directory itself stays 0700, so they remain protected." >&2
             exit 1

--- a/docker/prestart_core.sh
+++ b/docker/prestart_core.sh
@@ -9,38 +9,6 @@ echo "Running migrations..."
 python db_migration.py
 echo "Migrations are done."
 
-echo "Reading API key from file..."
-API_KEY=$(cat "/run/secrets/api_key")
-
-# The public-web feed is optional (compose profile "public-web"), so unlike the
-# collector and bot nodes its default node is only seeded when the service is
-# actually part of this deployment. Seeding it regardless would put a node in
-# Configuration -> Public Web that nothing backs: it can never be reached, and
-# core would keep dialling a host that does not resolve.
-PUBLIC_WEB_PROFILES=$(echo "${COMPOSE_PROFILES:-}" | tr -d ' ')
-case ",${PUBLIC_WEB_PROFILES}," in
-    *,public-web,*)
-        (
-            if [ "$(python ./manage.py public-web --list | grep 'Total:' | cut -d ' ' -f2)" == 0 ]; then
-                echo "Creating default public-web node..."
-                # --fronted-by-core: this node runs beside core in this stack, so
-                # core's own Traefik publishes its webs. A remote node registered by
-                # ansible fronts its own and must NOT be marked.
-                python ./manage.py public-web --create --name "Default Public Web" --description "A local public-web feed node configured as a part of Taranis NG default installation." --api-url "http://public-web" --api-key "$API_KEY" --fronted-by-core
-            fi
-            # Ensure the default node has a web so the running feed is represented in
-            # the GUI. It is created without a hostname: a node can serve several
-            # webs on several hostnames, so that belongs in Configuration ->
-            # Public Web, next to the rest of the web's settings.
-            echo "Ensuring default public-web web..."
-            python ./manage.py public-web --ensure-web --name "Default Public Web" --web-name "Default Web" --api-url "http://public-web"
-        ) &
-        ;;
-    *)
-        echo "Public-web feed is not enabled (COMPOSE_PROFILES=\"${COMPOSE_PROFILES:-}\"); skipping its default node."
-        ;;
-esac
-
 echo "Starting scheduler..."
 python ./scheduler.py &
 

--- a/src/core/bootstrap_docker.py
+++ b/src/core/bootstrap_docker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -10,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from flask import Flask
-from managers import bots_manager, collectors_manager, db_manager, presenters_manager, publishers_manager
+from managers import bots_manager, collectors_manager, db_manager, presenters_manager, public_web_manager, publishers_manager
 from migrations.repair_distribution_bundle import repair_distribution_bundle
 from model import (  # noqa: F401  Import the complete relationship graph before configuring mappers.
     attribute,
@@ -34,16 +35,29 @@ from model import (  # noqa: F401  Import the complete relationship graph before
 from model.bots_node import BotsNode
 from model.collectors_node import CollectorsNode
 from model.presenters_node import PresentersNode
+from model.public_web import PublicWeb
+from model.public_web_node import PublicWebNode
 from model.publishers_node import PublishersNode
 from sqlalchemy import func
 
-NodeModel = type[BotsNode] | type[CollectorsNode] | type[PresentersNode] | type[PublishersNode]
+NodeModel = type[BotsNode] | type[CollectorsNode] | type[PresentersNode] | type[PublicWebNode] | type[PublishersNode]
 NodeOperation = Callable[[dict[str, str]], HTTPStatus | int]
 NodeUpdateOperation = Callable[[str, dict[str, str]], HTTPStatus | int]
 
 DEFAULT_PRESENTER_URL = "http://presenters/"
 MAX_ATTEMPTS = 30
 RETRY_SECONDS = 2
+
+# The public-web feed is optional (compose profile "public-web"), so unlike the
+# other satellites its default node is only seeded when the service is actually
+# part of this deployment. Seeding it regardless would put a node in
+# Configuration -> Public Web that nothing backs: it can never be reached, and
+# core would keep dialling a host that does not resolve.
+PUBLIC_WEB_PROFILE = "public-web"
+DEFAULT_PUBLIC_WEB_URL = "http://public-web"
+DEFAULT_PUBLIC_WEB_NAME = "Default Public Web"
+DEFAULT_PUBLIC_WEB_DESCRIPTION = "A local public-web feed node configured as a part of Taranis NG default installation."
+DEFAULT_PUBLIC_WEB_WEB_NAME = "Default Web"
 
 
 @dataclass(frozen=True)
@@ -175,6 +189,100 @@ def _node_specs() -> tuple[NodeSpec, ...]:
     )
 
 
+def _public_web_enabled() -> bool:
+    """Tell whether this deployment runs the optional public-web feed.
+
+    Read from COMPOSE_PROFILES rather than probing the network, so a stack with
+    the feed switched off is never held up waiting for a container that compose
+    was never asked to create.
+
+    Returns:
+        (bool): True when the "public-web" compose profile is active.
+    """
+    profiles = os.getenv("COMPOSE_PROFILES", "").replace(" ", "")
+    return PUBLIC_WEB_PROFILE in profiles.split(",")
+
+
+def _create_public_web_node(api_key: str) -> PublicWebNode:
+    """Register the public-web node that runs beside core in this stack."""
+    # fronted_by_core: this node runs beside core, so core's own Traefik publishes
+    # its webs. A remote node registered by ansible fronts its own and must NOT be
+    # marked - see the PublicWebNode.fronted_by_core docstring.
+    node = PublicWebNode(
+        _available_name(PublicWebNode, DEFAULT_PUBLIC_WEB_NAME),
+        DEFAULT_PUBLIC_WEB_DESCRIPTION,
+        api_key,
+        DEFAULT_PUBLIC_WEB_URL,
+        fronted_by_core=True,
+    )
+    db_manager.db.session.add(node)
+    db_manager.db.session.commit()
+    return node
+
+
+def _seed_public_web(api_key: str) -> None:
+    """Create the default public-web node and its web, once, if they are missing.
+
+    Matched on api_url rather than on "is the table empty", so an operator who
+    renamed the node in Configuration -> Public Web keeps their name instead of
+    getting a second node beside it.
+    """
+    node = _node_by_url(PublicWebNode, DEFAULT_PUBLIC_WEB_URL)
+    if node is None:
+        node = _create_public_web_node(api_key)
+        print(f"Default public-web node '{node.name}' created.", flush=True)  # noqa: T201
+
+    # A node created before api_url existed, or seeded without one, has no
+    # core->node channel: backfill it so health checks and cache-reset pushes work.
+    if not node.api_url:
+        node.api_url = DEFAULT_PUBLIC_WEB_URL
+        db_manager.db.session.commit()
+
+    # A node can serve several webs on several hostnames, so this one is created
+    # without a hostname: that belongs in Configuration -> Public Web, next to the
+    # rest of the web's settings.
+    if not node.webs:
+        db_manager.db.session.add(PublicWeb(DEFAULT_PUBLIC_WEB_WEB_NAME, node.id, "", {}))
+        db_manager.db.session.commit()
+        print(f"Default web '{DEFAULT_PUBLIC_WEB_WEB_NAME}' created for node '{node.name}'.", flush=True)  # noqa: T201
+
+    print(f"Default public-web node ready: {node.name}", flush=True)  # noqa: T201
+
+
+def _ensure_public_web(api_key: str) -> None:
+    """Seed the default public-web node once its service answers.
+
+    Deliberately best-effort: unlike the four mandatory satellites this one is an
+    optional profile, and `gui`/`gui-v3` wait on this whole script completing
+    successfully. Raising here would take the entire stack down over a feed the
+    deployment can live without, so a node that never answers is reported and
+    skipped.
+    """
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        # The same check the configuration UI runs on node registration, so a node
+        # that is not really there is never stored.
+        problem = public_web_manager.verify_node(DEFAULT_PUBLIC_WEB_URL, api_key)
+        if problem is None:
+            try:
+                _seed_public_web(api_key)
+            except Exception as error:
+                db_manager.db.session.rollback()
+                print(f"Default public-web node attempt {attempt}/{MAX_ATTEMPTS} failed: {error}", flush=True)  # noqa: T201
+            else:
+                return
+        elif attempt in (1, MAX_ATTEMPTS):
+            print(f"Default public-web node attempt {attempt}/{MAX_ATTEMPTS}: {problem}", flush=True)  # noqa: T201
+
+        if attempt < MAX_ATTEMPTS:
+            time.sleep(RETRY_SECONDS)
+
+    print(  # noqa: T201
+        f"WARNING: the default public-web node was not seeded after {MAX_ATTEMPTS} attempts; "
+        "register it by hand under Configuration -> Public Web. Continuing.",
+        flush=True,
+    )
+
+
 def bootstrap() -> None:
     """Run the idempotent Docker initialization sequence."""
     app = Flask(__name__)
@@ -186,6 +294,12 @@ def bootstrap() -> None:
         api_key = _read_api_key()
         for spec in _node_specs():
             _ensure_node(spec, api_key)
+
+        if _public_web_enabled():
+            _ensure_public_web(api_key)
+        else:
+            profiles = os.getenv("COMPOSE_PROFILES", "")
+            print(f"Public-web feed is not enabled (COMPOSE_PROFILES={profiles!r}); skipping its default node.", flush=True)  # noqa: T201
 
         repair_distribution_bundle(db_manager.db.engine, DEFAULT_PRESENTER_URL, preserve_partial=True)
         print("Docker initialization complete.", flush=True)  # noqa: T201

--- a/src/core/manage.py
+++ b/src/core/manage.py
@@ -769,8 +769,7 @@ def public_web_management(
             logger.info(
                 f"Id: {node.id}\n\tName: {node.name}\n\t{api_key_str}Created: {node.created}\n\tLast seen: {node.last_seen}",
             )
-        # We need to use print here, because prestart_core.sh relies on the output
-        print(f"Total: {len(nodes)}")  # noqa: T201
+        logger.info(f"Total: {len(nodes)}")
 
     if opt_create:
         if not opt_name or not opt_api_key:

--- a/src/core/tests/test_bootstrap_public_web.py
+++ b/src/core/tests/test_bootstrap_public_web.py
@@ -1,0 +1,189 @@
+"""The default public-web node is seeded by bootstrap, and only when it should be.
+
+This seeding used to live in ``docker/prestart_core.sh``: a backgrounded subshell
+that grepped ``Total:`` out of ``manage.py public-web --list`` and created the node
+blind. It has moved into :mod:`bootstrap_docker`, beside the four mandatory
+satellites, and these tests pin the three properties that move bought:
+
+* the compose profile still gates it - a stack without the feed gets no node;
+* an existing node is matched on ``api_url``, so an operator who renamed it in
+  Configuration -> Public Web keeps their name and gets no duplicate;
+* a node that never answers is reported and skipped, never raised - ``gui`` and
+  ``gui-v3`` wait on this script completing, so an optional feed must not be able
+  to take the whole stack down.
+"""
+
+from __future__ import annotations
+
+import types
+
+import bootstrap_docker
+import pytest
+
+
+class _FakeSession:
+    """Records what bootstrap would have written, without a database."""
+
+    def __init__(self) -> None:
+        self.added: list[object] = []
+        self.commits = 0
+        self.rollbacks = 0
+
+    def add(self, row: object) -> None:
+        """Stage a row."""
+        self.added.append(row)
+
+    def commit(self) -> None:
+        """Count a commit."""
+        self.commits += 1
+
+    def rollback(self) -> None:
+        """Count a rollback."""
+        self.rollbacks += 1
+
+
+@pytest.fixture
+def session(monkeypatch: pytest.MonkeyPatch) -> _FakeSession:
+    """Swap the real db session for a recorder and skip the retry sleeps."""
+    fake = _FakeSession()
+    monkeypatch.setattr(bootstrap_docker.db_manager, "db", types.SimpleNamespace(session=fake))
+    monkeypatch.setattr(bootstrap_docker.time, "sleep", lambda _seconds: None)
+    return fake
+
+
+def _existing(name: str, api_url: str = bootstrap_docker.DEFAULT_PUBLIC_WEB_URL, webs: list | None = None) -> types.SimpleNamespace:
+    """Build a stand-in for a persisted PublicWebNode."""
+    return types.SimpleNamespace(id=7, name=name, api_url=api_url, webs=webs if webs is not None else [])
+
+
+def _stub_lookup(monkeypatch: pytest.MonkeyPatch, node: object | None) -> None:
+    """Make the api_url lookup answer with ``node``."""
+    monkeypatch.setattr(bootstrap_docker, "_node_by_url", lambda _model, _url: node)
+
+
+def _stub_verify(monkeypatch: pytest.MonkeyPatch, problem: str | None) -> None:
+    """Make the node liveness probe report ``problem`` (None means it answered)."""
+    monkeypatch.setattr(bootstrap_docker.public_web_manager, "verify_node", lambda _url, _key: problem)
+
+
+@pytest.mark.parametrize(
+    ("profiles", "expected"),
+    [
+        ("public-web", True),
+        ("public-web,other", True),
+        (" public-web , other ", True),
+        ("", False),
+        ("other", False),
+        # A prefix match must not count: "public-web-dev" is a different profile.
+        ("public-web-dev", False),
+    ],
+)
+def test_profile_gates_seeding(monkeypatch: pytest.MonkeyPatch, profiles: str, expected: bool) -> None:
+    """Only the exact "public-web" profile switches the seeding on."""
+    monkeypatch.setenv("COMPOSE_PROFILES", profiles)
+    assert bootstrap_docker._public_web_enabled() is expected
+
+
+def test_missing_env_leaves_feed_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A deployment that never sets COMPOSE_PROFILES gets no public-web node."""
+    monkeypatch.delenv("COMPOSE_PROFILES", raising=False)
+    assert bootstrap_docker._public_web_enabled() is False
+
+
+def test_creates_node_and_web(monkeypatch: pytest.MonkeyPatch, session: _FakeSession) -> None:
+    """A stack with no node yet gets one, fronted by core, with a single web."""
+    _stub_lookup(monkeypatch, None)
+    _stub_verify(monkeypatch, None)
+    monkeypatch.setattr(bootstrap_docker, "_available_name", lambda _model, name: name)
+
+    created: list[object] = []
+
+    def _create(name, description, api_key, api_url, fronted_by_core=False):  # noqa: ANN001, ANN202
+        node = types.SimpleNamespace(
+            id=1,
+            name=name,
+            description=description,
+            api_key=api_key,
+            api_url=api_url,
+            fronted_by_core=fronted_by_core,
+            webs=[],
+        )
+        created.append(node)
+        return node
+
+    monkeypatch.setattr(bootstrap_docker, "PublicWebNode", _create)
+
+    bootstrap_docker._ensure_public_web("the-key")
+
+    assert len(created) == 1
+    node = created[0]
+    assert node.name == bootstrap_docker.DEFAULT_PUBLIC_WEB_NAME
+    assert node.api_url == bootstrap_docker.DEFAULT_PUBLIC_WEB_URL
+    assert node.api_key == "the-key"
+    # The node beside core: core's own Traefik publishes its webs. An ansible-
+    # registered remote node fronts its own and must never be marked.
+    assert node.fronted_by_core is True
+
+    webs = [row for row in session.added if isinstance(row, bootstrap_docker.PublicWeb)]
+    assert len(webs) == 1
+    assert webs[0].name == bootstrap_docker.DEFAULT_PUBLIC_WEB_WEB_NAME
+    # No hostname: a node can serve several webs on several hostnames, so that is
+    # set in Configuration -> Public Web, not here.
+    assert webs[0].hostname == ""
+
+
+def test_existing_node_keeps_its_name_and_web(monkeypatch: pytest.MonkeyPatch, session: _FakeSession) -> None:
+    """A renamed node is matched on api_url: no rename, no second node, no second web."""
+    node = _existing("Our Public Feed", webs=[object()])
+    _stub_lookup(monkeypatch, node)
+    _stub_verify(monkeypatch, None)
+
+    bootstrap_docker._ensure_public_web("the-key")
+
+    assert node.name == "Our Public Feed"
+    assert session.added == []
+    assert session.commits == 0
+
+
+def test_backfills_missing_api_url(monkeypatch: pytest.MonkeyPatch, session: _FakeSession) -> None:
+    """A node stored before api_url existed gets the core->node channel back."""
+    node = _existing("Default Public Web", api_url="", webs=[object()])
+    # Matched by name-independent lookup even with an empty api_url (the caller's
+    # query is stubbed); the point here is the backfill.
+    _stub_lookup(monkeypatch, node)
+    _stub_verify(monkeypatch, None)
+
+    bootstrap_docker._ensure_public_web("the-key")
+
+    assert node.api_url == bootstrap_docker.DEFAULT_PUBLIC_WEB_URL
+    assert session.commits == 1
+
+
+def test_unreachable_node_warns_but_does_not_raise(
+    monkeypatch: pytest.MonkeyPatch,
+    session: _FakeSession,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """gui/gui-v3 gate on this script exiting 0, so an absent feed must not raise."""
+    _stub_lookup(monkeypatch, None)
+    _stub_verify(monkeypatch, "No public-web node answered at 'http://public-web'")
+    monkeypatch.setattr(bootstrap_docker, "MAX_ATTEMPTS", 3)
+
+    bootstrap_docker._ensure_public_web("the-key")
+
+    assert session.added == []
+    assert "WARNING" in capsys.readouterr().out
+
+
+def test_recovers_when_the_node_shows_up_late(monkeypatch: pytest.MonkeyPatch, session: _FakeSession) -> None:  # noqa: ARG001
+    """The retry loop is what lets a slow public-web container still be seeded.
+
+    The ``session`` fixture is required for its sleep stub, not for its recording.
+    """
+    answers = ["not yet", "not yet", None]
+    monkeypatch.setattr(bootstrap_docker.public_web_manager, "verify_node", lambda _url, _key: answers.pop(0))
+    _stub_lookup(monkeypatch, _existing("Default Public Web", webs=[object()]))
+
+    bootstrap_docker._ensure_public_web("the-key")
+
+    assert answers == []


### PR DESCRIPTION
The default public-web node was the only one seeded outside `bootstrap_docker.py`
— from `prestart_core.sh`, in shell, before gunicorn started.

- Seeding moves to `bootstrap_docker.py`, beside the collector/bot/presenter/publisher nodes
- Verifies the node answers first, reusing `public_web_manager.verify_node()` — the same check the GUI runs
- Matches on `api_url` instead of grepping `Total:` out of CLI output, so a renamed node keeps its name and gets no duplicate
- Best-effort with retries: `gui`/`gui-v3` gate on bootstrap exiting 0, so an optional feed can't take the stack down
- `prestart_core.sh` no longer reads `/run/secrets/api_key` at all
- `COMPOSE_PROFILES` moves from `core` to `bootstrap`; `public-web` added to its `depends_on` with `required: false`

## Tighten the container privilege setup

- `/app` is now root-owned and read-only to the runtime user — it was being `chown`ed to the exact account an RCE lands in
- Bytecode precompiled at build (`compileall` + `PYTHONDONTWRITEBYTECODE`), so a read-only `/app` costs nothing at import
- Writable dirs are owned at build time; the runtime pass is `find ! -user … -exec chown`, a no-op after the first start
- Kept in `entrypoint.sh`, not moved to `bootstrap`: bootstrap runs *after* the services boot, mounts none of these volumes, and doesn't exist in ansible worker deployments

## Verified

Full stack built and run on a throwaway project:

- bootstrap seeds `Default Public Web` + `Default Web`, `fronted_by_core=t`, `last_seen` populated — core really reaches the node it created
- Re-running is idempotent; after a rename it keeps the operator's name with no duplicate
- Profile off: bootstrap skips, exits 0, no `public-web` container created, nothing waits on it
- All six services' processes run as `taranis`; `/app` read-only in every one; each writes its own volume
- Upgrade path: volumes forced root-owned are fixed on start; a restart leaves ctime untouched (no chown work)
- 522 core+shared tests pass, 12 new
