### PR TITLE
fix(dev): /auth/redeem 403 on every login page visit in development

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -113,6 +113,9 @@ MODULES_LOG_LEVEL=WARN
 # port or hostname difference makes a different origin: http://localhost:4444
 # and http://127.0.0.1:4444 both need listing.
 #
+# The same list also says who may redeem a redirect (OIDC/SAML) login: POST
+# /api/v1/auth/redeem accepts an allow-listed origin, and otherwise only its own.
+#
 # Never enable this without an explicit list. Credentialed CORS that reflects
 # whatever Origin it is sent lets any site a logged-in analyst visits call the
 # API as them.

--- a/src/core/api/auth.py
+++ b/src/core/api/auth.py
@@ -205,16 +205,49 @@ def _login_cookie_kwargs() -> dict:
     }
 
 
+def _normalized_origin(value: str | None) -> str | None:
+    """Reduce an origin to a comparable ``scheme://host[:port]``, or None if unusable.
+
+    Args:
+        value (str | None): An Origin header value or a configured origin.
+
+    Returns:
+        str | None: The normalized origin, or None when it is not a usable http(s) origin.
+    """
+    if not value:
+        return None
+    parsed = urllib.parse.urlparse(value.strip())
+    if parsed.scheme not in ("http", "https") or not parsed.netloc or parsed.path not in ("", "/"):
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}".lower()
+
+
 def _is_same_origin_request() -> bool:
-    """Reject browser redemption requests originating outside this exact origin."""
+    """Reject browser redemption requests originating outside this exact origin.
+
+    An origin the deployment explicitly allow-listed in TARANIS_NG_CORS_ORIGINS is
+    accepted as well, and that branch is checked first: such a GUI (a Vite dev server
+    on another port, the E2E stack) is genuinely cross-site, so ``Sec-Fetch-Site``
+    below would otherwise reject it before its Origin is ever compared. Those origins
+    already hold a credentialed CORS grant over the whole API (see ``create_app``), so
+    this only stops redemption from being the one endpoint that ignores the opt-in. The
+    list is empty in production, where GUI and API share an origin, and this reduces to
+    the exact-origin comparison it has always been.
+
+    Returns:
+        bool: True when the request may redeem a redirect-login handle.
+    """
+    header = request.headers.get("Origin")
+    origin = _normalized_origin(header)
+    allowed = {normalized for normalized in (_normalized_origin(entry) for entry in Config.CORS_ORIGINS) if normalized}
+    if origin and origin in allowed:
+        return True
     fetch_site = request.headers.get("Sec-Fetch-Site")
     if fetch_site and fetch_site not in ("same-origin", "none"):
         return False
-    origin = request.headers.get("Origin")
-    if not origin:
+    if not header:
         return True
-    parsed = urllib.parse.urlparse(origin)
-    return parsed.scheme == request.scheme and parsed.netloc == request.host and parsed.path in ("", "/")
+    return bool(origin) and origin == _normalized_origin(f"{request.scheme}://{request.host}")
 
 
 def _oauth_redirect_uri(provider_slug: str, config: dict) -> str:

--- a/src/core/app.py
+++ b/src/core/app.py
@@ -48,7 +48,9 @@ def create_app() -> Flask:
         # deployment serves the GUI and the API from the same origin. A
         # development GUI on another port opts in explicitly:
         #   TARANIS_NG_CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
-        cors_origins = [origin for origin in (os.getenv("TARANIS_NG_CORS_ORIGINS") or "").split(",") if origin.strip()]
+        # The list is parsed once in config.Config so that this grant and the
+        # same-origin check on /auth/redeem always agree on who is trusted.
+        cors_origins = app.config.get("CORS_ORIGINS") or []
         if cors_origins:
             CORS(app, supports_credentials=True, origins=cors_origins)
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -43,6 +43,7 @@ class Config:
         OIDC_RESOURCE_CHECK_AUD (bool): Whether to check the audience of OIDC resource.
         OIDC_CLOCK_SKEW (int): The clock skew in seconds for OIDC.
         OPENID_LOGOUT_URL (str): The URL for OIDC logout.
