### PR TITLE
Disable satelite workers config by default

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -67,9 +67,9 @@ TRAEFIK_MANAGEMENT_PORT=127.0.0.1:8081
 # resolves this host's AAAA record - and unreachable as a TIMEOUT, not a refusal,
 # because nothing published on v6 means the packets fall through to filter/INPUT
 # where a default-deny host firewall drops them. Set both or neither.
-# TARANIS_NG_SATELLITE_BIND=127.0.0.1
-# TARANIS_NG_SATELLITE_BIND6=::1
-# TARANIS_NG_SATELLITE_PORT=8443
+TARANIS_NG_SATELLITE_BIND=127.0.0.1
+TARANIS_NG_SATELLITE_BIND6=::1
+TARANIS_NG_SATELLITE_PORT=8443
 
 # Limits
 DB_SHARED_BUFFERS=64MB

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -67,9 +67,9 @@ TRAEFIK_MANAGEMENT_PORT=127.0.0.1:8081
 # resolves this host's AAAA record - and unreachable as a TIMEOUT, not a refusal,
 # because nothing published on v6 means the packets fall through to filter/INPUT
 # where a default-deny host firewall drops them. Set both or neither.
-TARANIS_NG_SATELLITE_BIND=127.0.0.1
-TARANIS_NG_SATELLITE_BIND6=::1
-TARANIS_NG_SATELLITE_PORT=8443
+# TARANIS_NG_SATELLITE_BIND=127.0.0.1
+# TARANIS_NG_SATELLITE_BIND6=::1
+# TARANIS_NG_SATELLITE_PORT=8443
 
 # Limits
 DB_SHARED_BUFFERS=64MB

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -582,9 +582,9 @@ services:
       # on v6 the packets fall through to filter/INPUT and a default-deny host
       # firewall drops them. The other ports above name no address and so are
       # already dual-stack; these have to ask for it explicitly.
-      - "${TARANIS_NG_SATELLITE_BIND:-127.0.0.1}:${TARANIS_NG_SATELLITE_PORT:-8443}:8443"
-      - "[${TARANIS_NG_SATELLITE_BIND6:-::1}]:${TARANIS_NG_SATELLITE_PORT:-8443}:8443"
-      - "${TARANIS_NG_HTTPS_PORT}:443/udp"
+      # - "${TARANIS_NG_SATELLITE_BIND:-127.0.0.1}:${TARANIS_NG_SATELLITE_PORT:-8443}:8443"
+      # - "[${TARANIS_NG_SATELLITE_BIND6:-::1}]:${TARANIS_NG_SATELLITE_PORT:-8443}:8443"
+      # - "${TARANIS_NG_HTTPS_PORT}:443/udp"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       # Only dynamic/ - see the note on environment above.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -570,6 +570,7 @@ services:
     ports:
       - "${TARANIS_NG_HTTP_PORT}:80"
       - "${TARANIS_NG_HTTPS_PORT}:443"
+      - "${TARANIS_NG_HTTPS_PORT}:443/udp"
       - "${TRAEFIK_MANAGEMENT_PORT}:9090"
       # Bound to loopback by default: a single-host stack never uses it. A
       # distributed one sets TARANIS_NG_SATELLITE_BIND=0.0.0.0 (and _BIND6=::)
@@ -584,7 +585,6 @@ services:
       # already dual-stack; these have to ask for it explicitly.
       # - "${TARANIS_NG_SATELLITE_BIND:-127.0.0.1}:${TARANIS_NG_SATELLITE_PORT:-8443}:8443"
       # - "[${TARANIS_NG_SATELLITE_BIND6:-::1}]:${TARANIS_NG_SATELLITE_PORT:-8443}:8443"
-      # - "${TARANIS_NG_HTTPS_PORT}:443/udp"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       # Only dynamic/ - see the note on environment above.


### PR DESCRIPTION
- disable satellite workers config by default
- this also fix compose error: failed to bind host port [::1]:8443/tcp: cannot assign requested address (when IPv6 loopback is off)