### PR TITLE
Removed fixed small "Items per page" from Users + other grids

### DIFF
--- a/src/gui-v3/src/components/config/access-management/ACLTab.vue
+++ b/src/gui-v3/src/components/config/access-management/ACLTab.vue
@@ -27,6 +27,7 @@
             <v-data-table
                 :headers="headers"
                 :items="configStore.acls.items"
+                :items-per-page="-1"                
                 :search="search"
                 item-key="id"
                 class="elevation-1"

--- a/src/gui-v3/src/components/config/access-management/AuthProvidersTab.vue
+++ b/src/gui-v3/src/components/config/access-management/AuthProvidersTab.vue
@@ -27,6 +27,7 @@
             <v-data-table
                 :headers="headers"
                 :items="configStore.authProviders.items as AuthProviderItem[]"
+                :items-per-page="-1"
                 :search="search"
                 :loading="loading"
                 item-key="id"

--- a/src/gui-v3/src/components/config/access-management/OrganizationsTab.vue
+++ b/src/gui-v3/src/components/config/access-management/OrganizationsTab.vue
@@ -27,6 +27,7 @@
             <v-data-table
                 :headers="headers"
                 :items="configStore.organizations.items"
+                :items-per-page="-1"                
                 :search="search"
                 item-key="id"
                 class="elevation-1"

--- a/src/gui-v3/src/components/config/access-management/RolesTab.vue
+++ b/src/gui-v3/src/components/config/access-management/RolesTab.vue
@@ -27,6 +27,7 @@
             <v-data-table
                 :headers="headers"
                 :items="configStore.roles.items"
+                :items-per-page="-1"
                 :search="search"
                 item-key="id"
                 class="elevation-1"

--- a/src/gui-v3/src/components/config/access-management/UsersTab.vue
+++ b/src/gui-v3/src/components/config/access-management/UsersTab.vue
@@ -37,13 +37,13 @@
             <!-- Data Table -->
             <v-data-table
                 ref="tableRef"
-                v-model:items-per-page="itemsPerPage"
                 :headers="headers"
                 :items="filteredUsers"
+                :items-per-page="-1"
                 :search="search"
                 :row-props="rowProps"
                 item-key="id"
-                class="elevation-1 auto-paged"
+                class="elevation-1"
             >
                 <template #item.username="{ item }">
                     <strong>{{ asUserItem(item).username }}</strong>
@@ -172,7 +172,7 @@
 </template>
 
 <script setup lang="ts">
-    import { computed, ref, onMounted, nextTick } from 'vue'
+    import { computed, ref, onMounted } from 'vue'
     import { useI18n } from 'vue-i18n'
     import { useConfigStore } from '@/stores/config'
     import { deleteUser, updateUserStatus } from '@/api/config'
@@ -182,7 +182,6 @@
     import SearchField from '@/components/common/SearchField.vue'
     import { useAuth } from '@/composables/useAuth'
     import { useLocaleFormatters } from '@/composables/useLocaleFormatters'