+        CORS_ORIGINS (list): The origins allowed to call the API cross-origin with credentials.
 
     """
 
@@ -119,3 +120,14 @@ class Config:
     OIDC_CLOCK_SKEW = 560
 
     OPENID_LOGOUT_URL = os.getenv("OPENID_LOGOUT_URL")
+
+    # Origins allowed to drive the GUI cross-origin with credentials. Empty by
+    # default: the production deployment serves the GUI and the API from one
+    # origin, and a credentials-capable CORS grant must never reflect arbitrary
+    # origins. A development GUI on another port opts in explicitly (see
+    # TARANIS_NG_CORS_ORIGINS in docker/.env.example). Read here rather than at
+    # each use so the CORS grant in app.py and the same-origin check on the
+    # redirect-login redemption endpoint can never disagree about the list.
+    CORS_ORIGINS: ClassVar[list[str]] = [
+        origin.strip() for origin in (os.getenv("TARANIS_NG_CORS_ORIGINS") or "").split(",") if origin.strip()
+    ]

--- a/src/core/tests/conftest.py
+++ b/src/core/tests/conftest.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import sys
 import types
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import pytest
 
@@ -32,6 +32,12 @@ if "config" not in sys.modules:
 
     class Config(metaclass=_AnyConfig):
         """Stub of ``config.Config`` for import-time use in tests."""
+
+        # Declared explicitly because the metaclass fallback hands back a string,
+        # and code that iterates this list would then silently walk its characters
+        # instead of failing. Empty is also the production default: CORS is off
+        # unless TARANIS_NG_CORS_ORIGINS names the origins to trust.
+        CORS_ORIGINS: ClassVar[list[str]] = []
 
     _module.Config = Config
     sys.modules["config"] = _module

--- a/src/core/tests/test_goto_url.py
+++ b/src/core/tests/test_goto_url.py
@@ -115,3 +115,73 @@ def test_redemption_requires_same_origin_when_browser_origin_is_present() -> Non
         headers={"Origin": "https://other.example", "Sec-Fetch-Site": "same-site"},
     ):
         assert auth._is_same_origin_request() is False
+
+
+def test_redemption_default_config_allow_lists_nothing() -> None:
+    # Production ships with TARANIS_NG_CORS_ORIGINS unset (the default asserted here),
+    # and then the check is exactly the exact-origin comparison it has always been:
+    # nothing cross-origin gets through, whatever the browser labels the request.
+    assert auth.Config.CORS_ORIGINS == []
+
+    for fetch_site in ("cross-site", "same-site", "same-origin"):
+        with app.test_request_context(
+            "/api/v1/auth/redeem",
+            method="POST",
+            base_url="https://taranis.example",
+            headers={"Origin": "http://localhost:4444", "Sec-Fetch-Site": fetch_site},
+        ):
+            assert auth._is_same_origin_request() is False
+
+
+def test_redemption_accepts_an_explicitly_allow_listed_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The dev/E2E GUI runs on its own port and talks to core directly, so the browser
+    # labels the request cross-site. That origin already holds a credentialed CORS
+    # grant; redemption must not be the one endpoint that ignores it.
+    monkeypatch.setattr(auth.Config, "CORS_ORIGINS", ["http://localhost:4444", "http://127.0.0.1:4444"])
+
+    for origin in ("http://localhost:4444", "http://127.0.0.1:4444"):
+        with app.test_request_context(
+            "/api/v1/auth/redeem",
+            method="POST",
+            base_url="http://127.0.0.1:8090",
+            headers={"Origin": origin, "Sec-Fetch-Site": "cross-site"},
+        ):
+            assert auth._is_same_origin_request() is True
+
+
+def test_redemption_still_rejects_origins_outside_the_allow_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth.Config, "CORS_ORIGINS", ["http://localhost:4444"])
+
+    # Neither an unrelated origin nor a lookalike on another port/scheme gets in.
+    for origin in ("http://evil.example", "http://localhost:4445", "https://localhost:4444"):
+        with app.test_request_context(
+            "/api/v1/auth/redeem",
+            method="POST",
+            base_url="http://127.0.0.1:8090",
+            headers={"Origin": origin, "Sec-Fetch-Site": "cross-site"},
+        ):
+            assert auth._is_same_origin_request() is False
+
+
+def test_allow_list_matching_ignores_trailing_slash_and_case(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An operator-typed value should not fail to match over cosmetics.
+    monkeypatch.setattr(auth.Config, "CORS_ORIGINS", ["HTTP://LocalHost:4444/"])
+
+    with app.test_request_context(
+        "/api/v1/auth/redeem",
+        method="POST",
+        base_url="http://127.0.0.1:8090",
+        headers={"Origin": "http://localhost:4444", "Sec-Fetch-Site": "cross-site"},
+    ):
+        assert auth._is_same_origin_request() is True
+
+
+def test_redemption_rejects_an_opaque_origin() -> None:
+    # Browsers send the literal "null" for opaque origins (sandboxed iframe, data: URL).
+    with app.test_request_context(
+        "/api/v1/auth/redeem",
+        method="POST",
+        base_url="https://taranis.example",
+        headers={"Origin": "null", "Sec-Fetch-Site": "same-origin"},
+    ):
+        assert auth._is_same_origin_request() is False

--- a/src/gui-v3/tests/e2e/auth.spec.js
+++ b/src/gui-v3/tests/e2e/auth.spec.js
@@ -21,6 +21,28 @@ test.describe('Authentication', () => {
         await expect(page.locator('[data-test="login-submit"]')).toBeVisible()
     })
 
+    test('should reach the login page without a rejected redemption', async ({ page }) => {
+        // The login page POSTs /auth/redeem on every mount: the one-time handle left by an
+        // OIDC/SAML round trip is HttpOnly, so the GUI cannot tell whether one exists and
+        // has to ask. Anything but a clean answer surfaces as a failed request in the
+        // console and a login-error banner on an otherwise ordinary visit. This runs in the
+        // dev-server setup Playwright boots (see playwright.config.js), where the GUI is on
+        // :4444 and core on another port - a cross-origin call that core accepts only
+        // because TARANIS_NG_CORS_ORIGINS in docker/.env.e2e grants that origin.
+        // Armed before navigating and awaited after: the POST is only issued once
+        // /auth/methods resolves, which is also what renders the form, so waiting on
+        // the form and then reading collected responses races the request. The wait
+        // times out if the call never happens, which is the other half of the check.
+        const redemption = page.waitForResponse('**/api/v1/auth/redeem')
+
+        await page.goto('/v2/login')
+
+        // 204 is the normal "nothing to redeem"; 200 carries a verdict to apply.
+        expect((await redemption).status()).toBeLessThan(400)
+        await expect(page.locator('[data-test="login-submit"]')).toBeVisible()
+        await expect(page.locator('[data-test="login-error"]')).toBeHidden()
+    })
+
     test('should login with valid credentials', async ({ page }) => {
         // Fill login form
         await page.locator('[data-test="login-username"] input').fill('admin')

--- a/src/gui-v3/tests/unit/dev-server-proxy.spec.ts
+++ b/src/gui-v3/tests/unit/dev-server-proxy.spec.ts
@@ -1,0 +1,202 @@
+// @vitest-environment node
+/**
+ * The `npm run dev` contract.
+ *
+ * This runs the real `npm run dev` against a throwaway backend, so a change that
+ * breaks local development fails here instead of on the next developer's machine.
+ * It is a child process rather than an in-process `createServer()` because a Vite
+ * dev server installs process-wide exit handlers (stdin end / SIGTERM -> close and
+ * `process.exit()`); inside a vitest worker those fire at unpredictable moments and
+ * kill the worker mid-run. A child process also means this covers the npm script
+ * itself, which is what the developer actually types.
+ *
+ * The specific regression under guard: `changeOrigin: true` rewrites the outgoing
+ * Host to the backend but leaves the browser's Origin (http://localhost:4444) alone.
+ * Core's `_is_same_origin_request()` (src/core/api/auth.py) compares the two and
+ * answered 403 to every POST /api/v1/auth/redeem, which the login page issues on
+ * each mount - a failed request in the console and a spurious error banner on the
+ * login screen. The proxy is the origin as far as the backend is concerned, so it
+ * has to present Host and Origin consistently.
+ */
+import { spawn } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { createServer as createHttpServer } from 'node:http'
+import type { IncomingHttpHeaders, Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { fileURLToPath } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+type RecordedRequest = { url: string; headers: IncomingHttpHeaders }
+
+const root = fileURLToPath(new URL('../../', import.meta.url))
+const STARTUP_TIMEOUT_MS = 60_000
+
+const received: RecordedRequest[] = []
+
+let backend: Server
+let backendOrigin = ''
+let dev: ChildProcess
+let devOrigin = ''
+let devOutput = ''
+
+const listenOnEphemeralPort = (server: Server): Promise<number> =>
+    new Promise((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', () => {
+            resolve((server.address() as AddressInfo).port)
+        })
+    })
+
+/**
+ * Claim a free port by taking one and handing it straight back.
+ *
+ * VITE_PORT=0 does not mean "any port" to Vite - it falls back to the default 5173,
+ * which is both a port other Vite projects use and one editors watch for and open in
+ * a browser. A stray page load against this server would pollute the recorded
+ * requests. The dev server is started with --strictPort, so if something claims the
+ * port in between it fails loudly here instead of drifting onto another one.
+ */
+const reserveFreePort = async (): Promise<number> => {
+    const placeholder = createHttpServer()
+    const port = await listenOnEphemeralPort(placeholder)
+    await new Promise<void>((resolve) => placeholder.close(() => resolve()))
+    return port
+}
+
+/**
+ * Wait until the dev server answers on the port it was given.
+ *
+ * Readiness is probed over HTTP rather than read off stdout. Vite prints its URL with
+ * the port wrapped in ANSI colour codes whenever the runner asks for colour (an
+ * editor's test runner does, a pipe does not), so parsing that line passes from a
+ * terminal and times out inside the IDE. --strictPort means the port is either ours
+ * or the process dies, so there is nothing to parse: an answer on it IS the server.
+ * The output is still collected, to say what went wrong if it never comes up.
+ */
+const waitForDevServer = async (): Promise<void> => {
+    const deadline = Date.now() + STARTUP_TIMEOUT_MS
+
+    while (Date.now() < deadline) {
+        if (dev.exitCode !== null) {
+            throw new Error(`the dev server exited with ${dev.exitCode}:\n${devOutput}`)
+        }
+        try {
+            const response = await fetch(`${devOrigin}/v2/`)
+            await response.text()
+            if (response.ok) {
+                return
+            }
+        } catch {
+            // not listening yet
+        }
+        await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+
+    throw new Error(`the dev server did not answer on ${devOrigin} within ${STARTUP_TIMEOUT_MS} ms:\n${devOutput}`)
+}
+
+beforeAll(async () => {
+    backend = createHttpServer((req, res) => {
+        received.push({ url: req.url ?? '', headers: req.headers })
+        res.writeHead(204)
+        res.end()
+    })
+    backendOrigin = `http://127.0.0.1:${await listenOnEphemeralPort(backend)}`
+
+    const devPort = await reserveFreePort()
+    devOrigin = `http://localhost:${devPort}`
+
+    dev = spawn('npm', ['run', 'dev', '--', '--strictPort'], {
+        cwd: root,
+        // VITE_PORT keeps the test off 4444, where a developer's own dev server lives,
+        // and off 5173. The three backend variables are pinned at the stub so that
+        // whatever sits in the developer's docker/.env - which vite.config.js loads
+        // through `loadEnv(mode, dockerEnvDir, '')` - cannot change where these
+        // requests end up.
+        env: {
+            ...process.env,
+            VITE_PORT: String(devPort),
+            VITE_DEV_BACKEND_ORIGIN: backendOrigin,
+            VITE_APP_TARANIS_NG_CORE_API: `${backendOrigin}/api/v1`,
+            VITE_APP_TARANIS_NG_CORE_SSE: `${backendOrigin}/sse`
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+        // Own process group: npm forks vite, and killing npm alone would orphan it.
+        detached: true
+    })
+    dev.stdout?.setEncoding('utf8')
+    dev.stderr?.setEncoding('utf8')
+    dev.stdout?.on('data', (chunk: string) => (devOutput += chunk))
+    dev.stderr?.on('data', (chunk: string) => (devOutput += chunk))
+
+    await waitForDevServer()
+}, STARTUP_TIMEOUT_MS + 10_000)
+
+afterAll(async () => {
+    if (dev?.pid && dev.exitCode === null) {
+        const exited = new Promise<void>((resolve) => dev.once('exit', () => resolve()))
+        process.kill(-dev.pid, 'SIGTERM')
+        await exited
+    }
+    await new Promise<void>((resolve) => backend.close(() => resolve()))
+})
+
+/**
+ * Send one request through the dev proxy and return what the backend saw of it.
+ *
+ * Each probe carries its own marker rather than trusting the last recorded request:
+ * the dev server is a real one, and the browser page, the Vite client or a retry
+ * could otherwise slip a request in between the call and the assertion.
+ */
+const probe = async (path: string, init?: RequestInit): Promise<{ request: RecordedRequest; response: Response }> => {
+    const marker = `probe=${randomUUID()}`
+    const response = await fetch(`${devOrigin}${path}${path.includes('?') ? '&' : '?'}${marker}`, init)
+    const request = received.find((entry) => entry.url.includes(marker))
+    if (!request) {
+        throw new Error(`the dev server did not forward ${path} to the backend`)
+    }
+    return { request, response }
+}
+
+/** The path the backend was asked for, without the probe marker. */
+const pathOf = (request: RecordedRequest): string => request.url.split('?')[0] ?? ''
+
+describe('npm run dev', () => {
+    it('serves the app shell under the /v2 base', async () => {
+        const response = await fetch(`${devOrigin}/v2/`)
+
+        expect(response.status).toBe(200)
+        expect(await response.text()).toContain('<div id="app">')
+    })
+
+    it('forwards /api to the backend with the path intact', async () => {
+        const { request, response } = await probe('/api/v1/auth/redeem', { method: 'POST' })
+
+        expect(response.status).toBe(204)
+        expect(pathOf(request)).toBe('/api/v1/auth/redeem')
+    })
+
+    it('sends an Origin that agrees with the rewritten Host', async () => {
+        // What the browser sends from the dev server's own page.
+        const { request } = await probe('/api/v1/auth/redeem', {
+            method: 'POST',
+            headers: { 'Origin': devOrigin, 'Sec-Fetch-Site': 'same-origin' }
+        })
+
+        expect(request.headers['host']).toBe(new URL(backendOrigin).host)
+        expect(request.headers['origin']).toBe(backendOrigin)
+    })
+
+    it('does not invent an Origin the browser never sent', async () => {
+        const { request } = await probe('/api/v1/auth/methods')
+
+        expect(request.headers['origin']).toBeUndefined()
+    })
+
+    it('forwards /sse to the backend as well', async () => {
+        const { request } = await probe('/sse/events')
+
+        expect(pathOf(request)).toBe('/sse/events')
+    })
+})

--- a/src/gui-v3/vite.config.js
+++ b/src/gui-v3/vite.config.js
@@ -24,6 +24,22 @@ export default defineConfig(({ mode }) => {
         }
     }
 
+    const apiProxyTarget = getProxyTarget(apiBaseUrl)
+
+    // `changeOrigin` rewrites the Host header to the backend, but leaves the browser's
+    // Origin (http://localhost:4444) untouched. Core's redirect-login redemption endpoint
+    // refuses a request whose Origin does not match its own host, so that mismatch made
+    // every visit to /login answer 403 and raise a login error banner. As far as the
+    // backend is concerned the proxy *is* the origin, so present the Host and the Origin
+    // consistently. Only rewrite a header the browser actually sent.
+    const alignOriginWithHost = (target) => (proxy) => {
+        proxy.on('proxyReq', (proxyReq) => {
+            if (proxyReq.getHeader('origin')) {
+                proxyReq.setHeader('origin', target)
+            }
+        })
+    }
+
     return {
         plugins: [
             vue(),
@@ -47,10 +63,11 @@ export default defineConfig(({ mode }) => {
             proxy: {
                 // Proxy API calls during development
                 '/api': {
-                    target: getProxyTarget(apiBaseUrl),
+                    target: apiProxyTarget,
                     rewrite: (path) => path,
                     changeOrigin: true,
-                    secure: false
+                    secure: false,
+                    configure: alignOriginWithHost(apiProxyTarget)
                 },
                 '/sse': {
                     target: getProxyTarget(sseBaseUrl),


### PR DESCRIPTION
## Problem

`npm run dev` → open `/v2/` → every visit to the login page logged a failed
`POST /api/v1/auth/redeem` (403) and showed a login-error banner.

The login page has to call `/auth/redeem` on each mount (the redirect-login handle is
HttpOnly, so the GUI cannot tell whether one exists). The Vite proxy's `changeOrigin`
rewrites `Host` to the backend but leaves the browser's `Origin` alone, and core's
`_is_same_origin_request()` compares the two.

A second shape of the same bug: `dev:remote` (used by the E2E suite) points the GUI at an
absolute API base, so the browser talks to core cross-origin and skips the proxy entirely.
That origin already holds a credentialed CORS grant via `TARANIS_NG_CORS_ORIGINS` —
redemption was the only endpoint ignoring it.

## Changes

- **`vite.config.js`** — the `/api` proxy rewrites the outgoing `Origin` to match the
  `Host` it presents. Dev-server only; `server.proxy` is not part of the production build.
- **`core/api/auth.py`** — an allow-listed `Origin` is accepted, checked before the
  `Sec-Fetch-Site` test (a legitimately cross-origin dev GUI reports `cross-site` there).
- **`core/config.py` / `core/app.py`** — `TARANIS_NG_CORS_ORIGINS` is parsed once in
  `Config`, shared by the CORS grant and the redemption check.
- **`docker/.env.example`** — documents that the list also governs redemption.

## Tests

- `tests/unit/dev-server-proxy.spec.ts` — runs the real `npm run dev` against a throwaway
  backend on a reserved port: `/v2/` serves the shell, `/api` and `/sse` proxy with paths
  intact, `Host` and `Origin` agree, no `Origin` is invented when the browser sent none.
  ~1 s, no Docker, covered by the existing unit CI job.
- `tests/e2e/auth.spec.js` — the login page issues no rejected `/auth/redeem` and shows no
  error banner, against the real core in the cross-origin setup.
- `core/tests/test_goto_url.py` — allow-listed origin passes while cross-site; unlisted
  origins, lookalike ports/schemes and opaque `null` origins still rejected; empty list
  (production default) leaves behaviour unchanged.

## Risk

None in production: `TARANIS_NG_CORS_ORIGINS` is unset there, `CORS()` is still never
installed, and the redemption check reduces to the exact-origin comparison it has always
been. The open-redirect guard on `gotoUrl` is untouched.

Verified: 479 core tests, 1298 GUI unit tests, ruff/eslint/vue-tsc clean.
