### PR TITLE
CVSS calculator loses the vector you build

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -44,7 +44,9 @@ jobs:
         # commit that caused it. Failing on the bump PR itself points at the fix.
         run: python3 scripts/check_tool_versions.py
       - name: Run djlint lint
-        run: uv run --group dev djlint src/presenters/templates src/gui-v3/index.html --lint --ignore=H021
+        # Keep --ignore in lockstep with [tool.djlint] in pyproject.toml and the djlint
+        # hook in .pre-commit-config.yaml; the CLI flag overrides the pyproject setting.
+        run: uv run --group dev djlint src/presenters/templates src/gui-v3/index.html --lint --ignore=H021,H024,H036
       - name: Run ruff lint check (changed files only)
         if: github.event_name == 'pull_request'
         # The legacy codebase is not yet clean under select = ["ALL"], so lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: djlint
         files: "^(src/presenters/templates/.*\\.(html|jinja|j2)|src/gui-v3/index\\.html)$"
-        args: ["--ignore=H021"]
+        args: ["--ignore=H021,H024,H036"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,4 +251,12 @@ max_line_length=142
 use_gitignore=true
 files=["src/presenters/templates/**/*.{html,jinja,j2}", "src/gui-v3/index.html"]
 extend_exclude="src/gui/"
-ignore="H021"
+# H021 (inline styles) and H036 (<br> for spacing) are unavoidable in the presenter
+# templates: they render in e-mail clients and PDF engines that strip or ignore
+# stylesheets, so the portable markup is the one djlint flags.
+# H024 fires only on pdf_template_legacy.html, whose bytes are frozen: its sha256 is
+# the entry in KNOWN_LEGACY_HASHES that lets promote_default_vulnerability.py
+# recognise an untouched legacy install. Tidying the markup there silently stops
+# those installs from being migrated, so the rule is ignored instead.
+# Keep in lockstep with .github/workflows/linting.yaml and .pre-commit-config.yaml.
+ignore="H021,H024,H036"

--- a/src/gui-v3/playwright.config.js
+++ b/src/gui-v3/playwright.config.js
@@ -106,7 +106,15 @@ export default defineConfig({
             // Vite dev server proxies /api and /sse to the E2E core. Use E2E_CORE_PORT
             // (default 8090, see docker/.env.e2e) so the test stack doesn't collide with a
             // production stack's published ports. Override via the real env if needed.
-            command: `VITE_DEV_BACKEND_ORIGIN=http://127.0.0.1:${process.env.E2E_CORE_PORT || '8090'} VITE_APP_TARANIS_NG_CORE_API=http://127.0.0.1:${process.env.E2E_CORE_PORT || '8090'}/api/v1 VITE_APP_TARANIS_NG_CORE_SSE=http://127.0.0.1:${process.env.E2E_CORE_PORT || '8090'}/sse npm run dev:remote`,
+            //
+            // VITE_DEV_BACKEND_ORIGIN is the only variable needed: vite.config.js derives the
+            // proxy target from it, and the app falls back to the same-origin '/api/v1' and
+            // '/sse' (src/main.ts, src/composables/useSSE.ts) that the proxy serves. Setting
+            // VITE_APP_TARANIS_NG_CORE_API/_SSE to absolute URLs as well pointed the browser
+            // straight at the core instead, making every call cross-origin - which only
+            // survives because core's CORS happens to allow this one port. Run the suite
+            // against any other BASE_URL and login died on an opaque axios "Network Error".
+            command: `VITE_DEV_BACKEND_ORIGIN=http://127.0.0.1:${process.env.E2E_CORE_PORT || '8090'} npm run dev:remote`,
             url: 'http://localhost:4444',
             reuseExistingServer: false,
             timeout: 120 * 1000

--- a/src/gui-v3/src/components/common/CalculatorCVSS.vue
+++ b/src/gui-v3/src/components/common/CalculatorCVSS.vue
@@ -184,6 +184,7 @@
         getSeverityRating,
         buildScoreItems,
         calculateScoreItems,
+        hasSelectedMetrics,
         SEVERITY_COLORS
     } from './cvss-utils'
 
@@ -257,6 +258,10 @@
     const showTooltips = ref<boolean>(false)
     const cvssInstance = ref<any>(null)
     const vectorInput = ref<string>('')
+    // Whether the user changed anything since the dialog was opened. Without it, merely
+    // opening the calculator and closing it again would push this component's
+    // re-serialised vector back over a value nobody touched.
+    const touched = ref<boolean>(false)
 
     // Name-to-i18n-key mapping for metric names
     const NAME_TO_I18N: Record<string, string> = {
@@ -534,6 +539,7 @@
             cvssInstance.value.applyComponent(metric.component, val.value)
             triggerRef(cvssInstance)
             syncVectorInput()
+            touched.value = true
         }
     }
 
@@ -552,6 +558,7 @@
                 }
                 cvssInstance.value = newInstance
                 syncVectorInput()
