### PR TITLE
Custom e-mail headers from report items

### DIFF
--- a/src/core/managers/publishers_manager.py
+++ b/src/core/managers/publishers_manager.py
@@ -80,6 +80,8 @@ def publish(preset: PublisherPreset, data: dict, message_title: str, message_bod
     att_file_name = None
     # None when publishing without a presenter (e.g. asset notifications) — publishers treat that as plain text.
     message_body_mime_type = None
+    # Likewise: no presenter means no headers template, so no custom mail headers.
+    message_headers = None
     if data is not None:
         data_data = data["data"]
         data_mime = data["mime_type"]
@@ -87,6 +89,7 @@ def publish(preset: PublisherPreset, data: dict, message_title: str, message_bod
         message_body = data.get("message_body")
         att_file_name = data.get("att_file_name")
         message_body_mime_type = data.get("message_body_mime_type")
+        message_headers = data.get("message_headers")
 
     input_data = PublisherInput(
         preset.name,
@@ -99,6 +102,7 @@ def publish(preset: PublisherPreset, data: dict, message_title: str, message_bod
         recipients,
         att_file_name,
         message_body_mime_type,
+        message_headers,
     )
     input_schema = PublisherInputSchema()
 

--- a/src/presenters/presenters/base_presenter.py
+++ b/src/presenters/presenters/base_presenter.py
@@ -428,6 +428,8 @@ class BasePresenter:
         env.filters["regex_replace"] = jinja_filters.filter_regex_replace
         env.filters["truncate_on_symbol"] = jinja_filters.filter_truncate_on_symbol
         env.filters["tlp_color"] = jinja_filters.filter_tlp_color
+        env.filters["collect_attrs"] = jinja_filters.filter_collect_attrs
+        env.filters["header_value"] = jinja_filters.filter_header_value
 
     @classmethod
     def resolve_template_path(cls, template_path: str) -> tuple[str, str]:

--- a/src/presenters/presenters/jinja_filters.py
+++ b/src/presenters/presenters/jinja_filters.py
@@ -2,8 +2,10 @@
 
 import datetime
 import re
+from collections.abc import Iterable
 
 from shared.common import TZ
+from shared.mail_headers import scrub_header_text
 
 
 def filter_strfdate(date: str, fmtin: str | None = None, fmtout: str | None = None) -> str:
@@ -72,3 +74,92 @@ def filter_tlp_color(tlp: str) -> str:
     """Return color code for TLP value."""
     mapping = {"CLEAR": "white", "WHITE": "white", "GREEN": "#33ff00", "AMBER": "#ffc000", "AMBER+STRICT": "#ffc000", "RED": "#ff2b2b"}
     return mapping.get(tlp, "white")
+
+
+def _attr_values(value: object) -> list[str]:
+    """Flatten one report item's value for a single attribute into a list of strings.
+
+    ``BasePresenter.ReportItemObject`` stores an attribute in one of several shapes
+    depending on how the report item type declares it, so unpack them all:
+
+    * ``str`` -- the attribute group item has ``max_occurrence == 1``
+    * ``list[str]`` -- any other ``max_occurrence``
+    * ``dict`` -- the ``cwe*`` shape, ``{value: value_description}``; the keys are the values
+    * ``list[list]`` -- two attribute group items in different groups share a title
+
+    Args:
+        value (object): The raw ``attrs`` entry.
+
+    Returns:
+        list[str]: The values it holds, unscrubbed.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        return [str(key) for key in value]
+    if isinstance(value, (list, tuple, set)):
+        values = []
+        for item in value:
+            values.extend(_attr_values(item))
+        return values
+    return [str(value)]
+
+
+def filter_collect_attrs(report_items: Iterable, key: str, *, unique: bool = True) -> list[str]:
+    """Collect one attribute's values from every report item of a product.
+
+    This is what lets a headers template list the values of every report item combined into
+    a product: ``{{ data.report_items | collect_attrs('report_category') | join(', ') }}``.
+    Every value is scrubbed of characters that would break out of a header line, so the
+    result is safe to interpolate directly.
+
+    Report items reach a filter as plain dicts, not objects -- ``generate_input_data`` runs
+    them through ``BasePresenter.to_template_data`` first -- so this reads them with
+    ``.get()``. An ``getattr``-based implementation would silently return an empty list.
+
+    Takes an iterable rather than a list so it composes with ``selectattr``, e.g.
+    ``data.report_items | selectattr('type', 'equalto', 'Vulnerability Report') | collect_attrs('cve')``.
+
+    Note that ``collect_attrs('cvss')`` is not useful: by this point ``attrs.cvss`` is the
+    parsed CVSS dict, so you would get its keys. Use ``data.product.max_cvss`` instead.
+
+    Args:
+        report_items (Iterable): ``data.report_items``, or a filtered subset of it.
+        key (str): The ``attrs`` key, i.e. the attribute group item title lowercased with
+            spaces replaced by underscores.
+        unique (bool): Drop repeats, keeping first-seen order. Defaults to True -- three
+            report items all tagged "Ransomware" should list it once.
+
+    Returns:
+        list[str]: The collected values.
+    """
+    collected = []
+    for report_item in report_items:
+        attrs = report_item.get("attrs") if isinstance(report_item, dict) else None
+        if not attrs:
+            continue
+        for value in _attr_values(attrs.get(key)):
+            scrubbed = scrub_header_text(value)
+            if scrubbed:
+                collected.append(scrubbed)
+
+    return list(dict.fromkeys(collected)) if unique else collected
+
+
+def filter_header_value(value: object) -> str:
+    """Make a single value safe to interpolate into a mail header.
+
+    Mandatory whenever a headers template interpolates a value it did not get from
+    ``collect_attrs``, e.g. ``X-Report-Type: {{ report_item.attrs.report_type | header_value }}``.
+    Returns an empty string for None, which also keeps ``data.product.max_cvss`` from
+    rendering as the literal "None" when no report item carries a CVSS score.
+
+    Args:
+        value (object): The raw value.
+
+    Returns:
+        str: The scrubbed value, possibly empty.
+    """
+    return scrub_header_text(value)

--- a/src/presenters/presenters/message_presenter.py
+++ b/src/presenters/presenters/message_presenter.py
@@ -4,13 +4,13 @@ Returns:
     _description_
 """
 
-from base64 import b64encode
+from base64 import b64decode, b64encode
 from pathlib import Path
 
 from shared.config_presenter import ConfigPresenter
 
 from presenters.pdf_presenter import PDFPresenter
-from shared import common
+from shared import common, mail_headers
 
 from .base_presenter import BasePresenter
 
@@ -31,7 +31,7 @@ class MESSAGEPresenter(BasePresenter):
     description = config.description
     parameters = config.parameters
 
-    def generate(self, presenter_input: dict) -> dict[str, str]:
+    def generate(self, presenter_input: dict) -> dict[str, object]:
         """Generate message parts from Jinja templates.
 
         Arguments:
@@ -42,6 +42,7 @@ class MESSAGEPresenter(BasePresenter):
         """
         message_title_template_path = presenter_input.param_key_values["TITLE_TEMPLATE_PATH"]
         message_body_template_path = presenter_input.param_key_values["BODY_TEMPLATE_PATH"]
+        headers_template_path = common.read_str_parameter("HEADERS_TEMPLATE_PATH", None, presenter_input)
         att_template_path = common.read_str_parameter("ATTACHMENT_TEMPLATE_PATH", None, presenter_input)
         att_file_name = common.read_str_parameter("ATTACHMENT_FILE_NAME", None, presenter_input)
         # `mime_type` describes the optional attachment — the PDF branch below overwrites it — so the
@@ -56,15 +57,33 @@ class MESSAGEPresenter(BasePresenter):
             "message_body": None,
             "data": None,
             "att_file_name": None,
+            "message_headers": [],
         }
+
+        # Which template we are on, so a failure names it. This presenter renders up to five,
+        # and the error reaches the user as the rendered product with no traceback: without
+        # this, "'variables' not found" gives no clue which template asked for 'variables'.
+        rendering = "the input data"
 
         try:
             input_data = BasePresenter.generate_input_data(presenter_input)
+            rendering = f"title template '{message_title_template_path}'"
             presenter_output["message_title"] = BasePresenter.render_jinja(input_data, message_title_template_path)
+            rendering = f"body template '{message_body_template_path}'"
             presenter_output["message_body"] = BasePresenter.render_jinja(input_data, message_body_template_path)
+            if headers_template_path:
+                rendering = f"headers template '{headers_template_path}'"
+                # render_jinja base64-encodes every render, so decode our own output back to the
+                # header block. Parsing here rather than in the publisher means the sanitizing
+                # happens where untrusted attribute text first becomes a protocol element, and a
+                # broken headers template surfaces in the product preview.
+                rendered_headers = b64decode(BasePresenter.render_jinja(input_data, headers_template_path)).decode("UTF-8")
+                presenter_output["message_headers"] = mail_headers.parse_header_block(rendered_headers)
             if att_file_name:
+                rendering = f"attachment file name template '{att_file_name}'"
                 presenter_output["att_file_name"] = BasePresenter.render_jinja(input_data, None, att_file_name)
             if att_template_path:
+                rendering = f"attachment template '{att_template_path}'"
                 presenter_input.param_key_values.update({"PDF_TEMPLATE_PATH": att_template_path})
                 pdf_presenter = PDFPresenter()
                 pdf_output = pdf_presenter.generate(presenter_input)
@@ -74,4 +93,5 @@ class MESSAGEPresenter(BasePresenter):
 
         except Exception as error:
             BasePresenter.print_exception(self, error)
-            return {"mime_type": "text/plain", "data": b64encode((f"TEMPLATING ERROR\n{error}").encode()).decode("UTF-8")}
+            report = f"TEMPLATING ERROR in {rendering}\n{error}"
+            return {"mime_type": "text/plain", "data": b64encode(report.encode()).decode("UTF-8")}

--- a/src/presenters/templates/custom/README.md
+++ b/src/presenters/templates/custom/README.md
@@ -6,3 +6,9 @@ cannot collide with bundled templates.
 
 Keep secrets out of templates and version control. Back up custom templates
 before upgrading or replacing presenter storage.
+
+Mail headers templates for the MESSAGE presenter belong here too. A headers template
+must never emit a header the publisher owns - `To`, `Cc`, `Bcc`, `From`, `Subject`,
+`Reply-To`, `Date`, `Message-ID`, `MIME-Version`, `Content-*` or the trace headers.
+Those are refused with a warning rather than sent, because a `Bcc` header would add a
+real recipient. See "Custom e-mail headers" in `docs/howto.md`.

--- a/src/presenters/templates/email_headers_template.txt
+++ b/src/presenters/templates/email_headers_template.txt
@@ -1,0 +1,38 @@
+{# Custom mail headers for the MESSAGE presenter.
+
+   Every rendered "X-Name: value" line becomes a header on the published e-mail. Blank
+   lines and lines without a colon are ignored, so you do not have to fight Jinja
+   whitespace control to keep this readable.
+
+   The values come from ordinary report item attributes. Give the report item type an
+   attribute titled e.g. "Report Category" (set max_occurrence above 1 to let an analyst
+   enter several values), then read it here by its title, lowercased with spaces replaced
+   by underscores. `collect_attrs` gathers that attribute from every report item in the
+   product, drops empties and repeats, and scrubs anything that could break a header line.
+
+   A header whose value renders empty is dropped, so nothing is sent for an attribute no
+   report item filled in.
+
+   Names the publisher owns are refused with a warning in the presenters log: To, Cc, Bcc,
+   From, Subject, Reply-To, Content-*, MIME-Version, Date, Message-ID and the other
+   trace headers. These headers are NOT covered by S/MIME or PGP signing or encryption, so
+   do not put anything sensitive in one.
+
+   Alternative styles:
+
+     One header per value instead of one comma-joined header - envelope appends on repeat:
+       {% raw %}{% for c in categories %}X-Report-Category: {{ c }}
+       {% endfor %}{% endraw %}
+
+     A single report item's attribute, interpolated raw. `header_value` is mandatory here:
+     it is what `collect_attrs` applies for you, and without it an analyst's newline can
+     start a header line of their own.
+       {% raw %}X-Report-Type: {{ data.report_items[0].attrs.report_type | header_value }}{% endraw %}
+#}
+{% set categories = data.report_items | collect_attrs('report_category') %}
+{% if categories %}X-Report-Category: {{ categories | join(', ') }}{% endif %}
+{% set types = data.report_items | collect_attrs('report_type') %}
+{% if types %}X-Report-Type: {{ types | join(', ') }}{% endif %}
+{# max_cvss is only set for products containing a Vulnerability Report, and is None when
+   none of those carries a CVSS score - without both guards this renders "None". #}
+{% if data.product.max_cvss is defined and data.product.max_cvss is not none %}X-Report-Max-CVSS: {{ data.product.max_cvss }}{% endif %}

--- a/src/presenters/tests/test_collect_attrs_filter.py
+++ b/src/presenters/tests/test_collect_attrs_filter.py
@@ -1,0 +1,130 @@
+"""Tests for the Jinja filters that feed the mail headers template.
+
+``collect_attrs`` is what turns "several report items in one product, each with its own
+values" into a single header value. It runs against the *rendered* input data, where every
+presenter object has already been flattened into plain dicts by
+``BasePresenter.to_template_data`` -- so the fixtures here are literal dicts, exactly as in
+``test_default_vulnerability_template.py``. That is deliberate: an implementation reaching
+for ``getattr`` passes nothing else and fails here.
+"""
+
+from base64 import b64decode
+
+from presenters.base_presenter import BasePresenter
+from presenters.jinja_filters import filter_collect_attrs, filter_header_value
+
+
+def render(template: str, data: dict) -> str:
+    """Render a template string through the real presenter environment."""
+    return b64decode(BasePresenter.render_jinja(data, None, template_string=template)).decode("UTF-8")
+
+
+def item(**attrs: object) -> dict:
+    """Build one report item the way to_template_data leaves it."""
+    return {"name": "Report", "type": "Vulnerability Report", "attrs": attrs}
+
+
+# --- the attribute value shapes ----------------------------------------------------
+
+
+def test_scalar_value_is_collected() -> None:
+    # An attribute group item with max_occurrence == 1 stores a bare string.
+    assert filter_collect_attrs([item(report_category="Ransomware")], "report_category") == ["Ransomware"]
+
+
+def test_list_value_is_collected() -> None:
+    # Any other max_occurrence stores a list, one entry per value row.
+    assert filter_collect_attrs([item(report_category=["Ransomware", "Phishing"])], "report_category") == ["Ransomware", "Phishing"]
+
+
+def test_dict_value_yields_its_keys() -> None:
+    # The cwe* shape is {value: value_description}.
+    assert filter_collect_attrs([item(cwe={"CWE-79": "XSS", "CWE-89": "SQLi"})], "cwe") == ["CWE-79", "CWE-89"]
+
+
+def test_nested_list_is_flattened() -> None:
+    # Two attribute group items in different groups sharing a title.
+    assert filter_collect_attrs([item(report_category=[["Ransomware"], ["Phishing"]])], "report_category") == ["Ransomware", "Phishing"]
+
+
+def test_missing_attribute_is_skipped_not_an_error() -> None:
+    items = [item(report_category="Ransomware"), item(), item(report_type="Advisory")]
+
+    assert filter_collect_attrs(items, "report_category") == ["Ransomware"]
+
+
+def test_report_item_without_attrs_is_skipped() -> None:
+    assert filter_collect_attrs([{"name": "Report", "type": "Vulnerability Report"}], "report_category") == []
+
+
+# --- combining across report items -------------------------------------------------
+
+
+def test_values_from_every_report_item_are_combined() -> None:
+    items = [item(report_category=["Ransomware", "Phishing"]), item(report_category="Supply Chain")]
+
+    assert filter_collect_attrs(items, "report_category") == ["Ransomware", "Phishing", "Supply Chain"]
+
+
+def test_repeats_across_report_items_are_deduped_in_first_seen_order() -> None:
+    items = [item(report_category="Phishing"), item(report_category="Ransomware"), item(report_category="Phishing")]
+
+    assert filter_collect_attrs(items, "report_category") == ["Phishing", "Ransomware"]
+
+
+def test_unique_false_keeps_every_occurrence() -> None:
+    items = [item(report_category="Phishing"), item(report_category="Phishing")]
+
+    assert filter_collect_attrs(items, "report_category", unique=False) == ["Phishing", "Phishing"]
+
+
+def test_empty_values_are_dropped() -> None:
+    assert filter_collect_attrs([item(report_category=["", "   ", "Phishing"])], "report_category") == ["Phishing"]
+
+
+def test_collected_values_are_scrubbed_of_line_breaks() -> None:
+    # An analyst pasting a newline into an attribute must not be able to start a new header.
+    items = [item(report_category="Ransomware\nBcc: attacker@evil.test")]
+
+    assert filter_collect_attrs(items, "report_category") == ["Ransomware Bcc: attacker@evil.test"]
+
+
+# --- header_value ------------------------------------------------------------------
+
+
+def test_header_value_of_none_is_empty() -> None:
+    # Without this, "{{ data.product.max_cvss }}" renders the literal "None".
+    assert filter_header_value(None) == ""
+
+
+def test_header_value_scrubs_and_collapses() -> None:
+    assert filter_header_value("  Advisory \r\n Urgent  ") == "Advisory Urgent"
+
+
+def test_header_value_stringifies_a_number() -> None:
+    assert filter_header_value(9.8) == "9.8"
+
+
+# --- registered in the real environment --------------------------------------------
+
+
+def test_filters_are_available_to_templates() -> None:
+    data = {"report_items": [item(report_category=["Ransomware", "Phishing"]), item(report_category="Ransomware")]}
+    template = "X-Report-Category: {{ data.report_items | collect_attrs('report_category') | join(', ') }}"
+
+    assert render(template, data) == "X-Report-Category: Ransomware, Phishing"
+
+
+def test_collect_attrs_composes_with_selectattr() -> None:
+    # selectattr yields a generator, so the filter must accept any iterable.
+    data = {
+        "report_items": [
+            {"type": "Vulnerability Report", "attrs": {"report_category": "Ransomware"}},
+            {"type": "Disinformation", "attrs": {"report_category": "Propaganda"}},
+        ],
+    }
+    template = (
+        "{{ data.report_items | selectattr('type', 'equalto', 'Vulnerability Report') | collect_attrs('report_category') | join(', ') }}"
+    )
+
+    assert render(template, data) == "Ransomware"

--- a/src/presenters/tests/test_email_headers_template.py
+++ b/src/presenters/tests/test_email_headers_template.py
@@ -1,0 +1,90 @@
+"""Tests for the shipped mail headers template.
+
+This renders the real ``templates/email_headers_template.txt`` through the real presenter
+environment and the real parser, so it covers the whole path an operator gets out of the
+box: attribute values on several report items becoming headers on one e-mail.
+"""
+
+from base64 import b64decode
+from pathlib import Path
+
+import pytest
+from presenters.base_presenter import BasePresenter
+from shared.mail_headers import parse_header_block
+
+TEMPLATES_ROOT = Path(__file__).resolve().parents[1] / "templates"
+TEMPLATE = str(TEMPLATES_ROOT / "email_headers_template.txt")
+
+
+@pytest.fixture(autouse=True)
+def _templates_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the template sandbox at the repo, not the container's /app/templates."""
+    monkeypatch.setattr(BasePresenter, "JINJA_TEMPLATES_ROOT", str(TEMPLATES_ROOT))
+
+
+def headers_for(product: dict, report_items: list[dict]) -> list[dict[str, str]]:
+    """Render the shipped template for a product and parse the result."""
+    data = {"product": product, "report_items": report_items}
+    rendered = b64decode(BasePresenter.render_jinja(data, TEMPLATE)).decode("UTF-8")
+    return parse_header_block(rendered)
+
+
+def item(**attrs: object) -> dict:
+    """Build one report item the way to_template_data leaves it."""
+    return {"name": "Report", "type": "Vulnerability Report", "attrs": attrs}
+
+
+def value_of(headers: list[dict[str, str]], name: str) -> str | None:
+    """Return the single value of a header, or None when it was not emitted."""
+    values = [h["value"] for h in headers if h["name"] == name]
+    return values[0] if values else None
+
+
+def test_a_product_with_no_attributes_emits_no_headers() -> None:
+    # Nothing to say means nothing on the wire - no empty "X-Report-Category:".
+    assert headers_for({"title": "Test"}, [item()]) == []
+
+
+def test_values_of_several_report_items_land_in_one_header() -> None:
+    items = [item(report_category=["Ransomware", "Phishing"]), item(report_category="Supply Chain")]
+
+    assert value_of(headers_for({"title": "Test"}, items), "X-Report-Category") == "Ransomware, Phishing, Supply Chain"
+
+
+def test_the_same_value_on_two_report_items_is_listed_once() -> None:
+    items = [item(report_category="Ransomware"), item(report_category="Ransomware")]
+
+    assert value_of(headers_for({"title": "Test"}, items), "X-Report-Category") == "Ransomware"
+
+
+def test_report_type_is_emitted_independently_of_category() -> None:
+    headers = headers_for({"title": "Test"}, [item(report_type="Advisory")])
+
+    assert [(h["name"], h["value"]) for h in headers] == [("X-Report-Type", "Advisory")]
+
+
+def test_max_cvss_is_emitted_when_the_product_has_one() -> None:
+    assert value_of(headers_for({"title": "Test", "max_cvss": 9.8}, [item()]), "X-Report-Max-CVSS") == "9.8"
+
+
+def test_max_cvss_of_none_emits_nothing_rather_than_the_string_none() -> None:
+    # get_max_cvss returns None when vulnerability reports carry no CVSS score, and Jinja
+    # stringifies that as "None". Shipping "X-Report-Max-CVSS: None" would be a bug.
+    headers = headers_for({"title": "Test", "max_cvss": None}, [item(report_category="Ransomware")])
+
+    assert value_of(headers, "X-Report-Max-CVSS") is None
+    assert "None" not in str(headers)
+
+
+def test_max_cvss_absent_from_the_product_emits_nothing() -> None:
+    # product.max_cvss is only set at all for products containing a Vulnerability Report.
+    assert value_of(headers_for({"title": "Test"}, [item(report_category="Ransomware")]), "X-Report-Max-CVSS") is None
+
+
+def test_a_newline_in_an_attribute_cannot_add_a_recipient() -> None:
+    # End to end through the real template: the analyst's payload stays inside its value.
+    items = [item(report_category="Ransomware\nBcc: attacker@evil.test")]
+    headers = headers_for({"title": "Test"}, items)
+
+    assert not [h for h in headers if h["name"].lower() == "bcc"]
+    assert value_of(headers, "X-Report-Category") == "Ransomware Bcc: attacker@evil.test"

--- a/src/presenters/tests/test_message_presenter_errors.py
+++ b/src/presenters/tests/test_message_presenter_errors.py
@@ -1,0 +1,116 @@
+"""A failing template must say which template failed.
+
+The MESSAGE presenter renders up to five templates, and a failure comes back to the user
+as the rendered product - a "TEMPLATING ERROR" body with no traceback. Naming the template
+is the only clue the operator gets. The regression this pins: a body template failing on a
+missing import read as though the newly added headers template were at fault.
+"""
+
+from __future__ import annotations
+
+import types
+from base64 import b64decode
+from pathlib import Path
+
+import pytest
+from presenters.base_presenter import BasePresenter
+from presenters.message_presenter import MESSAGEPresenter
+
+TEMPLATES_ROOT = Path(__file__).resolve().parents[1] / "templates"
+
+
+@pytest.fixture(autouse=True)
+def _templates_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the template sandbox at the repo, not the container's /app/templates."""
+    monkeypatch.setattr(BasePresenter, "JINJA_TEMPLATES_ROOT", str(TEMPLATES_ROOT))
+
+
+@pytest.fixture
+def presenter_input() -> object:
+    """A minimal product with one report item carrying one attribute."""
+    group_item = types.SimpleNamespace(id=10, title="Report Category", max_occurrence=5)
+    report_type = types.SimpleNamespace(
+        id=1,
+        title="Vulnerability Report",
+        description="",
+        attribute_groups=[types.SimpleNamespace(attribute_group_items=[group_item])],
+    )
+    report = types.SimpleNamespace(
+        title="R1",
+        title_prefix="",
+        uuid="u",
+        created=None,
+        last_updated=None,
+        report_item_type_id=1,
+        news_item_aggregates=[],
+        attributes=[types.SimpleNamespace(attribute_group_item_id=10, value="Ransomware", value_description="")],
+    )
+    product = types.SimpleNamespace(
+        title="P",
+        description="d",
+        product_type="T",
+        product_type_description="",
+        user=types.SimpleNamespace(name="Analyst"),
+        id="1",
+    )
+    return types.SimpleNamespace(product=product, reports=[report], report_types=[report_type], param_key_values={})
+
+
+def error_text(output: dict) -> str:
+    """The TEMPLATING ERROR body a failed render returns."""
+    return b64decode(output["data"]).decode("UTF-8")
+
+
+def write_template(name: str, body: str) -> str:
+    """Write a template inside the sandbox root so resolve_template_path accepts it."""
+    path = TEMPLATES_ROOT / name
+    path.write_text(body)
+    return str(path)
+
+
+def test_a_failing_body_template_names_the_body_template(presenter_input: object) -> None:
+    # The reported case: the body template imports something that does not exist, and the
+    # error must not read as though the headers template were at fault.
+    body = write_template("_test_broken_body.txt", "{% import 'no_such_file' as missing %}")
+    presenter_input.param_key_values = {
+        "TITLE_TEMPLATE_PATH": str(TEMPLATES_ROOT / "email_subject_template.txt"),
+        "BODY_TEMPLATE_PATH": body,
+        "HEADERS_TEMPLATE_PATH": str(TEMPLATES_ROOT / "email_headers_template.txt"),
+    }
+    try:
+        report = error_text(MESSAGEPresenter().generate(presenter_input))
+    finally:
+        Path(body).unlink()
+
+    assert "TEMPLATING ERROR in body template" in report
+    assert "_test_broken_body.txt" in report
+    assert "headers template" not in report
+
+
+def test_a_failing_headers_template_names_the_headers_template(presenter_input: object) -> None:
+    headers = write_template("_test_broken_headers.txt", "{% import 'no_such_file' as missing %}")
+    presenter_input.param_key_values = {
+        "TITLE_TEMPLATE_PATH": str(TEMPLATES_ROOT / "email_subject_template.txt"),
+        "BODY_TEMPLATE_PATH": str(TEMPLATES_ROOT / "email_body_template.txt"),
+        "HEADERS_TEMPLATE_PATH": headers,
+    }
+    try:
+        report = error_text(MESSAGEPresenter().generate(presenter_input))
+    finally:
+        Path(headers).unlink()
+
+    assert "TEMPLATING ERROR in headers template" in report
+    assert "_test_broken_headers.txt" in report
+
+
+def test_a_missing_headers_template_path_is_not_an_error(presenter_input: object) -> None:
+    # Leaving the parameter empty must publish normally with no custom headers.
+    presenter_input.param_key_values = {
+        "TITLE_TEMPLATE_PATH": str(TEMPLATES_ROOT / "email_subject_template.txt"),
+        "BODY_TEMPLATE_PATH": str(TEMPLATES_ROOT / "email_body_template.txt"),
+    }
+
+    output = MESSAGEPresenter().generate(presenter_input)
+
+    assert output["message_headers"] == []
+    assert output["message_body"] is not None

--- a/src/publishers/publishers/email_publisher.py
+++ b/src/publishers/publishers/email_publisher.py
@@ -12,6 +12,8 @@ from shared.common import TZ
 from shared.config_publisher import ConfigPublisher
 from shared.log_manager import logger
 
+from shared import mail_headers
+
 from .base_publisher import BasePublisher
 
 
@@ -122,6 +124,18 @@ class EMAILPublisher(BasePublisher):
             envelope.subject(subject)
         envelope.from_(sender)
         envelope.to(recipients)
+
+        # The presenter already sanitized these, but it is a separate node reached over the
+        # network, so re-check rather than trust the wire: envelope.header() reroutes `bcc`
+        # (and `to`/`cc`) into the real SMTP recipient list, so an unchecked header could add
+        # a recipient. Note these headers sit outside any S/MIME or PGP signature.
+        # envelope.header() only catches TypeError, and the try below starts after this point,
+        # so guard here too - a decorative header must never cost the send.
+        try:
+            for custom_header in mail_headers.sanitize_headers(publisher_input.message_headers or []):
+                envelope.header(custom_header["name"], custom_header["value"])
+        except Exception as error:
+            self.logger.warning(f"Custom headers skipped: {error}")
 
         try:
             if sign == "auto":

--- a/src/publishers/tests/conftest.py
+++ b/src/publishers/tests/conftest.py
@@ -131,6 +131,7 @@ def publisher_input() -> Callable[..., types.SimpleNamespace]:
             message_title=None,
             message_body=None,
             message_body_mime_type=None,
+            message_headers=[],
             recipients=[],
             att_file_name=None,
             param_key_values=param_key_values,

--- a/src/publishers/tests/test_email_publisher_headers.py
+++ b/src/publishers/tests/test_email_publisher_headers.py
@@ -1,0 +1,196 @@
+"""Custom mail headers a presenter asks the email publisher to set.
+
+The presenter that renders these is a separate node reached over the network, so its
+output is untrusted input here. ``envelope.header()`` reroutes ``bcc``, ``cc`` and ``to``
+to its own setters, and the SMTP recipient list is built from those - so a header this
+publisher accepts without checking could add a recipient. These assert that it checks.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+
+import pytest
+from publishers.email_publisher import EMAILPublisher
+
+from publishers import email_publisher
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class FakeEnvelope:
+    """Stand-in for ``envelope.Envelope`` that records the headers it was given."""
+
+    last: FakeEnvelope | None = None
+
+    def __init__(self) -> None:
+        """Register this instance and start with no headers."""
+        self.headers: list[tuple[str, str]] = []
+        self.header_error: Exception | None = None
+        self.sent = False
+        FakeEnvelope.last = self
+
+    def header(self, key: str, val: str | None = None) -> FakeEnvelope:
+        """Record a header. Overrides the catch-all below, which would swallow the call."""
+        if self.header_error is not None:
+            raise self.header_error
+        self.headers.append((key, val))
+        return self
+
+    def send(self) -> bool:
+        """Pretend the message went out."""
+        self.sent = True
+        return True
+
+    def __getattr__(self, name: str) -> Callable[..., FakeEnvelope]:
+        """Accept every other envelope call (message, subject, attach, smtp...)."""
+        return lambda *_args, **_kwargs: self
+
+    @staticmethod
+    def smtp_quit() -> None:
+        """Close the SMTP session."""
+
+    def __str__(self) -> str:
+        """Render the composed message for the publisher's debug log."""
+        return "<envelope>"
+
+
+@pytest.fixture
+def envelope(monkeypatch: pytest.MonkeyPatch) -> type[FakeEnvelope]:
+    """Replace the envelope the publisher builds."""
+    FakeEnvelope.last = None
+    monkeypatch.setattr(email_publisher, "Envelope", FakeEnvelope)
+    return FakeEnvelope
+
+
+@pytest.fixture
+def email_preset(publisher_input: Callable[..., object]) -> Callable[..., object]:
+    """Build an email preset carrying the given custom headers."""
+
+    def _build(message_headers: object) -> object:
+        preset = publisher_input(
+            SMTP_SERVER="smtp.example.org",
+            SMTP_SERVER_PORT="587",
+            EMAIL_USERNAME="taranis",
+            EMAIL_PASSWORD="hunter2",
+            EMAIL_SENDER="taranis@example.org",
+            EMAIL_RECIPIENT="constituency@example.org",
+            EMAIL_SUBJECT="Security Warning",
+            EMAIL_MESSAGE="See attached.",
+            EMAIL_SIGN="",
+            EMAIL_SIGN_PASSWORD="",
+            EMAIL_ENCRYPT="",
+        )
+        preset.message_headers = message_headers
+        return preset
+
+    return _build
+
+
+def test_every_header_reaches_the_envelope_in_order(
+    email_preset: Callable[..., object],
+    envelope: type[FakeEnvelope],
+) -> None:
+    preset = email_preset(
+        [
+            {"name": "X-Report-Category", "value": "Ransomware, Phishing"},
+            {"name": "X-Report-Max-CVSS", "value": "9.8"},
+        ],
+    )
+
+    _, status = EMAILPublisher().publish(preset)
+
+    assert status == HTTPStatus.OK
+    assert envelope.last.headers == [("X-Report-Category", "Ransomware, Phishing"), ("X-Report-Max-CVSS", "9.8")]
+
+
+def test_a_repeated_header_name_is_passed_through_twice(
+    email_preset: Callable[..., object],
+    envelope: type[FakeEnvelope],
+) -> None:
+    # envelope.header() appends on repeat, which is how a template emits one line per value.
+    preset = email_preset(
+        [
+            {"name": "X-Report-Category", "value": "Ransomware"},
+            {"name": "X-Report-Category", "value": "Phishing"},
+        ],
+    )
+
+    EMAILPublisher().publish(preset)
+
+    assert envelope.last.headers == [("X-Report-Category", "Ransomware"), ("X-Report-Category", "Phishing")]
+
+
+@pytest.mark.parametrize("message_headers", [None, []])
+def test_no_headers_sets_none_and_still_publishes(
+    email_preset: Callable[..., object],
+    envelope: type[FakeEnvelope],
+    message_headers: object,
+) -> None:
+    # None is the asset-notification path, where no presenter ran at all.
+    _, status = EMAILPublisher().publish(email_preset(message_headers))
+
+    assert status == HTTPStatus.OK
+    assert envelope.last.headers == []
+    assert envelope.last.sent
+
+
+def test_a_hostile_presenter_cannot_add_a_recipient(
+    email_preset: Callable[..., object],
+    envelope: type[FakeEnvelope],
+) -> None:
+    """Defence in depth: the pair arrives pre-structured, bypassing the presenter's parser."""
+    preset = email_preset(
+        [
+            {"name": "Bcc", "value": "attacker@evil.test"},
+            {"name": "X-Report-Type", "value": "Advisory"},
+        ],
+    )
+
+    _, status = EMAILPublisher().publish(preset)
+
+    assert status == HTTPStatus.OK
+    assert envelope.last.headers == [("X-Report-Type", "Advisory")]
+
+
+def test_a_value_with_a_newline_is_scrubbed_before_the_envelope_sees_it(
+    email_preset: Callable[..., object],
+    envelope: type[FakeEnvelope],
+) -> None:
+    # EmailMessage.__setitem__ raises ValueError on CR/LF; we must never get that far.
+    preset = email_preset([{"name": "X-Report-Category", "value": "Ransomware\r\nBcc: attacker@evil.test"}])
+
+    EMAILPublisher().publish(preset)
+
+    assert envelope.last.headers == [("X-Report-Category", "Ransomware Bcc: attacker@evil.test")]
+
+
+def test_a_failing_header_call_does_not_cost_the_send(
+    email_preset: Callable[..., object],
+    envelope: type[FakeEnvelope],
+) -> None:
+    """A decorative header must never fail the publish.
+
+    ``envelope.header()`` catches only ``TypeError``, and the publisher's own ``try``
+    starts below the header loop, so anything else would escape ``publish()`` and become
+    an unexplained 500.
+    """
+    preset = email_preset([{"name": "X-Report-Category", "value": "Ransomware"}])
+
+    envelope_class = envelope
+    original_init = envelope_class.__init__
+
+    def init_with_failing_header(self: FakeEnvelope) -> None:
+        original_init(self)
+        self.header_error = ValueError("header values may not contain linefeed")
+
+    envelope_class.__init__ = init_with_failing_header
+    try:
+        _, status = EMAILPublisher().publish(preset)
+    finally:
+        envelope_class.__init__ = original_init
+
+    assert status == HTTPStatus.OK
+    assert envelope.last.sent

--- a/src/shared/shared/config_presenter.py
+++ b/src/shared/shared/config_presenter.py
@@ -44,6 +44,14 @@ class ConfigPresenter(ConfigBase):
                 ParameterType.STRING,
                 "/app/templates/email_body_template.txt",
             ),
+            param_type(
+                "HEADERS_TEMPLATE_PATH",
+                "Path to Headers template",
+                "Optional. Path to a message headers template file. Each rendered 'X-Name: value' line becomes a "
+                "custom mail header; repeat a name to send several values. Leave empty to send no custom headers. "
+                "Example: /app/templates/email_headers_template.txt",
+                ParameterType.STRING,
+            ),
             param_type("ATTACHMENT_TEMPLATE_PATH", "Path to PDF attachment template", "Path to PDF template file", ParameterType.STRING),
             param_type(
                 "ATTACHMENT_FILE_NAME",

--- a/src/shared/shared/mail_headers.py
+++ b/src/shared/shared/mail_headers.py
@@ -1,0 +1,226 @@
+"""Turn rendered template text into mail headers that are safe to hand to an MTA.
+
+Header values here originate in analyst-entered report item attributes, so this module is
+the boundary where untrusted text stops being data and becomes a protocol element. Two
+facts drive every rule below:
+
+* Header **values** are guarded by the standard library — ``EmailMessage.__setitem__``
+  under ``policy.default`` raises ``ValueError`` on CR/LF. But that exception would escape
+  the email publisher (``envelope`` catches only ``TypeError``) and kill the whole send, so
+  we scrub instead of relying on it.
+* Header **names** are guarded by nothing. ``"X-Colon: Injected"``, ``"X Bad Name"``,
+  ``"X-ü"`` and ``""`` are all accepted and serialised verbatim, so we validate them here.
+
+The deny-list is not defence in depth, it is the primary control: ``envelope.header()``
+reroutes ``bcc``/``cc``/``to`` to its own setters, and ``_send_now`` builds the SMTP
+recipient list from ``self._to + self._cc + self._bcc``. A rendered ``Bcc:`` line would
+therefore add a **real recipient**, not a decorative header.
+
+Do **not** RFC 2047-encode and do **not** fold values here. ``EmailMessage.__setitem__``
+already does both; pre-encoding delivers literal ``=?utf-8?q?...?=`` text to the reader.
+
+Failure policy: warn and drop, never raise. A malformed line is nearly always a template
+typo or an analyst pasting a colon into free text, and killing a product publish over a
+decorative header is the worse outcome.
+
+Residual risk, stated plainly: unfolding means a value containing a bare newline starts a
+*new* logical line rather than continuing the current one. ``Bcc:`` and everything else
+that changes delivery is caught by the deny-list, but a benign ``X-Whatever:`` could slip
+through that way. Three things mitigate it, in order of importance: the deny-list; the
+presenters' ``collect_attrs`` filter scrubbing control characters out of every value it
+emits; and the ``header_value`` filter being mandatory for raw ``{{ }}`` interpolation.
+"""
+
+import re
+from collections.abc import Iterable, Mapping
+
+from shared.log_manager import logger
+
+MAX_HEADERS = 20
+MAX_NAME_LENGTH = 64
+MAX_VALUE_LENGTH = 998  # RFC 5322 section 2.1.1 line length limit, reused as a per-header budget
+MAX_TOTAL_LENGTH = 8192  # total of all values; stays clear of MTA header section limits
+
+# RFC 5322 ftext: printable ASCII (%d33-57 / %d59-126), i.e. everything but space and ":".
+_FIELD_NAME = re.compile(r"[!-9;-~]+")
+
+# Everything str.splitlines() treats as a line break, not just CR/LF: the standard library's
+# header folder splits on all of these, so U+2028 is a live line-break vector that a naive
+# "\r\n"-only scrub misses.
+_CONTROL = re.compile("[\x00-\x1f\x7f\u0085\u2028\u2029]")
+
+_WHITESPACE_RUN = re.compile(r"\s+")
+
+RESERVED_HEADERS = frozenset(
+    {
+        # envelope.header() reroutes these to its own setters; "bcc" adds a real SMTP recipient
+        "to",
+        "cc",
+        "bcc",
+        "reply-to",
+        "from",
+        "subject",
+        "sender",
+        # MIME structure the publisher builds itself
+        "content-type",
+        "content-transfer-encoding",
+        "content-disposition",
+        "content-id",
+        "mime-version",
+        # envelope fills these in; a duplicate makes a malformed message
+        "date",
+        "message-id",
+        # trace and envelope headers - forging them is spoofing
+        "received",
+        "return-path",
+        "delivered-to",
+        "dkim-signature",
+        "authentication-results",
+        # envelope derives behaviour from this one
+        "list-unsubscribe",
+    },
+)
+
+RESERVED_PREFIXES = ("resent-", "arc-", "x-original-")
+
+
+def scrub_header_text(value: object) -> str:
+    """Make a single value safe to sit on one header line.
+
+    Strips every character that could break the header out of its line, collapses the
+    resulting whitespace and trims the ends. Used both here and by the presenters' Jinja
+    filters, so a value is already safe by the time a template interpolates it.
+
+    Args:
+        value (object): The raw value. ``None`` and non-strings are accepted.
+
+    Returns:
+        str: The scrubbed value, possibly empty.
+    """
+    if value is None:
+        return ""
+    text = _CONTROL.sub(" ", str(value))
+    return _WHITESPACE_RUN.sub(" ", text).strip()
+
+
+def sanitize_header(name: str, value: object) -> tuple[str, str] | None:
+    """Validate one header name/value pair.
+
+    Args:
+        name (str): The header field name.
+        value (object): The header value.
+
+    Returns:
+        tuple[str, str] | None: The safe pair, or None when the header must be dropped.
+    """
+    name = str(name).strip()
+
+    if not _FIELD_NAME.fullmatch(name):
+        logger.warning(f"Custom header dropped, not a valid field name: {name!r}")
+        return None
+
+    if len(name) > MAX_NAME_LENGTH:
+        logger.warning(f"Custom header dropped, name longer than {MAX_NAME_LENGTH} characters: {name[:MAX_NAME_LENGTH]!r}")
+        return None
+
+    lowered = name.lower()
+    if lowered in RESERVED_HEADERS or lowered.startswith(RESERVED_PREFIXES):
+        # This is the line that stops a rendered "Bcc:" from adding a recipient.
+        logger.warning(f"Custom header '{name}' refused: the publisher owns this header.")
+        return None
+
+    value = scrub_header_text(value)
+    if not value:
+        # The common case rather than an edge case: "X-Report-Category: {{ ... | join(', ') }}"
+        # renders an empty value whenever no report item carries the attribute.
+        return None
+
+    if len(value) > MAX_VALUE_LENGTH:
+        logger.warning(f"Custom header '{name}' truncated to {MAX_VALUE_LENGTH} characters.")
+        value = f"{value[: MAX_VALUE_LENGTH - 1]}…"
+
+    return name, value
+
+
+def sanitize_headers(pairs: Iterable[Mapping[str, object] | tuple[str, object]]) -> list[dict[str, str]]:
+    """Validate a whole set of headers and enforce the size limits.
+
+    Idempotent: running the result back through returns the same list. The email publisher
+    relies on that to re-check what a presenter sent it.
+
+    Args:
+        pairs (Iterable): Header pairs, either ``{"name": ..., "value": ...}`` mappings or
+            ``(name, value)`` tuples.
+
+    Returns:
+        list[dict[str, str]]: The headers that survived, as ``{"name", "value"}`` dicts.
+    """
+    headers: list[dict[str, str]] = []
+    total_length = 0
+
+    for pair in pairs:
+        if len(headers) >= MAX_HEADERS:
+            logger.warning(f"Custom headers truncated at {MAX_HEADERS}, the rest were dropped.")
+            break
+
+        if isinstance(pair, Mapping):
+            name, value = pair.get("name", ""), pair.get("value", "")
+        else:
+            name, value = pair
+
+        sanitized = sanitize_header(name, value)
+        if sanitized is None:
+            continue
+
+        name, value = sanitized
+        if total_length + len(value) > MAX_TOTAL_LENGTH:
+            logger.warning(f"Custom header '{name}' dropped, total header size would exceed {MAX_TOTAL_LENGTH} characters.")
+            break
+
+        total_length += len(value)
+        headers.append({"name": name, "value": value})
+
+    return headers
+
+
+def parse_header_block(text: str) -> list[dict[str, str]]:
+    """Parse rendered template output into sanitized mail headers.
+
+    Understands RFC 5322 folding (a line starting with whitespace continues the previous
+    one). Unlike a real message parser it does *not* stop at the first blank line: Jinja
+    output is ragged, and a template author should not have to fight whitespace control to
+    get a header block out.
+
+    Args:
+        text (str): The rendered headers template.
+
+    Returns:
+        list[dict[str, str]]: The headers that survived, as ``{"name", "value"}`` dicts.
+    """
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    logical_lines: list[str] = []
+
+    for raw_line in normalized.split("\n"):
+        if not raw_line.strip():
+            # Checked before the continuation test: a whitespace-only line is a Jinja
+            # artefact, not a continuation appending nothing.
+            continue
+
+        if raw_line[0] in " \t":
+            if not logical_lines:
+                logger.warning(f"Custom header continuation without a header dropped: {raw_line.strip()[:80]!r}")
+                continue
+            logical_lines[-1] = f"{logical_lines[-1]} {raw_line.strip()}"
+            continue
+
+        logical_lines.append(raw_line.strip())
+
+    pairs: list[tuple[str, str]] = []
+    for line in logical_lines:
+        name, separator, value = line.partition(":")
+        if not separator:
+            logger.warning(f"Custom header line without a colon dropped: {line[:80]!r}")
+            continue
+        pairs.append((name, value))
+
+    return sanitize_headers(pairs)

--- a/src/shared/shared/schema/message_header.py
+++ b/src/shared/shared/schema/message_header.py
@@ -1,0 +1,23 @@
+"""Schema for a single custom mail header."""
+
+from marshmallow import EXCLUDE, Schema, fields
+
+
+class MessageHeaderSchema(Schema):
+    """Schema for one ``{name, value}`` mail header pair.
+
+    Deliberately has no ``@post_load``: nested this way it loads to a plain dict, which is
+    what the email publisher wants, and it stays usable from both the presenter output and
+    the publisher input schemas without either owning a class the other has to import.
+
+    Header names and values crossing this schema have already been validated by
+    ``shared.mail_headers``; the publisher re-validates rather than trusting the wire.
+    """
+
+    class Meta:
+        """Meta class to define schema behavior."""
+
+        unknown = EXCLUDE
+
+    name = fields.Str()
+    value = fields.Str()

--- a/src/shared/shared/schema/presenter.py
+++ b/src/shared/shared/schema/presenter.py
@@ -6,6 +6,7 @@ Returns:
 
 from marshmallow import Schema, fields, post_load
 
+from shared.schema.message_header import MessageHeaderSchema
 from shared.schema.parameter import ParameterSchema
 from shared.schema.parameter_value import ParameterValueSchema
 from shared.schema.report_item import ReportItemSchema
@@ -195,6 +196,7 @@ class PresenterOutput:
         message_title: str,
         att_file_name: str,
         message_body_mime_type: str = "text/plain",
+        message_headers: list | None = None,
     ) -> None:
         """Initialize the "presenter output".
 
@@ -205,6 +207,8 @@ class PresenterOutput:
             message_title (str): Title of the message.
             att_file_name (str): Attached file name.
             message_body_mime_type (str): MIME type of the message body itself. Defaults to "text/plain".
+            message_headers (list | None): Custom mail headers as {name, value} pairs, already
+                sanitized by the presenter. Empty when no headers template is configured.
         """
         self.mime_type = mime_type
         self.data = data
@@ -212,6 +216,7 @@ class PresenterOutput:
         self.message_title = message_title
         self.att_file_name = att_file_name
         self.message_body_mime_type = message_body_mime_type
+        self.message_headers = message_headers or []
 
 
 class PresenterOutputSchema(Schema):
@@ -227,6 +232,7 @@ class PresenterOutputSchema(Schema):
     message_title = fields.Str()
     att_file_name = fields.Str()
     message_body_mime_type = fields.Str(allow_none=True)
+    message_headers = fields.List(fields.Nested(MessageHeaderSchema), allow_none=True)
 
     @post_load
     def make(self, data: dict, **kwargs) -> PresenterOutput:  # noqa: ANN003, ARG002

--- a/src/shared/shared/schema/publisher.py
+++ b/src/shared/shared/schema/publisher.py
@@ -1,7 +1,8 @@
 """Schema for Publisher and Publisher Input."""
 
-from marshmallow import Schema, fields, post_load
+from marshmallow import EXCLUDE, Schema, fields, post_load
 
+from shared.schema.message_header import MessageHeaderSchema
 from shared.schema.parameter import ParameterSchema
 from shared.schema.parameter_value import ParameterValueSchema
 
@@ -31,6 +32,7 @@ class PublisherInput:
         recipients: list,
         att_file_name: str,
         message_body_mime_type: str | None = None,
+        message_headers: list | None = None,
     ) -> None:
         """Initialize the PublisherInput object.
 
@@ -46,6 +48,8 @@ class PublisherInput:
             att_file_name (str): The attachment file name.
             message_body_mime_type (str | None): MIME type of the message body, as declared by the
                 presenter. None when no presenter was involved; publishers should then assume plain text.
+            message_headers (list | None): Custom mail headers as {name, value} pairs. Empty when no
+                presenter was involved, or when the presenter has no headers template configured.
         """
         self.name = name
         self.type = type
@@ -57,6 +61,7 @@ class PublisherInput:
         self.recipients = recipients
         self.att_file_name = att_file_name
         self.message_body_mime_type = message_body_mime_type
+        self.message_headers = message_headers or []
 
         self.param_key_values = {}
         for pv in parameter_values:
@@ -65,6 +70,16 @@ class PublisherInput:
 
 class PublisherInputSchema(Schema):
     """Schema for Publisher Input."""
+
+    class Meta:
+        """Meta class to define schema behavior.
+
+        Unknown fields are excluded so a core running ahead of a publishers node - they are
+        deployed and upgraded separately - does not fail the whole publish on a field this
+        version has never heard of.
+        """
+
+        unknown = EXCLUDE
 
     name = fields.Str()
     type = fields.Str()
@@ -76,6 +91,7 @@ class PublisherInputSchema(Schema):
     recipients = fields.List(fields.String, allow_none=True)
     att_file_name = fields.Str(allow_none=True)
     message_body_mime_type = fields.Str(allow_none=True)
+    message_headers = fields.List(fields.Nested(MessageHeaderSchema), allow_none=True)
 
     @post_load
     def make(self, data: dict, **kwargs) -> PublisherInput:  # noqa: ANN003, ARG002

--- a/src/shared/tests/test_mail_headers.py
+++ b/src/shared/tests/test_mail_headers.py
@@ -1,0 +1,220 @@
+"""Tests for the mail header sanitizer.
+
+Header values come from analyst-entered report item attributes, and the email publisher
+hands whatever survives here straight to ``envelope.header()`` — which reroutes ``bcc``
+into the real SMTP recipient list. So the properties asserted here are: no attribute value
+can ever produce a header that changes delivery, no attribute value can escape its own
+header line, and a template typo costs one header rather than the whole publish.
+"""
+
+import pytest
+from shared.mail_headers import (
+    MAX_HEADERS,
+    MAX_TOTAL_LENGTH,
+    MAX_VALUE_LENGTH,
+    RESERVED_HEADERS,
+    RESERVED_PREFIXES,
+    parse_header_block,
+    sanitize_header,
+    sanitize_headers,
+    scrub_header_text,
+)
+
+
+def test_plain_header_survives_intact() -> None:
+    assert parse_header_block("X-Report-Category: Ransomware") == [{"name": "X-Report-Category", "value": "Ransomware"}]
+
+
+# --- injection ---------------------------------------------------------------------
+
+
+def test_newline_in_a_value_cannot_smuggle_a_bcc() -> None:
+    # The whole point of the module: an analyst types a newline and an address into an
+    # attribute, and it must not become a recipient.
+    headers = parse_header_block("X-Report-Category: Ransomware\nBcc: attacker@evil.test")
+
+    assert headers == [{"name": "X-Report-Category", "value": "Ransomware"}]
+    assert not [h for h in headers if h["name"].lower() == "bcc"]
+
+
+def test_bcc_is_refused_whatever_its_casing() -> None:
+    assert parse_header_block("BcC: attacker@evil.test") == []
+
+
+@pytest.mark.parametrize("name", sorted(RESERVED_HEADERS))
+def test_every_reserved_header_is_dropped(name: str) -> None:
+    assert parse_header_block(f"{name}: whatever") == []
+
+
+@pytest.mark.parametrize("prefix", RESERVED_PREFIXES)
+def test_every_reserved_prefix_is_dropped(prefix: str) -> None:
+    assert parse_header_block(f"{prefix}something: whatever") == []
+
+
+def test_a_refused_header_does_not_take_its_neighbours_with_it() -> None:
+    block = "X-Report-Type: Advisory\nBcc: attacker@evil.test\nX-Report-Category: Phishing"
+
+    assert [h["name"] for h in parse_header_block(block)] == ["X-Report-Type", "X-Report-Category"]
+
+
+# --- field names -------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "X-Colon: Injected",  # a second colon would serialise as "X-Colon: Injected: value"
+        "X Bad Name",  # space is not ftext
+        "X-ü",  # non-ASCII names are accepted by the stdlib and serialised raw
+        "",
+        "  ",
+        "X" * 65,  # over MAX_NAME_LENGTH
+    ],
+)
+def test_invalid_field_names_are_dropped(name: str) -> None:
+    assert sanitize_header(name, "value") is None
+
+
+@pytest.mark.parametrize("name", ["X-Report-Category", "X-Report-Max-CVSS", "Organization", "Auto-Submitted"])
+def test_valid_field_names_are_kept(name: str) -> None:
+    assert sanitize_header(name, "value") == (name, "value")
+
+
+def test_space_before_the_colon_is_tolerated() -> None:
+    assert parse_header_block("X-Report-Type : Advisory") == [{"name": "X-Report-Type", "value": "Advisory"}]
+
+
+# --- value scrubbing ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "char",
+    [
+        "\x00",
+        "\x0b",
+        "\x0c",
+        "\r",
+        "\x1f",
+        "\x7f",
+        "\u0085",  # NEL
+        "\u2028",  # LINE SEPARATOR - not a "\n", but str.splitlines() breaks on it
+        "\u2029",  # PARAGRAPH SEPARATOR
+    ],
+)
+def test_line_breaking_characters_become_a_single_space(char: str) -> None:
+    assert scrub_header_text(f"Ransomware{char}Phishing") == "Ransomware Phishing"
+
+
+def test_tabs_and_runs_of_whitespace_collapse() -> None:
+    assert scrub_header_text("  Ransomware \t\t  Phishing  ") == "Ransomware Phishing"
+
+
+def test_none_scrubs_to_empty_string() -> None:
+    # Guards the max_cvss case: Jinja stringifies None as "None" without this.
+    assert scrub_header_text(None) == ""
+
+
+def test_non_ascii_values_are_kept_verbatim() -> None:
+    # EmailMessage.__setitem__ does the RFC 2047 encoding; doing it here would deliver
+    # literal "=?utf-8?q?" text to the reader.
+    assert sanitize_header("X-Report-Category", "Ransomware, Špionáž") == ("X-Report-Category", "Ransomware, Špionáž")
+
+
+# --- empty values ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("block", ["X-Report-Category:", "X-Report-Category: ", "X-Report-Category:   \t "])
+def test_empty_values_are_dropped(block: str) -> None:
+    # The common case: the template's join() produced nothing because no report item
+    # carries the attribute. An empty header must not reach the wire.
+    assert parse_header_block(block) == []
+
+
+# --- folding -----------------------------------------------------------------------
+
+
+def test_a_continuation_line_joins_the_previous_header() -> None:
+    block = "X-Report-Category: Ransomware,\n  Phishing"
+
+    assert parse_header_block(block) == [{"name": "X-Report-Category", "value": "Ransomware, Phishing"}]
+
+
+def test_a_continuation_without_a_header_is_dropped() -> None:
+    assert parse_header_block("   orphaned continuation") == []
+
+
+def test_blank_lines_do_not_terminate_the_block() -> None:
+    # Unlike a real message parser. Jinja output is ragged and a template author should
+    # not have to fight whitespace control to emit a header block.
+    block = "X-Report-Type: Advisory\n\n\n   \n\nX-Report-Category: Phishing"
+
+    assert [h["name"] for h in parse_header_block(block)] == ["X-Report-Type", "X-Report-Category"]
+
+
+def test_crlf_line_endings_are_handled() -> None:
+    assert len(parse_header_block("X-Report-Type: Advisory\r\nX-Report-Category: Phishing")) == 2
+
+
+def test_a_line_without_a_colon_is_dropped() -> None:
+    assert parse_header_block("this is not a header\nX-Report-Type: Advisory") == [{"name": "X-Report-Type", "value": "Advisory"}]
+
+
+# --- limits ------------------------------------------------------------------------
+
+
+def test_header_count_is_capped() -> None:
+    block = "\n".join(f"X-Header-{index}: value" for index in range(MAX_HEADERS + 10))
+
+    assert len(parse_header_block(block)) == MAX_HEADERS
+
+
+def test_an_overlong_value_is_truncated_rather_than_dropped() -> None:
+    headers = parse_header_block(f"X-Report-Category: {'a' * 5000}")
+
+    assert len(headers) == 1
+    assert len(headers[0]["value"]) == MAX_VALUE_LENGTH
+    assert headers[0]["value"].endswith("…")
+
+
+def test_total_value_length_is_capped() -> None:
+    # Each value is just under MAX_VALUE_LENGTH, so the cap bites before MAX_HEADERS does.
+    block = "\n".join(f"X-Header-{index}: {'a' * 900}" for index in range(MAX_HEADERS))
+    headers = parse_header_block(block)
+
+    assert 0 < len(headers) < MAX_HEADERS
+    assert sum(len(h["value"]) for h in headers) <= MAX_TOTAL_LENGTH
+
+
+# --- contract the publisher relies on ----------------------------------------------
+
+
+def test_sanitize_headers_is_idempotent() -> None:
+    # The email publisher re-runs sanitize_headers on what the presenter sent it, so a
+    # second pass must be a no-op for anything that legitimately survived the first.
+    block = "X-Report-Category: Ransomware, Phishing\nX-Report-Max-CVSS: 9.8"
+    once = parse_header_block(block)
+
+    assert sanitize_headers(once) == once
+
+
+def test_sanitize_headers_accepts_both_mappings_and_tuples() -> None:
+    expected = [{"name": "X-Report-Type", "value": "Advisory"}]
+
+    assert sanitize_headers([("X-Report-Type", "Advisory")]) == expected
+    assert sanitize_headers([{"name": "X-Report-Type", "value": "Advisory"}]) == expected
+
+
+def test_a_hostile_pair_is_still_refused_when_it_arrives_pre_structured() -> None:
+    # Defence in depth: a version-skewed or compromised presenter node sends the pair
+    # directly rather than through parse_header_block.
+    assert sanitize_headers([{"name": "Bcc", "value": "attacker@evil.test"}]) == []
+
+
+def test_repeated_names_are_preserved() -> None:
+    # envelope.header() appends on repeat, so a template may emit one line per value.
+    block = "X-Report-Category: Ransomware\nX-Report-Category: Phishing"
+
+    assert parse_header_block(block) == [
+        {"name": "X-Report-Category", "value": "Ransomware"},
+        {"name": "X-Report-Category", "value": "Phishing"},
+    ]


