### PR TITLE
Publisher key files unreadable since the unprivileged-user change

### DIFF
--- a/docker/Dockerfile.publishers
+++ b/docker/Dockerfile.publishers
@@ -60,11 +60,17 @@ ENV GUNICORN_CMD_ARGS="--timeout 120"
 # Run the service as an unprivileged user; docker/entrypoint.sh drops to it via
 # su-exec. /app stays root-owned so the runtime user cannot rewrite its own code;
 # the bytecode is precompiled instead.
+
 RUN apk add --no-cache su-exec \
     && adduser -D -u 10001 taranis \
-    && python -m compileall -q /app
+    && python -m compileall -q /app \
+    && mkdir -p /app/crypto \
+    && chown -R taranis /app/crypto
 ENV PYTHONDONTWRITEBYTECODE="1"
 ENV TARANIS_USER="taranis"
+# Covers the other way the material arrives: a bind mount over /app/crypto, whose
+# ownership comes from the host and so cannot be fixed at build time.
+ENV TARANIS_WRITABLE_PATHS="/app/crypto"
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/start.sh"]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -139,15 +139,19 @@ point CI uses.
 - **`src/bots`, `src/collectors` have no tests yet.** Add a `tests/` directory, then list
   the project in `PYTEST_SUITES` in `scripts/run_tests.py` and in `testpaths` in the root
   `pyproject.toml`.
-- **`src/publishers` cannot be collected yet.** Adding `tests/` there is not enough: pytest
-  tries to import the service root `src/publishers/__init__.py` as a test module, that
-  `__init__` does `from .app import create_app`, and the chain reaches
-  `managers/publishers_manager.py`'s `from publishers.email_publisher import ...` while the
-  service-root package named `publishers` is still half-initialized — so collection dies on
-  `ModuleNotFoundError: No module named 'publishers.email_publisher'`, even for an empty
-  test file, and `--import-mode=importlib` does not help. Presenters has the same
-  service-root/inner-package name clash but survives it. Making this suite runnable means
-  breaking the clash (rename the inner `publishers/` package, or drop the service-root
-  `__init__.py`), which is a structural change rather than a pytest setting.
-  `managers/ssh_host_keys.py` is the code most in need of it: its host-key verification is
-  a security control with no automated coverage until this is resolved.
+- **`src/publishers/tests` has to bind its own package before pytest does.** It stubs
+  `config` like presenters, and works around a service-root/inner-package name clash on
+  top of that: `src/publishers/__init__.py` makes the service root a package called
+  `publishers`, so pytest imports it, its `from .app import create_app` reaches
+  `managers/publishers_manager.py`'s `from publishers.email_publisher import ...` while
+  that same name is still half-initialized, and collection dies on `ModuleNotFoundError:
+  No module named 'publishers.email_publisher'` — even for an empty test file, and
+  `--import-mode=importlib` does not help. `tests/conftest.py` therefore imports
+  `publishers` itself first, binding it to the inner package the way the running service
+  does (its `PYTHONPATH` is `/app`); pytest then finds it in `sys.modules` and never
+  executes the service-root `__init__`. Presenters has the same clash and survives it
+  only by luck of `sys.path` ordering, so do not read that suite as proof the layout is
+  fine.
+- **`managers/ssh_host_keys.py` still has no coverage.** Its host-key verification is a
+  security control, and the publishers suite covers key loading and the publishers
+  themselves but not the pinning policy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ members = ["src/shared"]
 # scripts/run_tests.py instead runs pytest per project, picking up that project's own
 # [tool.pytest.ini_options]. Keep in sync with PYTEST_SUITES in scripts/run_tests.py.
 [tool.pytest.ini_options]
-testpaths = ["src/core/tests", "src/shared/tests", "src/presenters/tests", "src/public_web/tests"]
+testpaths = ["src/core/tests", "src/shared/tests", "src/presenters/tests", "src/public_web/tests", "src/publishers/tests"]
 # The projects are never pip-installed for a test run, so their roots go on sys.path.
 pythonpath = ["src/core", "src/shared"]
 

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -45,7 +45,7 @@ GUI_DIR = REPO_ROOT / "src" / "gui-v3"
 # Projects with a pytest suite, as directories under src/. Keep in sync with `testpaths`
 # in the root pyproject.toml, which is what editors use. The other services have no
 # tests yet - see "Known gaps" in docs/testing.md.
-PYTEST_SUITES: tuple[str, ...] = ("core", "shared", "presenters", "public_web")
+PYTEST_SUITES: tuple[str, ...] = ("core", "shared", "presenters", "public_web", "publishers")
 
 DEFAULT_SUITES: tuple[str, ...] = ("pytest", "vitest", "ansible")
 ALL_SUITES: tuple[str, ...] = (*DEFAULT_SUITES, "e2e")