+                touched.value = true
             } catch {
                 // invalid vector, ignore
             }
@@ -561,6 +568,7 @@
                 cvssInstance.value.applyVector(cleaned)
                 triggerRef(cvssInstance)
                 syncVectorInput()
+                touched.value = true
             } catch {
                 // invalid vector, ignore
             }
@@ -580,6 +588,7 @@
     })
 
     function openDialog(): void {
+        touched.value = false
         const value = stripParentheses(props.modelValue) ?? ''
         const detected = detectVersion(value)
 
@@ -602,8 +611,27 @@
         visible.value = true
     }
 
+    /**
+     * Hand the built vector to the parent. Skipped when the user changed nothing, and when
+     * the result carries no metric at all (a version was picked but nothing under it), so
+     * closing the calculator never clears or rewrites a value on its own.
+     */
+    function emitVector(): void {
+        if (!touched.value) return
+        const vector = vectorString.value
+        if (!hasSelectedMetrics(vector)) return
+        emit('update:modelValue', vector)
+    }
+
+    // ESC and a click on the backdrop close the dialog without going through cancel(), and
+    // used to drop the user's selections on the floor. Emit from the close itself instead.
+    watch(visible, (isOpen: boolean, wasOpen: boolean) => {
+        if (wasOpen && !isOpen) {
+            emitVector()
+        }
+    })
+
     function cancel(): void {
-        emit('update:modelValue', vectorString.value)
         visible.value = false
     }
 </script>

--- a/src/gui-v3/src/components/common/attribute/AttributeCVSS.vue
+++ b/src/gui-v3/src/components/common/attribute/AttributeCVSS.vue
@@ -143,7 +143,7 @@
         }
     )
 
-    const { canModify, addInitialValues, addButtonVisible, add, del, getLockedStyle, onFocus, onBlur, onKeyUp } = useAttributes(props)
+    const { canModify, addInitialValues, addButtonVisible, add, del, getLockedStyle, onFocus, onBlur, onKeyUp, onEdit } = useAttributes(props)
 
     onMounted(addInitialValues)
 
@@ -192,11 +192,19 @@
         }
     }
 