### PR DESCRIPTION
Lets a product carry classification values from its report items as custom mail
headers, so downstream filters and archives can route on them.

### How it works

- New optional `HEADERS_TEMPLATE_PATH` parameter on the MESSAGE presenter — a third
  Jinja template alongside subject and body
- Values come from ordinary report item attributes, so **no data model or GUI change**:
  an admin adds e.g. an ENUM attribute "Report Category" with `max_occurrence > 1`, and
  the existing report item editor already gives the dropdown and the `+` button
- `collect_attrs` gathers one attribute across every report item in the product,
  deduplicated, so combined products list all their values in one header
- Ships `email_headers_template.txt` covering `X-Report-Category`, `X-Report-Type`
  and `X-Report-Max-CVSS`

### Operator setup

1. Add the attributes to the report item type (Configuration → Report Types)
2. Set *Path to Headers template* on the product type (Configuration → Product Types)

Empty by default, so existing product types send no custom headers.

### Security

Header values are analyst-entered free text, so `shared/mail_headers.py` sanitizes
them before they become protocol elements:

- **Deny-list of headers the publisher owns** — `envelope.header()` routes `Bcc`/`Cc`/`To`
  into the real SMTP recipient list, so an unchecked header would add a **real recipient**
- Control-character scrubbing, field-name validation, empty-value dropping, size limits
- Re-validated in the publisher, because the presenter is a separate network node

These headers sit outside any S/MIME or PGP protection — documented in the template.

### Also in here

- `PublisherInputSchema` now excludes unknown fields, so a core running ahead of a
  publishers node no longer 500s the whole publish on a field it hasn't heard of
- `TEMPLATING ERROR` now names the failing template. The presenter renders up to five
  and named none of them, which made a pre-existing failure in `email_body_template_SK.txt`
  (it imports a `variables` file that was never shipped) read as though the new headers
  template were at fault

### Testing

- 87 new tests; all six suites pass (774 total), lint and format clean
- Verified end to end against a real `Envelope`: `Bcc` refused with recipients unchanged,
  repeated header names append, long values fold under 998 chars, non-ASCII RFC 2047
  encoded on the wire

### Upgrade note

⚠️ No migration is included, so existing databases need `python db_migration.py regenerate`
for `HEADERS_TEMPLATE_PATH` to appear in the product type form. Fresh installs get it from
`config_presenter.py` directly.