-    import { useAutoItemsPerPage } from '@/composables/useAutoItemsPerPage'
 
     type HeaderEntry = {
         title: string
@@ -270,20 +269,12 @@
 
     const hasMfa = (user: UserItem): boolean => !!(user.mfa?.totp || (user.mfa?.passkeys ?? 0) > 0)
 
-    // The page holds as many rows as the viewport fits, so the footer's page-size select is
-    // hidden (see the scoped style below) - there is nothing left for it to choose.
-    const tableRef = ref<{ $el?: HTMLElement } | null>(null)
-    const { itemsPerPage, recalculate } = useAutoItemsPerPage(tableRef)
-
     const loadData = async (): Promise<void> => {
         try {
             await configStore.loadUsers({ search: search.value })
         } catch (error) {
             console.error('Error loading users:', error)
         }
-        // Rows only exist to measure once the data has rendered.
-        await nextTick()
-        recalculate()
     }
 
     const setStatus = async (item: UserItem, status: string): Promise<void> => {
@@ -341,11 +332,6 @@
 </script>
 
 <style scoped>
-    /* The page size is computed from the viewport, so the footer's selector is redundant. */
-    .auto-paged :deep(.v-data-table-footer__items-per-page) {
-        display: none;
-    }
-
     /* Matches the disabled OSINT source rows: dimmed at rest, full contrast under the pointer
        so a disabled account can still be read and acted on. */
     :deep(.user-disabled) {

--- a/src/gui-v3/src/components/config/data-providers/AiProvidersTab.vue
+++ b/src/gui-v3/src/components/config/data-providers/AiProvidersTab.vue
@@ -27,6 +27,7 @@
             <v-data-table
                 :headers="headers"
                 :items="configStore.aiProviders.items"
+                :items-per-page="-1"                            
                 :search="search"
                 item-key="id"
                 class="elevation-1"

--- a/src/gui-v3/src/components/config/data-providers/DataProvidersTab.vue
+++ b/src/gui-v3/src/components/config/data-providers/DataProvidersTab.vue
@@ -27,6 +27,7 @@
             <v-data-table
                 :headers="headers"
                 :items="configStore.dataProviders.items"
+                :items-per-page="-1"                            
                 :search="search"
                 item-key="id"
                 class="elevation-1"

--- a/src/gui-v3/src/components/config/reports/AttributesTab.vue
+++ b/src/gui-v3/src/components/config/reports/AttributesTab.vue
@@ -25,13 +25,13 @@
             <!-- Data Table -->
             <v-data-table
                 ref="tableRef"
-                v-model:items-per-page="itemsPerPage"
                 :headers="headers"
                 :items="configStore.attributes.items"
+                :items-per-page="-1"
                 :search="search"
                 :loading="loading"
                 item-key="id"
-                class="elevation-1 auto-paged"
+                class="elevation-1"
             >
                 <template #item.name="{ item }">
                     <v-icon
@@ -71,7 +71,6 @@
     import ActionButton from '@/components/common/buttons/ActionButton.vue'
     import SearchField from '@/components/common/SearchField.vue'
     import { useAuth } from '@/composables/useAuth'
-    import { useAutoItemsPerPage } from '@/composables/useAutoItemsPerPage'
 
     // Representative icon per attribute type.
     const TYPE_ICONS: Record<string, string> = {
@@ -127,11 +126,6 @@
 
     const asAttributeItem = (item: unknown): AttributeItem => item as AttributeItem
 
-    // The page holds as many rows as the viewport fits, so the footer's page-size select is
-    // hidden (see the scoped style below) - there is nothing left for it to choose.
-    const tableRef = ref<{ $el?: HTMLElement } | null>(null)
-    const { itemsPerPage, recalculate } = useAutoItemsPerPage(tableRef)
-
     const loadData = async (): Promise<void> => {
         loading.value = true
         try {
@@ -141,9 +135,6 @@
         } finally {
             loading.value = false
         }
-        // Rows only exist to measure once the data has rendered.
-        await nextTick()
-        recalculate()
     }
 
     const handleEdit = async (item: AttributeItem): Promise<void> => {
@@ -178,9 +169,3 @@
     onMounted(loadData)
 </script>
 
-<style scoped>
-    /* The page size is computed from the viewport, so the footer's selector is redundant. */
-    .auto-paged :deep(.v-data-table-footer__items-per-page) {
-        display: none;
-    }
-</style>

--- a/src/gui-v3/src/components/config/workflow/StateWorkflowTab.vue
+++ b/src/gui-v3/src/components/config/workflow/StateWorkflowTab.vue
@@ -31,6 +31,7 @@
             <v-data-table
                 :headers="headers"
                 :items="filteredRecords"
+                :items-per-page="-1"                            
                 item-key="id"
                 class="elevation-1"
             >

--- a/src/gui-v3/src/components/config/workflow/StatesTab.vue
+++ b/src/gui-v3/src/components/config/workflow/StatesTab.vue
@@ -26,6 +26,7 @@
             <v-data-table
                 :headers="headers"
                 :items="filteredRecords"
+                :items-per-page="-1"                
                 :search="search"
                 item-key="id"
                 class="elevation-1"


### PR DESCRIPTION
- removed fixed small Items per page from Users screen. Now show default ALL and allow user select custom page size (annoying user management, you need always switch fixed page that was too small. was impossible show all records)
- added also on other tabs where we don't expect large amount of records