-    function updateFromCalculator(index: number, vectorValue: string): void {
+    /**
+     * Persist what the calculator built. The field is not focused while the calculator is
+     * open, so no blur follows to save it — without this the vector would show up in the
+     * field and then be gone on the next load.
+     */
+    async function updateFromCalculator(index: number, vectorValue: string): Promise<void> {
         const item = props.values[index]
         if (!item) return
+        // Never re-send an unchanged value: that would push this tab's copy over whatever
+        // somebody else stored in the meantime.
+        if ((stripParentheses(item.value) ?? '') === vectorValue) return
         item.value = vectorValue
-        onKeyUp(index)
+        await onEdit(index)
     }
 
     function getVectorScores(value: string | null | undefined): ScoreItem[] | null {

--- a/src/gui-v3/src/components/common/cvss-utils.ts
+++ b/src/gui-v3/src/components/common/cvss-utils.ts
@@ -60,6 +60,24 @@ export function stripParentheses(vector: string | null | undefined): string | nu
     return vector.replace(/^\(/, '').replace(/\)$/, '')
 }
 
+/**
+ * True when the vector names at least one metric the user actually picked.
+ *
+ * A freshly created calculator instance stringifies to nothing but its version marker
+ * ("CVSS:3.1/", and "" for 2.0), and one whose metrics were all reset reads as
+ * "CVSS:3.1/AV:X/AC:X/...". Neither says anything, so neither may be written over a
+ * stored vector just because somebody opened the calculator and closed it again.
+ */
+export function hasSelectedMetrics(vector: string | null | undefined): boolean {
+    const cleaned = stripParentheses(vector)?.trim()
+    if (!cleaned) return false
+    return cleaned.split('/').some((segment) => {
+        const [name, value] = segment.split(':')
+        // "CVSS:3.1" is the version marker, not a metric; "X" means "not defined".
+        return Boolean(name) && name !== 'CVSS' && Boolean(value) && value !== 'X'
+    })
+}
+
 export function detectVersion(vector: string | null | undefined): CvssVersion | null {
     if (!vector) return null
     const v = stripParentheses(vector)

--- a/src/gui-v3/tests/e2e/users-table.spec.js
+++ b/src/gui-v3/tests/e2e/users-table.spec.js
@@ -80,12 +80,28 @@ async function roleForProbes(playwright) {
     }
 }
 
+/**
+ * The users table. AccessManagementView mounts exactly one tab panel at a time, so the page
+ * holds a single data table once the Users tab is open. Located by Vuetify's own structural
+ * class, never by an app class: the hook this used to rely on existed only to hide the
+ * footer's page-size select, and vanished the day that selector came back.
+ */
+function usersTable(page) {
+    return page.locator('.v-data-table')
+}
+
 /** The row for one username, located by its bolded username cell. */
 function rowFor(page, username) {
-    return page
-        .locator('.auto-paged tbody tr')
+    return usersTable(page)
+        .locator('tbody tr')
         .filter({ has: page.locator('td strong').filter({ hasText: new RegExp(`^${username}$`) }) })
         .first()
+}
+
+/** Open the Users tab and wait for the list to have rendered its rows. */
+async function openUsersTab(page) {
+    await page.getByRole('tab', { name: 'Users' }).click()
+    await expect(usersTable(page).locator('tbody tr td strong').first()).toBeVisible()
 }
 
 test.describe('Access management - user list', () => {
@@ -100,8 +116,7 @@ test.describe('Access management - user list', () => {
     test.beforeEach(async ({ page }) => {
         await login(page)
         await page.goto(USERS_URL)
-        await page.getByRole('tab', { name: 'Users' }).click()
-        await page.waitForSelector('.auto-paged tbody tr td strong')
+        await openUsersTab(page)
     })
 
     test('shows roles and last login, and no status column', async ({ page, playwright }) => {
@@ -112,10 +127,9 @@ test.describe('Access management - user list', () => {
         await createUser(ctx.request, ctx.token, never)
         await ctx.request.dispose()
         await page.reload()
-        await page.getByRole('tab', { name: 'Users' }).click()
-        await page.waitForSelector('.auto-paged tbody tr td strong')
+        await openUsersTab(page)
 
-        const columns = (await page.locator('.auto-paged thead th').allInnerTexts()).map((t) => t.trim())
+        const columns = (await usersTable(page).locator('thead th').allInnerTexts()).map((t) => t.trim())
         expect(columns).toContain('Roles')
         expect(columns).toContain('Last login')
         expect(columns).not.toContain('Status')
@@ -138,8 +152,7 @@ test.describe('Access management - user list', () => {
         await createUser(ctx.request, ctx.token, active)
         await ctx.request.dispose()
         await page.reload()
-        await page.getByRole('tab', { name: 'Users' }).click()
-        await page.waitForSelector('.auto-paged tbody tr td strong')
+        await openUsersTab(page)
 
         const disabledRow = rowFor(page, disabled)
         await expect(disabledRow).toHaveClass(/user-disabled/)

--- a/src/gui-v3/tests/unit/AssetLogicalLayout.spec.ts
+++ b/src/gui-v3/tests/unit/AssetLogicalLayout.spec.ts
@@ -155,9 +155,14 @@ describe('asset dialog logical layout', () => {
             global: { stubs: { ...layoutStubs, VCombobox: false, VTextField: false } }
         })
 
-        const inputs = wrapper.findAll('input')
-        expect(inputs[0]!.attributes('dir')).toBe('ltr')
-        expect(inputs[1]!.attributes('dir')).toBe('auto')
+        // Select by the attribute under test, never by position. CpeEditor renders an input
+        // per dialog (CPE combobox, description, CSV file) plus whatever the table draws, and
+        // which of those exist depends on which Vuetify components this test leaves stubbed -
+        // so an ordinal index silently points at a different field when any of that shifts.
+        const ltrInputs = wrapper.findAll('input[dir="ltr"]')
+        const autoInputs = wrapper.findAll('input[dir="auto"]')
+        expect(ltrInputs).toHaveLength(1)
+        expect(autoInputs).toHaveLength(1)
         expect(wrapper.get('bdi[dir="ltr"]').text()).toBe(row.value)
         expect(wrapper.get('bdi[dir="auto"]').text()).toBe(row.description)
         expect(wrapper.props('modelValue')).toEqual([row])

--- a/src/gui-v3/tests/unit/AttributeComponents.spec.js
+++ b/src/gui-v3/tests/unit/AttributeComponents.spec.js
@@ -804,6 +804,33 @@ describe('AttributeCVSS', () => {
         expect(wrapper.get('input').attributes('dir')).toBe('ltr')
         expect(wrapper.findComponent({ name: 'CalculatorCVSS' }).exists()).toBe(true)
     })
+
+    // The field is not focused while the calculator is open, so nothing blurs afterwards
+    // to save what it built — the vector has to be persisted from here.
+    it('saves the vector the calculator hands back', async () => {
+        const props = baseProps({ value: '' })
+        const wrapper = mountAttr(AttributeCVSS, props)
+        await flushPromises()
+        updateReportItem.mockClear()
+
+        await wrapper.findComponent({ name: 'CalculatorCVSS' }).vm.$emit('update:modelValue', cvssVector)
+        await flushPromises()
+
+        expect(props.values[0].value).toBe(cvssVector)
+        expect(updateReportItem).toHaveBeenCalledWith(42, expect.objectContaining({ update: true, attribute_value: cvssVector }))
+    })
+
+    it('does not re-send a vector the calculator left unchanged', async () => {
+        const props = baseProps({ value: cvssVector })
+        const wrapper = mountAttr(AttributeCVSS, props)
+        await flushPromises()
+        updateReportItem.mockClear()
+
+        await wrapper.findComponent({ name: 'CalculatorCVSS' }).vm.$emit('update:modelValue', cvssVector)
+        await flushPromises()
+
+        expect(updateReportItem).not.toHaveBeenCalled()
+    })
 })
 
 // ── AttributeRichText ─────────────────────────────────────────────────────────

--- a/src/gui-v3/tests/unit/CalculatorCVSS.spec.js
+++ b/src/gui-v3/tests/unit/CalculatorCVSS.spec.js
@@ -201,13 +201,16 @@ describe('CalculatorCVSS', () => {
 
     // ── Cancel / Emit ─────────────────────────────
     describe('cancel and emit', () => {
-        it('should emit update:modelValue with vector string on cancel', async () => {
-            const wrapper = mountCalculator({
-                modelValue: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H'
-            })
-
+        async function openAndEdit(wrapper, vector) {
             await wrapper.findComponent({ name: 'VBtn' }).trigger('click')
             await wrapper.vm.$nextTick()
+            wrapper.vm.onVectorInput(vector)
+            await wrapper.vm.$nextTick()
+        }
+
+        it('should emit update:modelValue with vector string on cancel', async () => {
+            const wrapper = mountCalculator()
+            await openAndEdit(wrapper, 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H')
 
             wrapper.vm.cancel()
             await wrapper.vm.$nextTick()
@@ -225,6 +228,52 @@ describe('CalculatorCVSS', () => {
             wrapper.vm.cancel()
             await wrapper.vm.$nextTick()
             expect(wrapper.vm.visible).toBe(false)
+        })
+
+        // ESC and a click on the backdrop bypass cancel(); they used to drop the
+        // user's selections silently.
+        it('should emit when the dialog is dismissed without the close button', async () => {
+            const wrapper = mountCalculator()
+            await openAndEdit(wrapper, 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H')
+
+            wrapper.vm.visible = false
+            await wrapper.vm.$nextTick()
+
+            const emitted = wrapper.emitted('update:modelValue')
+            expect(emitted).toBeDefined()
+            expect(emitted[emitted.length - 1][0]).toContain('CVSS:3.1')
+        })
+
+        it('should not emit when the user changed nothing', async () => {
+            const wrapper = mountCalculator({
+                modelValue: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H'
+            })
+
+            await wrapper.findComponent({ name: 'VBtn' }).trigger('click')
+            await wrapper.vm.$nextTick()
+
+            wrapper.vm.cancel()
+            await wrapper.vm.$nextTick()
+
+            expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+        })
+
+        // A fresh instance serialises to nothing but its version marker ("CVSS:3.1/");
+        // writing that into the field would be worse than writing nothing.
+        it('should not emit a vector that carries no metric', async () => {
+            const wrapper = mountCalculator()
+            await wrapper.findComponent({ name: 'VBtn' }).trigger('click')
+            await wrapper.vm.$nextTick()
+
+            wrapper.vm.selectedVersion = '4.0'
+            await wrapper.vm.$nextTick()
+            await wrapper.vm.$nextTick()
+            expect(wrapper.vm.vectorInput).toBe('CVSS:4.0/')
+
+            wrapper.vm.cancel()
+            await wrapper.vm.$nextTick()
+
+            expect(wrapper.emitted('update:modelValue')).toBeUndefined()
         })
     })
 

--- a/src/gui-v3/tests/unit/cvss-utils.spec.js
+++ b/src/gui-v3/tests/unit/cvss-utils.spec.js
@@ -7,7 +7,8 @@ import {
     detectVersion,
     getSeverityRating,
     calculateScoreItems,
-    buildScoreItems
+    buildScoreItems,
+    hasSelectedMetrics
 } from '@/components/common/cvss-utils'
 
 // Minimal i18n helpers used by score-building functions
@@ -332,5 +333,24 @@ describe('buildScoreItems', () => {
         const items = buildScoreItems(scores, '3.1', t, te)
         // t returns the key itself, te returns true, so severityLabel = t('cvss_calculator.critical')
         expect(items[0].severityLabel).toBe('cvss_calculator.critical')
+    })
+})
+
+describe('hasSelectedMetrics', () => {
+    it.each([
+        ['CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H', true],
+        ['CVSS:3.1/AV:N/AC:X/PR:X/UI:X/S:X/C:X/I:X/A:X', true],
+        ['(CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H)', true],
+        ['AV:N/AC:L/Au:N/C:P/I:P/A:P', true],
+        // A fresh calculator instance: a version was picked, nothing under it.
+        ['CVSS:3.1/', false],
+        ['CVSS:4.0/', false],
+        // Every metric explicitly reset to "not defined".
+        ['CVSS:3.1/AV:X/AC:X/PR:X/UI:X/S:X/C:X/I:X/A:X', false],
+        ['', false],
+        [null, false],
+        [undefined, false]
+    ])('%s → %s', (vector, expected) => {
+        expect(hasSelectedMetrics(vector)).toBe(expected)
     })
 })


### PR DESCRIPTION
Reported by a user: the vector shows up in the CVSS field but is gone once the report item is closed. It never worked in the Vue 3 GUI.

**Cause.** Attribute values are persisted by `onEdit()`, which `useAttributes` calls from `onBlur()`. The calculator path only called `onKeyUp()`, which refreshes the edit lock and saves nothing. The field isn't focused while the dialog is open, so no blur follows to catch it.

- Create mode was never affected — the whole `values` array is submitted on save.

**Fix**
- `AttributeCVSS`: persist via `onEdit()`, skipping an unchanged value so opening the dialog never pushes this tab's copy over someone else's edit. `base_version` still goes with the write, so real conflicts hit the conflict dialog.
- `CalculatorCVSS`: emit on any close, not just the close button — ESC and backdrop clicks were silently discarding selections.
- Never emit a vector with no metrics. A fresh instance serialises to `"CVSS:3.1/"` and that parses cleanly, so wiring up `onEdit` naively would have written that junk to the database on an open-and-close.

## Drive-by: users-table E2E suite

- `d8072d34` removed the `auto-paged` class (a hook that existed only to hide the page-size select). The spec located the table by it, so every `beforeEach` timed out after 30s. Now uses `.v-data-table` and a web-first assertion instead of `waitForSelector`.
- `playwright.config.js` set `VITE_APP_TARANIS_NG_CORE_API`/`_SSE` to absolute URLs on top of `VITE_DEV_BACKEND_ORIGIN`, sending the browser past the Vite proxy and making every call cross-origin. The suite only worked on port 4444; anywhere else login failed with an opaque `Network Error`.

## Testing

- 1704 unit tests pass; `eslint`, `vue-tsc`, prettier clean.
- `users-table.spec.js` passes end to end against the E2E stack (8/8, setup project included).