--- a/src/publishers/managers/key_files.py
+++ b/src/publishers/managers/key_files.py
@@ -1,0 +1,41 @@
+"""Diagnostics for the key files publisher presets point at.
+
+Two presets name a file the publisher has to read: the SFTP publisher's private
+key, and the email publisher's signing and encryption keys. Both are mounted in
+from the host, and both used to be read by a service running as root. Since the
+services dropped to an unprivileged user a key mounted 0600 root:root is
+readable on the host and not in the container, so the failure an operator hits
+first is a bare ``Permission denied`` naming a path that, being relative to the
+container's working directory, does not exist anywhere they can look.
+
+Everything needed to act on that - the path actually opened and the uid that
+could not open it - lives here so the two publishers report it the same way.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def unreadable_key_error(key_path: str, description: str, error: OSError) -> OSError:
+    """Build the error to raise when a configured key file cannot be read.
+
+    Args:
+        key_path (str): The path as configured in the preset, absolute or relative.
+        description (str): What the file is, for the message ("SSH key").
+        error (OSError): The failure from the attempted read.
+
+    Returns:
+        OSError: The replacement error, to raise ``from`` the original.
+    """
+    # A relative path resolves against the container's working directory, not
+    # against anything the operator who typed it into the preset can see. Report
+    # the path actually opened, so the failure names a findable file.
+    msg = f"Cannot read the {description} at {Path(key_path).resolve()}: {error.strerror}."
+    if isinstance(error, PermissionError):
+        msg += (
+            f" The publishers service runs as uid {os.getuid()}, so a file only root can read is unusable - "
+            f"'chown {os.getuid()} <file>' on the host lets the container read it while it stays 0600."
+        )
+    return OSError(msg)

--- a/src/publishers/publishers/email_publisher.py
+++ b/src/publishers/publishers/email_publisher.py
@@ -7,6 +7,7 @@ from http import HTTPStatus
 from pathlib import Path
 
 from envelope import Envelope
+from managers.key_files import unreadable_key_error
 from shared.common import TZ
 from shared.config_publisher import ConfigPublisher
 from shared.log_manager import logger
@@ -58,6 +59,24 @@ class EMAILPublisher(BasePublisher):
 
         smtp = {"host": smtp_server, "port": smtp_server_port, "user": user, "password": password}
 
+        def _read_key(key_path: str, description: str) -> str:
+            """Read the signing or encryption key the preset points at.
+
+            Args:
+                key_path (str): The configured path to the key file.
+                description (str): What the file is, for the error message.
+
+            Returns:
+                str: The key material.
+
+            Raises:
+                OSError: The key file cannot be read.
+            """
+            try:
+                return Path(key_path).read_text()
+            except OSError as error:
+                raise unreadable_key_error(key_path, description, error) from error
+
         envelope = Envelope()
 
         # if attachment data available from presenter
@@ -104,18 +123,20 @@ class EMAILPublisher(BasePublisher):
         envelope.from_(sender)
         envelope.to(recipients)
 
-        if sign == "auto":
-            envelope.signature(key=sign)
-        elif Path(sign).is_file():
-            self.logger.info(f"Signing email with file {sign}")
-            with Path(sign).open("r") as sign_file:
-                envelope.signature(key=sign_file.read(), passphrase=sign_password)
-        if encrypt == "auto":
-            envelope.encryption(key=encrypt)
-        elif Path(encrypt).is_file():
-            self.logger.info(f"Encrypting email with file {encrypt}")
-            with Path(encrypt).open("r") as encrypt_file:
-                envelope.encryption(key=encrypt_file.read())
+        try:
+            if sign == "auto":
+                envelope.signature(key=sign)
+            elif sign:
+                self.logger.info(f"Signing email with file {sign}")
+                envelope.signature(key=_read_key(sign, "email signing key"), passphrase=sign_password)
+            if encrypt == "auto":
+                envelope.encryption(key=encrypt)
+            elif encrypt:
+                self.logger.info(f"Encrypting email with file {encrypt}")
+                envelope.encryption(key=_read_key(encrypt, "email encryption key"))
+        except OSError as error:
+            self.logger.exception(f"Error: {error}")
+            return {"error": str(error)}, HTTPStatus.INTERNAL_SERVER_ERROR
 
         email_string = str(envelope)
         max_length = 3000

--- a/src/publishers/publishers/ftp_publisher.py
+++ b/src/publishers/publishers/ftp_publisher.py
@@ -5,7 +5,7 @@ import ftplib
 import mimetypes
 from base64 import b64decode
 from http import HTTPStatus
-from pathlib import Path
+from io import BytesIO
 from urllib.parse import urlsplit
 
 from shared.common import TZ
@@ -49,10 +49,10 @@ class FTPPublisher(BasePublisher):
             filename = f"file_{datetime.datetime.now(TZ).strftime('%d-%m-%Y_%H:%M')}{file_extension}"
             data = publisher_input.data[:]
             bytes_data = b64decode(data, validate=True)
-
-            with Path(filename).open("wb") as f:
-                f.write(bytes_data)
-                f.close()
+            # Kept in memory rather than staged on disk: the working directory belongs
+            # to root so the unprivileged service cannot write there, and a temporary
+            # file left behind on a failed upload is one more thing to clean up.
+            file_object = BytesIO(bytes_data)
 
             ftp_data = urlsplit(ftp_url)
 
@@ -68,8 +68,7 @@ class FTPPublisher(BasePublisher):
                 self.logger.debug(f"Connecting FTP: {ftp_hostname}, port {ftp_port}")
                 ftp.connect(host=ftp_hostname, port=ftp_port)
                 ftp.login(ftp_username, ftp_password)
-                with Path(filename).open("rb") as f:
-                    ftp.storbinary("STOR " + remote_path, f)
+                ftp.storbinary("STOR " + remote_path, file_object)
                 ftp.quit()
                 return {}, HTTPStatus.OK
 
@@ -80,6 +79,3 @@ class FTPPublisher(BasePublisher):
         except Exception as error:
             self.logger.exception(f"Error: {error}")
             return {"error": str(error)}, HTTPStatus.INTERNAL_SERVER_ERROR
-
-        finally:
-            Path(filename).unlink()

--- a/src/publishers/publishers/sftp_publisher.py
+++ b/src/publishers/publishers/sftp_publisher.py
@@ -16,6 +16,7 @@ from io import BytesIO
 from pathlib import Path
 
 import paramiko
+from managers.key_files import unreadable_key_error
 from managers.ssh_host_keys import apply_host_key_policy
 from shared.common import TZ
 from shared.config_publisher import ConfigPublisher
@@ -60,23 +61,44 @@ class SFTPPublisher(BasePublisher):
         now = datetime.now(TZ).strftime("%Y%m%d%H%M%S")
 
         def _get_key(key_path: str, ssh_key_password: str | None) -> PKey:
-            try:
-                return paramiko.RSAKey(filename=key_path, password=ssh_key_password)
-            except paramiko.ssh_exception.SSHException:
-                pass
-            try:
-                return paramiko.Ed25519Key(filename=key_path, password=ssh_key_password)
-            except paramiko.ssh_exception.SSHException:
-                pass
-            try:
-                return paramiko.ECDSAKey(filename=key_path, password=ssh_key_password)
-            except paramiko.ssh_exception.SSHException:
-                pass
-            try:
-                return paramiko.DSSKey(filename=key_path, password=ssh_key_password)
-            except paramiko.ssh_exception.SSHException as error:
-                self.logger.exception(f"Issue with SSH key {key_path}: {error}")
-                return None
+            """Load the configured private key, trying every type paramiko supports.
+
+            Args:
+                key_path (str): Path to the private key, absolute or relative to the
+                    publishers working directory.
+                ssh_key_password (str | None): Passphrase, if the key is encrypted.
+
+            Returns:
+                PKey: The loaded private key.
+
+            Raises:
+                OSError: The key file cannot be read.
+                paramiko.ssh_exception.SSHException: The file is not a private key of
+                    any supported type, or its passphrase is missing or wrong.
+            """
+            resolved = str(Path(key_path).resolve())
+            # An unset preset field arrives as "", which paramiko takes for a real
+            # passphrase and fails deep in bcrypt with "password and salt must not
+            # be empty". None gets the meaningful "private key file is encrypted".
+            ssh_key_password = ssh_key_password or None
+            last_error = None
+            # paramiko 5 dropped DSSKey along with DSA support, so these three are
+            # every private key type it can still load.
+            key_classes = (paramiko.RSAKey, paramiko.Ed25519Key, paramiko.ECDSAKey)
+            for key_class in key_classes:
+                try:
+                    return key_class(filename=resolved, password=ssh_key_password)
+                except paramiko.PasswordRequiredException:
+                    # The OpenSSH envelope is decrypted before the key type inside it
+                    # matters, so no other class gets further with this passphrase.
+                    raise
+                except paramiko.ssh_exception.SSHException as error:
+                    last_error = error
+                except OSError as error:
+                    raise unreadable_key_error(key_path, "SSH key", error) from error
+            supported = ", ".join(key_class.__name__.removesuffix("Key") for key_class in key_classes)
+            msg = f"{resolved} is not a private key of any supported type ({supported}): {last_error}"
+            raise paramiko.ssh_exception.SSHException(msg)
 
         try:
             # decide filename and extension

--- a/src/publishers/tests/conftest.py
+++ b/src/publishers/tests/conftest.py
@@ -1,0 +1,139 @@
+"""Pytest bootstrap and shared key fixtures for the publishers package.
+
+Importing the application package reads the Docker secret ``/run/secrets/api_key``
+at import time (``config.Config``). Tests have no secrets, so a stub ``config``
+module is injected before any application import, exactly as the core and
+presenters suites do.
+
+Two publishers read a key file an operator names in a preset - the SFTP
+publisher's private key and the email publisher's signing and encryption keys -
+and both are mounted in from the host. The fixtures here generate real key
+material so those paths are exercised for what they are, rather than mocked.
+
+Permission failures are *injected* rather than provoked with ``chmod``: root
+bypasses file modes, so a 0000 file is readable when the suite runs as root
+(the usual case in a container) and unreadable otherwise, which would make the
+most important assertions silently uid-dependent.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519, rsa
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Make the service importable when the suite runs from the repo root (the
+# aggregate testpaths config) as well as from src/publishers. This one goes to
+# the FRONT: src/publishers/__init__.py is the Flask app package, so with src/
+# on the path ahead of it `publishers` resolves there instead of to the inner
+# src/publishers/publishers, and `from publishers.sftp_publisher import ...` -
+# how the service itself imports, with /app on PYTHONPATH - stops resolving.
+_SERVICE_ROOT = str(Path(__file__).resolve().parents[1])
+if sys.path[:1] != [_SERVICE_ROOT]:
+    sys.path.insert(0, _SERVICE_ROOT)
+
+# Bind `publishers` to the inner package now, the way the running service does
+# (its PYTHONPATH is /app, so `import publishers` is /app/publishers). Otherwise
+# pytest gets there first: src/publishers has an __init__.py, so pytest collects
+# the service root as a package and imports it as `publishers` with src/ on the
+# path - which shadows the inner package, and every
+# `from publishers.<x>_publisher import ...` inside the app stops resolving.
+importlib.import_module("publishers")
+
+if "config" not in sys.modules:
+
+    class _AnyConfig(type):
+        """Metaclass yielding a throwaway value for any Config attribute access."""
+
+        def __getattr__(cls, name: str) -> str:
+            return "test-value"
+
+    _module = types.ModuleType("config")
+
+    class Config(metaclass=_AnyConfig):
+        """Stub of ``config.Config`` for import-time use in tests."""
+
+    _module.Config = Config
+    sys.modules["config"] = _module
+
+KEY_PASSPHRASE = "correct horse battery staple"
+
+
+def _write_openssh_key(path: Path, key: object, passphrase: str | None = None) -> Path:
+    """Serialise a generated private key to OpenSSH format on disk."""
+    encryption = serialization.BestAvailableEncryption(passphrase.encode()) if passphrase else serialization.NoEncryption()
+    path.write_bytes(key.private_bytes(serialization.Encoding.PEM, serialization.PrivateFormat.OpenSSH, encryption))
+    return path
+
+
+@pytest.fixture(scope="session")
+def rsa_key_file(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """An unencrypted RSA private key."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return _write_openssh_key(tmp_path_factory.mktemp("keys") / "id_rsa", key)
+
+
+@pytest.fixture(scope="session")
+def ed25519_key_file(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """An unencrypted Ed25519 private key."""
+    key = ed25519.Ed25519PrivateKey.generate()
+    return _write_openssh_key(tmp_path_factory.mktemp("keys") / "id_ed25519", key)
+
+
+@pytest.fixture(scope="session")
+def ecdsa_key_file(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """An unencrypted ECDSA private key."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    return _write_openssh_key(tmp_path_factory.mktemp("keys") / "id_ecdsa", key)
+
+
+@pytest.fixture(scope="session")
+def encrypted_key_file(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """An Ed25519 private key protected by ``KEY_PASSPHRASE``."""
+    key = ed25519.Ed25519PrivateKey.generate()
+    return _write_openssh_key(tmp_path_factory.mktemp("keys") / "id_encrypted", key, KEY_PASSPHRASE)
+
+
+@pytest.fixture
+def not_a_key_file(tmp_path: Path) -> Path:
+    """A readable file that is not a private key of any kind."""
+    path = tmp_path / "notakey.txt"
+    path.write_text("this is not a private key\n")
+    return path
+
+
+@pytest.fixture
+def publisher_input() -> Callable[..., types.SimpleNamespace]:
+    """Build the input object a publisher's ``publish`` receives.
+
+    Returns:
+        Callable: Takes the preset's parameter values as keyword arguments and
+            returns the input, with the payload fields a presenter would fill in.
+    """
+
+    def _build(**param_key_values: str) -> types.SimpleNamespace:
+        # The payload fields mirror shared.schema.publisher.PublisherInput, so a
+        # publisher reading one the tests forgot fails here rather than silently.
+        return types.SimpleNamespace(
+            name="test preset",
+            type="TEST_PUBLISHER",
+            mime_type="application/json",
+            data="eyJyZXBvcnQiOiAidGVzdCJ9",  # {"report": "test"}
+            message_title=None,
+            message_body=None,
+            message_body_mime_type=None,
+            recipients=[],
+            att_file_name=None,
+            param_key_values=param_key_values,
+        )
+
+    return _build

--- a/src/publishers/tests/test_email_publisher_keys.py
+++ b/src/publishers/tests/test_email_publisher_keys.py
@@ -1,0 +1,197 @@
+"""Signing and encryption keys an email preset names.
+
+A preset that names a key file is asking for the report to be protected. The
+question these ask is what happens when that file cannot be read: the answer
+has to be a failed publish, never a message that goes out unprotected.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+from http import HTTPStatus
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from publishers.email_publisher import EMAILPublisher
+
+from publishers import email_publisher
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class FakeEnvelope:
+    """Stand-in for ``envelope.Envelope``, recording what protection was applied."""
+
+    last: FakeEnvelope | None = None
+
+    def __init__(self) -> None:
+        """Register this instance and start with nothing applied."""
+        self.signed_with: str | None = None
+        self.signed_passphrase: str | None = None
+        self.encrypted_with: str | None = None
+        self.sent = False
+        FakeEnvelope.last = self
+
+    def signature(self, key: str | None = None, passphrase: str | None = None) -> FakeEnvelope:
+        """Record the signing key and its passphrase."""
+        self.signed_with = key
+        self.signed_passphrase = passphrase
+        return self
+
+    def encryption(self, key: str | None = None) -> FakeEnvelope:
+        """Record the encryption key."""
+        self.encrypted_with = key
+        return self
+
+    def send(self) -> bool:
+        """Pretend the message went out."""
+        self.sent = True
+        return True
+
+    def __getattr__(self, name: str) -> Callable[..., FakeEnvelope]:
+        """Accept every other envelope call (message, subject, attach, smtp...)."""
+        return lambda *_args, **_kwargs: self
+
+    @staticmethod
+    def smtp_quit() -> None:
+        """Close the SMTP session."""
+
+    def __str__(self) -> str:
+        """Render the composed message for the publisher's debug log."""
+        return "<envelope>"
+
+
+@pytest.fixture
+def envelope(monkeypatch: pytest.MonkeyPatch) -> type[FakeEnvelope]:
+    """Replace the envelope the publisher builds."""
+    FakeEnvelope.last = None
+    monkeypatch.setattr(email_publisher, "Envelope", FakeEnvelope)
+    return FakeEnvelope
+
+
+@pytest.fixture
+def email_preset(publisher_input: Callable[..., object]) -> Callable[..., object]:
+    """Build an email preset, overriding only what a test cares about."""
+
+    def _build(**overrides: str) -> object:
+        values = {
+            "SMTP_SERVER": "smtp.example.org",
+            "SMTP_SERVER_PORT": "587",
+            "EMAIL_USERNAME": "taranis",
+            "EMAIL_PASSWORD": "hunter2",
+            "EMAIL_SENDER": "taranis@example.org",
+            "EMAIL_RECIPIENT": "constituency@example.org",
+            "EMAIL_SUBJECT": "Security Warning",
+            "EMAIL_MESSAGE": "See attached.",
+            "EMAIL_SIGN": "",
+            "EMAIL_SIGN_PASSWORD": "",
+            "EMAIL_ENCRYPT": "",
+        }
+        values.update(overrides)
+        return publisher_input(**values)
+
+    return _build
+
+
+@pytest.fixture
+def signing_key(tmp_path: Path) -> Path:
+    """A readable file standing in for signing material."""
+    path = tmp_path / "sign.pem"
+    path.write_text("-----BEGIN PGP PRIVATE KEY BLOCK-----\nkey\n")
+    return path
+
+
+def test_a_configured_key_that_is_missing_fails_the_publish(
+    email_preset: Callable[..., object],
+    envelope: type[FakeEnvelope],
+    tmp_path: Path,
+) -> None:
+    """The regression this suite exists for.
+
+    ``Path(sign).is_file()`` was False for a path that does not exist, which
+    skipped the whole branch: the report was sent unsigned, with no error and no
+    log line. A preset asking for a signature must fail instead.
+    """
+    preset = email_preset(EMAIL_SIGN=str(tmp_path / "absent.pem"))
+
+    body, status = EMAILPublisher().publish(preset)
+
+    assert status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert "email signing key" in body["error"]
+    assert envelope.last.signed_with is None
+    assert not envelope.last.sent
+
+
+def test_a_missing_encryption_key_is_never_sent_in_clear(
+    email_preset: Callable[..., object],
+    envelope: type[FakeEnvelope],
+    tmp_path: Path,
+) -> None:
+    """Same for encryption, where sending anyway means sending in the clear."""
+    preset = email_preset(EMAIL_ENCRYPT=str(tmp_path / "absent.pem"))
+
+    body, status = EMAILPublisher().publish(preset)
+
+    assert status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert "email encryption key" in body["error"]
+    assert not envelope.last.sent
+
+
+def test_an_unreadable_key_explains_the_unprivileged_user(
+    email_preset: Callable[..., object],
+    envelope: type[FakeEnvelope],
+    signing_key: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The mounted-key case, injected so the result does not depend on the uid."""
+
+    def deny(self: Path, *_args: object, **_kwargs: object) -> str:
+        raise PermissionError(errno.EACCES, os.strerror(errno.EACCES), str(self))
+
+    monkeypatch.setattr(Path, "read_text", deny)
+
+    body, status = EMAILPublisher().publish(email_preset(EMAIL_SIGN=str(signing_key)))
+
+    assert status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert f"chown {os.getuid()}" in body["error"]
+    assert not envelope.last.sent
+
+
+def test_a_readable_key_signs_the_message(
+    email_preset: Callable[..., object],
+    envelope: type[FakeEnvelope],
+    signing_key: Path,
+) -> None:
+    """The configured key's contents reach the envelope."""
+    _, status = EMAILPublisher().publish(email_preset(EMAIL_SIGN=str(signing_key)))
+
+    assert status == HTTPStatus.OK
+    assert envelope.last.signed_with == signing_key.read_text()
+
+
+def test_auto_is_passed_through_rather_than_read_as_a_path(
+    email_preset: Callable[..., object],
+    envelope: type[FakeEnvelope],
+) -> None:
+    """The literal "auto" asks the envelope library to find the key; it is not a path."""
+    _, status = EMAILPublisher().publish(email_preset(EMAIL_SIGN="auto", EMAIL_ENCRYPT="auto"))
+
+    assert status == HTTPStatus.OK
+    assert envelope.last.signed_with == "auto"
+    assert envelope.last.encrypted_with == "auto"
+
+
+def test_an_unconfigured_preset_sends_without_protection(
+    email_preset: Callable[..., object],
+    envelope: type[FakeEnvelope],
+) -> None:
+    """An empty setting means the preset never asked for signing; that still sends."""
+    _, status = EMAILPublisher().publish(email_preset())
+
+    assert status == HTTPStatus.OK
+    assert envelope.last.signed_with is None
+    assert envelope.last.encrypted_with is None
+    assert envelope.last.sent

--- a/src/publishers/tests/test_ftp_publisher.py
+++ b/src/publishers/tests/test_ftp_publisher.py
@@ -1,0 +1,138 @@
+"""The FTP publisher's upload path.
+
+It used to stage the payload as a temporary file in the working directory,
+which the image owns as root - so every publish failed once the service stopped
+running as root, and the ``finally`` that removed the file then raised
+FileNotFoundError over the top of the real error.
+"""
+
+from __future__ import annotations
+
+import errno
+import ftplib
+import os
+from http import HTTPStatus
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from publishers.ftp_publisher import FTPPublisher
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class FakeFTP:
+    """Stand-in for ``ftplib.FTP``, recording what was stored."""
+
+    last: FakeFTP | None = None
+
+    def __init__(self) -> None:
+        """Register this instance as the most recently constructed one."""
+        self.stored: list[tuple[str, bytes]] = []
+        self.quit_called = False
+        FakeFTP.last = self
+
+    def connect(self, host: str, port: int) -> None:
+        """Accept the connection."""
+
+    def login(self, user: str | None, passwd: str | None) -> None:
+        """Accept the credentials."""
+
+    def storbinary(self, command: str, fp: object) -> None:
+        """Record the upload, reading the payload the way ftplib does."""
+        self.stored.append((command, fp.read()))
+
+    def quit(self) -> None:
+        """Close the session."""
+        self.quit_called = True
+
+
+@pytest.fixture
+def unwritable_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Put the publisher in a working directory it cannot write to.
+
+    This is /app in the image: root owns it so the runtime user cannot create
+    files there. Simulated rather than reproduced with permissions, because root
+    bypasses file modes and the suite would otherwise assert nothing when it runs
+    as root - which is the normal case in a container.
+    """
+    monkeypatch.chdir(tmp_path)
+    real_open = Path.open
+
+    def guarded(self: Path, mode: str = "r", *args: object, **kwargs: object) -> object:
+        if any(flag in mode for flag in "wax"):
+            raise PermissionError(errno.EACCES, os.strerror(errno.EACCES), str(self))
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", guarded)
+    return tmp_path
+
+
+@pytest.fixture
+def ftp(monkeypatch: pytest.MonkeyPatch) -> type[FakeFTP]:
+    """Replace the FTP client the publisher builds."""
+    FakeFTP.last = None
+    monkeypatch.setattr(ftplib, "FTP", FakeFTP)
+    return FakeFTP
+
+
+def test_the_payload_is_uploaded_from_memory(
+    publisher_input: Callable[..., object],
+    ftp: type[FakeFTP],
+    unwritable_cwd: Path,
+) -> None:
+    """The upload succeeds even though the working directory refuses writes.
+
+    It used to stage the payload there first, so this failed outright once the
+    service stopped running as root - and the ``finally`` that removed the file
+    then raised FileNotFoundError over the top of the real error, so what
+    reached the operator did not mention permissions at all.
+    """
+    preset = publisher_input(FTP_URL="ftp://user:pass@ftp.example.org/incoming/")
+
+    _, status = FTPPublisher().publish(preset)
+
+    assert status == HTTPStatus.OK
+    assert list(unwritable_cwd.iterdir()) == []
+    command, payload = ftp.last.stored[0]
+    assert command.startswith("STOR /incoming/file_")
+    assert payload == b'{"report": "test"}'
+    assert ftp.last.quit_called
+
+
+@pytest.mark.usefixtures("ftp", "unwritable_cwd")
+def test_an_unsupported_scheme_is_reported_not_raised(
+    publisher_input: Callable[..., object],
+) -> None:
+    """The branch returns its own error, not one from a cleanup step.
+
+    This return used to run a ``finally`` that unlinked the staged file, so the
+    error the operator saw came from the cleanup rather than from the scheme.
+    """
+    preset = publisher_input(FTP_URL="sftp://user:pass@ftp.example.org/incoming/")
+
+    body, status = FTPPublisher().publish(preset)
+
+    assert status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert "not supported by the FTP publisher" in body["error"]
+
+
+@pytest.mark.usefixtures("ftp", "unwritable_cwd")
+def test_a_failed_upload_reports_the_upload_error(
+    publisher_input: Callable[..., object],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The error that reaches the operator is the one that actually happened."""
+
+    def refuse(*_args: object) -> None:
+        msg = "550 Permission denied on the remote server"
+        raise ftplib.error_perm(msg)  # noqa: S321 - the publisher under test speaks FTP
+
+    monkeypatch.setattr(FakeFTP, "storbinary", refuse)
+    preset = publisher_input(FTP_URL="ftp://user:pass@ftp.example.org/incoming/")
+
+    body, status = FTPPublisher().publish(preset)
+
+    assert status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert "550 Permission denied on the remote server" in body["error"]

--- a/src/publishers/tests/test_key_files.py
+++ b/src/publishers/tests/test_key_files.py
@@ -1,0 +1,79 @@
+"""The shared diagnostic for a key file a preset names but the publisher cannot read.
+
+Both publishers that read a mounted key report the failure through
+``unreadable_key_error``, so what an operator is told - which path was actually
+opened, and that an unprivileged service could not open it - is asserted here
+once.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+from pathlib import Path
+
+import pytest
+from managers.key_files import unreadable_key_error
+
+
+def _permission_denied(path: str) -> PermissionError:
+    """Build the error the OS raises for a file the service may not read."""
+    return PermissionError(errno.EACCES, os.strerror(errno.EACCES), path)
+
+
+def _not_found(path: str) -> FileNotFoundError:
+    """Build the error the OS raises for a path that does not exist."""
+    return FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
+
+
+def test_relative_path_is_reported_as_the_absolute_one_opened() -> None:
+    """A preset's relative path means nothing outside the container; resolve it.
+
+    The failure that prompted this named ``crypto/taranis``, which exists
+    nowhere the operator could look - it is ``/app/crypto/taranis`` inside the
+    publishers image.
+    """
+    error = unreadable_key_error("crypto/taranis", "SSH key", _permission_denied("crypto/taranis"))
+
+    reported = str(error)
+    assert str(Path("crypto/taranis").resolve()) in reported
+    # The path is reported absolute, never as the bare relative string given.
+    assert " at /" in reported
+
+
+def test_permission_denied_names_the_uid_and_the_remedy() -> None:
+    """The service no longer runs as root, so say so and how to fix it."""
+    message = str(unreadable_key_error("/app/crypto/taranis", "SSH key", _permission_denied("/app/crypto/taranis")))
+
+    assert "Permission denied" in message
+    assert f"uid {os.getuid()}" in message
+    assert f"chown {os.getuid()}" in message
+
+
+def test_other_errors_do_not_claim_a_permission_problem() -> None:
+    """A missing key is not an ownership problem; do not send the operator chowning."""
+    message = str(unreadable_key_error("/app/crypto/typo", "SSH key", _not_found("/app/crypto/typo")))
+
+    assert "No such file or directory" in message
+    assert "chown" not in message
+    assert "uid" not in message
+
+
+def test_description_identifies_which_configured_file_failed() -> None:
+    """A preset can name three key files; the message has to say which one."""
+    path = "/app/crypto/sign.pem"
+
+    assert "email signing key" in str(unreadable_key_error(path, "email signing key", _not_found(path)))
+    assert "SSH key" in str(unreadable_key_error(path, "SSH key", _not_found(path)))
+
+
+def test_the_original_error_is_available_as_the_cause() -> None:
+    """The replacement carries the message; the original still carries the errno."""
+    original = _permission_denied("/app/crypto/taranis")
+    replacement = unreadable_key_error("/app/crypto/taranis", "SSH key", original)
+
+    with pytest.raises(OSError, match="Cannot read the SSH key") as caught:
+        raise replacement from original
+
+    assert caught.value.__cause__ is original
+    assert caught.value.__cause__.errno == errno.EACCES

--- a/src/publishers/tests/test_sftp_publisher_keys.py
+++ b/src/publishers/tests/test_sftp_publisher_keys.py
@@ -1,0 +1,241 @@
+"""Loading the private key an SFTP preset names.
+
+These drive the real ``SFTPPublisher.publish`` with paramiko's client replaced,
+so the assertions cover both the key loading and what the publisher then does
+with the result - which is the half that used to go wrong quietly.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+
+import paramiko
+import pytest
+from conftest import KEY_PASSPHRASE
+from publishers.sftp_publisher import SFTPPublisher
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+
+class FakeSFTP:
+    """The SFTP channel, recording what was uploaded."""
+
+    def __init__(self) -> None:
+        """Start with nothing uploaded."""
+        self.uploaded: list[tuple[str, bytes]] = []
+
+    def putfo(self, file_object: object, path: str, confirm: bool = True) -> None:
+        """Record an upload, reading the payload the way paramiko does."""
+        assert confirm, "the publisher should ask for the upload to be confirmed"
+        self.uploaded.append((path, file_object.read()))
+
+    def close(self) -> None:
+        """Close the channel."""
+
+
+class FakeSSHClient:
+    """Stand-in for ``paramiko.SSHClient`` that records the connect arguments."""
+
+    last: FakeSSHClient | None = None
+
+    def __init__(self) -> None:
+        """Register this instance as the most recently constructed one."""
+        self.connect_kwargs: dict | None = None
+        self.sftp = FakeSFTP()
+        FakeSSHClient.last = self
+
+    def set_missing_host_key_policy(self, policy: object) -> None:
+        """Accept whatever policy the publisher installs."""
+
+    def get_host_keys(self) -> dict:
+        """Return an empty host key store."""
+        return {}
+
+    def connect(self, **kwargs: object) -> None:
+        """Record how authentication was attempted."""
+        self.connect_kwargs = kwargs
+
+    def open_sftp(self) -> FakeSFTP:
+        """Return the recording channel."""
+        return self.sftp
+
+    def exec_command(self, command: str) -> None:
+        """Accept a post-upload command."""
+
+    def close(self) -> None:
+        """Close the connection."""
+
+
+@pytest.fixture
+def ssh_client(monkeypatch: pytest.MonkeyPatch) -> type[FakeSSHClient]:
+    """Replace the paramiko client the publisher builds."""
+    FakeSSHClient.last = None
+    monkeypatch.setattr(paramiko, "SSHClient", FakeSSHClient)
+    return FakeSSHClient
+
+
+@pytest.fixture
+def sftp_preset(publisher_input: Callable[..., object]) -> Callable[..., object]:
+    """Build an SFTP preset, overriding only what a test cares about."""
+
+    def _build(**overrides: str) -> object:
+        values = {
+            "SFTP_URL": "sftp.example.org",
+            "PORT": "22",
+            "USERNAME": "taranis",
+            "PASSWORD": "",
+            "PATH": "/upload",
+            "FILENAME": "report",
+            "COMMAND": "",
+            "SSH_KEY": "",
+            "SSH_KEY_PASSWORD": "",
+            "HOST_KEY": "",
+        }
+        values.update(overrides)
+        return publisher_input(**values)
+
+    return _build
+
+
+@pytest.mark.parametrize("key_fixture", ["rsa_key_file", "ed25519_key_file", "ecdsa_key_file"])
+def test_every_key_type_paramiko_still_supports_is_loaded(
+    key_fixture: str,
+    request: pytest.FixtureRequest,
+    sftp_preset: Callable[..., object],
+    ssh_client: type[FakeSSHClient],
+) -> None:
+    """RSA, Ed25519 and ECDSA all authenticate.
+
+    These are every type paramiko 5 can load, DSA having been removed with
+    ``paramiko.DSSKey``. The loader's dead reference to that class is reached
+    only once every type has failed, which
+    ``test_a_file_that_is_not_a_key_names_the_supported_types`` covers.
+    """
+    key_path = request.getfixturevalue(key_fixture)
+
+    _, status = SFTPPublisher().publish(sftp_preset(SSH_KEY=str(key_path)))
+
+    assert status == HTTPStatus.OK
+    assert "pkey" in ssh_client.last.connect_kwargs
+
+
+def test_encrypted_key_is_loaded_with_its_passphrase(
+    encrypted_key_file: Path,
+    sftp_preset: Callable[..., object],
+    ssh_client: type[FakeSSHClient],
+) -> None:
+    """A passphrase-protected key works when the preset carries the passphrase."""
+    preset = sftp_preset(SSH_KEY=str(encrypted_key_file), SSH_KEY_PASSWORD=KEY_PASSPHRASE)
+
+    _, status = SFTPPublisher().publish(preset)
+
+    assert status == HTTPStatus.OK
+    assert ssh_client.last.connect_kwargs["pkey"].get_name() == "ssh-ed25519"
+
+
+def test_encrypted_key_without_a_passphrase_says_so(
+    encrypted_key_file: Path,
+    sftp_preset: Callable[..., object],
+    ssh_client: type[FakeSSHClient],
+) -> None:
+    """Report the missing passphrase, not a complaint about the last key type.
+
+    The OpenSSH envelope is decrypted before the key type inside it matters, so
+    retrying the other classes only replaced this diagnosis with a worse one.
+    """
+    body, status = SFTPPublisher().publish(sftp_preset(SSH_KEY=str(encrypted_key_file)))
+
+    assert status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert "encrypted" in body["error"]
+    assert ssh_client.last is None or ssh_client.last.connect_kwargs is None
+
+
+@pytest.mark.usefixtures("ssh_client")
+def test_a_file_that_is_not_a_key_names_the_supported_types(
+    not_a_key_file: Path,
+    sftp_preset: Callable[..., object],
+) -> None:
+    """Say what the file is not, and what would have worked."""
+    body, status = SFTPPublisher().publish(sftp_preset(SSH_KEY=str(not_a_key_file)))
+
+    assert status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert str(not_a_key_file) in body["error"]
+    for key_type in ("RSA", "Ed25519", "ECDSA"):
+        assert key_type in body["error"]
+
+
+def test_an_unusable_key_never_falls_back_to_password_authentication(
+    not_a_key_file: Path,
+    sftp_preset: Callable[..., object],
+    ssh_client: type[FakeSSHClient],
+) -> None:
+    """A preset naming a key must fail rather than quietly authenticate by password.
+
+    The loader used to return None when no key type matched, which sent the
+    caller down the ``else`` branch and connected with the preset's password. On
+    the pinned paramiko that return was unreachable - the missing DSSKey raised
+    AttributeError first - so this guards the contract rather than a live bug:
+    a key the preset names is now either used or fatal, never skipped.
+    """
+    preset = sftp_preset(SSH_KEY=str(not_a_key_file), PASSWORD="a-password-that-must-not-be-used")
+
+    _, status = SFTPPublisher().publish(preset)
+
+    assert status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert ssh_client.last is None or ssh_client.last.connect_kwargs is None
+
+
+def test_a_preset_with_no_key_still_authenticates_by_password(
+    sftp_preset: Callable[..., object],
+    ssh_client: type[FakeSSHClient],
+) -> None:
+    """Password auth stays available for the presets that are configured for it."""
+    _, status = SFTPPublisher().publish(sftp_preset(PASSWORD="hunter2"))
+
+    assert status == HTTPStatus.OK
+    assert ssh_client.last.connect_kwargs["password"] == "hunter2"
+    assert "pkey" not in ssh_client.last.connect_kwargs
+
+
+@pytest.mark.usefixtures("ssh_client")
+def test_a_relative_key_path_is_reported_as_the_absolute_one(
+    sftp_preset: Callable[..., object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reported path has to be findable; ``crypto/taranis`` was not."""
+    monkeypatch.chdir(tmp_path)
+
+    body, status = SFTPPublisher().publish(sftp_preset(SSH_KEY="crypto/taranis"))
+
+    assert status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert str(tmp_path / "crypto" / "taranis") in body["error"]
+
+
+@pytest.mark.usefixtures("ssh_client")
+def test_an_unreadable_key_explains_the_unprivileged_user(
+    rsa_key_file: Path,
+    sftp_preset: Callable[..., object],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A key only root can read is the failure this whole path exists for.
+
+    Injected rather than provoked with ``chmod``, so the assertion holds whether
+    or not the suite happens to run as root.
+    """
+
+    def deny(*_args: object, **_kwargs: object) -> None:
+        raise PermissionError(errno.EACCES, os.strerror(errno.EACCES), str(rsa_key_file))
+
+    monkeypatch.setattr(paramiko.RSAKey, "__init__", deny)
+
+    body, status = SFTPPublisher().publish(sftp_preset(SSH_KEY=str(rsa_key_file)))
+
+    assert status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert "Permission denied" in body["error"]
+    assert f"chown {os.getuid()}" in body["error"]


### PR DESCRIPTION
c519bbd9 moved every service to uid 10001 (fixed #723). Production hit:

    SFTP Publisher: [Errno 13] Permission denied: 'crypto/taranis'

**Root cause:** a key dropped into `src/publishers/crypto` is copied into the image
by `COPY ./src/publishers/. /app/`, and **`COPY` preserves the source mode but not
its ownership** — everything lands `root:root`. A key at `0600`, which that
directory's README tells you to use, became readable only by root the moment the
service stopped being root. The shipped samples are `0644`, which hid it.

### Fix
- `Dockerfile.publishers` owns `/app/crypto` as the runtime user, mirroring what the collectors image does for `/app/storage`.
- **Drop a key in, rebuild, it works — at `0600`, as before the breaking change, no operator action.**
- `TARANIS_WRITABLE_PATHS` covers a bind mount over the same path, where ownership comes from the host.
- Verified against a built image: `-rw------- 1 10001 0 463 taranis`, readable by the runtime user.

### Also fixed, same root cause
- **FTP publishing has been broken outright** since `c519bbd9` — it staged the payload in the root-owned working directory, and the `finally` that removed it raised `FileNotFoundError` over the real error. Uploads from memory now.
- **The email publisher silently sent reports unsigned and unencrypted.** `EMAIL_SIGN`/`EMAIL_ENCRYPT` were guarded by `Path(...).is_file()`, false for a path that doesn't exist, so the branch was skipped with no error and no log line. Now reads the key and fails the publish.

### SFTP diagnostics
- Reports the resolved path, the runtime uid and the remedy, not a bare errno on a path relative to `/app`.
- Dropped the `paramiko.DSSKey` branch — gone in paramiko 5, so anything not RSA/Ed25519/ECDSA raised `AttributeError` instead of a diagnosis.
- `PasswordRequiredException` aborts instead of being retried against every key class; an unset `SSH_KEY_PASSWORD` (`""`) becomes `None`, giving `private key file is encrypted` rather than a bcrypt error.
- An unusable key fails the publish instead of falling through to password auth.

### Tests
- New `src/publishers/tests` — 24 tests, in `PYTEST_SUITES` and the root `testpaths`.
- `docs/testing.md` listed this suite as uncollectable pending a structural change; `conftest.py` binds `publishers` to the inner package before pytest imports the service root, so none was needed. Entry updated.
- Each test verified to fail against the previous code (SFTP 4, email 3, FTP 3).
- Permission failures are injected, not set up with `chmod` — root bypasses file modes, so those assertions would otherwise be uid-dependent.
- 595 tests pass across all five suites.

### Still open
- `managers/ssh_host_keys.py` has no coverage — host-key pinning is a security control this suite doesn't reach.